### PR TITLE
refactor: 프로젝트 전체 코드리뷰 반영 및 KDoc 최신화

### DIFF
--- a/00-shared/README.md
+++ b/00-shared/README.md
@@ -1,0 +1,100 @@
+# 00. 공유 라이브러리
+
+워크샵 전 모듈에서 공통으로 사용하는 테스트 인프라를 제공하는 섹션입니다. 데이터베이스 연결 설정, 테스트 베이스 클래스, 테이블 생성/삭제 헬퍼 등 반복 코드를 캡슐화하여 각 챕터의 예제가 비즈니스 로직에 집중할 수 있도록 지원합니다.
+
+## 챕터 목표
+
+- 모든 Exposed 테스트가 공유하는 기반 클래스(`AbstractExposedTest`)의 구조를 파악한다.
+- `TestDB` enum을 통해 H2·PostgreSQL·MySQL·MariaDB 등 다양한 DB를 일관된 방식으로 다루는 패턴을 이해한다.
+- `withTables` / `withTablesSuspending` 헬퍼로 테스트 전후 테이블 생명주기를 관리하는 방법을 익힌다.
+- 이후 챕터에서 이 공유 모듈을 의존성으로 추가하는 방식을 확인한다.
+
+## 선수 지식
+
+- Kotlin 기본 문법
+- JUnit 5 기초 (어노테이션, 파라미터화 테스트)
+- 관계형 데이터베이스 기본 개념 (연결 URL, 드라이버)
+
+## 포함 모듈
+
+| 모듈                     | 설명                                                                        |
+|------------------------|---------------------------------------------------------------------------|
+| [`exposed-shared-tests`](./exposed-shared-tests/README.md) | 공통 테스트 베이스 클래스, DB 설정, `WithTables` 헬퍼 및 ERD 문서 집합 |
+
+## 핵심 인프라 클래스
+
+### `AbstractExposedTest`
+
+모든 Exposed 테스트의 기반 추상 클래스입니다.
+
+- 기본 타임존을 **UTC**로 설정합니다.
+- `Fakers.faker` 인스턴스를 제공하여 테스트 데이터 생성을 지원합니다.
+- `enableDialects()` 메서드로 현재 활성화된 DB 방언 목록을 반환하며, `@MethodSource`와 함께 파라미터화 테스트에 사용됩니다.
+
+```kotlin
+@ParameterizedTest
+@MethodSource(AbstractExposedTest.ENABLE_DIALECTS_METHOD)
+fun `예제 테스트`(testDB: TestDB) {
+    withTables(testDB, MyTable) {
+        // 테스트 로직
+    }
+}
+```
+
+### `TestDB`
+
+테스트 대상 데이터베이스를 열거형으로 정의합니다. Testcontainers를 기본으로 사용하며, `-PuseFastDB=true` 옵션으로 H2 전용 빠른 테스트를 실행할 수 있습니다.
+
+| 값              | 설명                         |
+|----------------|----------------------------|
+| `H2`           | H2 인메모리 DB (기본 모드)       |
+| `H2_MYSQL`     | H2 (MySQL 호환 모드)           |
+| `H2_MARIADB`   | H2 (MariaDB 호환 모드)         |
+| `H2_PSQL`      | H2 (PostgreSQL 호환 모드)      |
+| `MARIADB`      | MariaDB (Testcontainers)    |
+| `MYSQL_V8`     | MySQL 8.x (Testcontainers)  |
+| `POSTGRESQL`   | PostgreSQL (Testcontainers) |
+
+### `WithTables` / `WithTablesSuspending`
+
+테스트 실행 전 테이블을 생성하고, 완료 후 삭제하는 헬퍼 함수입니다. 동기 트랜잭션과 코루틴 기반 트랜잭션 두 가지 버전을 제공합니다.
+
+```kotlin
+// 동기 방식
+withTables(testDB, UsersTable, OrdersTable) {
+    // 테이블이 생성된 상태에서 테스트 실행
+}
+
+// 코루틴 방식
+withTablesSuspending(testDB, UsersTable) {
+    // suspend 함수 내에서 사용 가능
+}
+```
+
+### `withDb`
+
+단일 `TestDB`에 연결하여 트랜잭션 블록을 실행하는 저수준 헬퍼입니다. DB별 Semaphore로 동시 접근을 제어합니다.
+
+## 실행 방법
+
+```bash
+# 공유 테스트 모듈 단독 실행
+./gradlew :exposed-shared-tests:test
+
+# H2만 대상으로 빠르게 실행
+./gradlew :exposed-shared-tests:test -PuseFastDB=true
+```
+
+## 테스트 포인트
+
+- `WithTables` 헬퍼가 테스트 전후 테이블을 정확히 생성·삭제하는지 검증
+- `TestDB.enabledDialects()`가 환경 변수 설정에 따라 올바른 DB 목록을 반환하는지 확인
+
+## 성능·안정성 체크포인트
+
+- 테스트 간 DB 연결 공유 시 Semaphore로 상호 배제가 보장되는지 확인
+- Testcontainers 기동 오버헤드를 줄이기 위해 `-PuseFastDB=true`를 로컬 개발 시 활용
+
+## 다음 챕터
+
+- [03-exposed-basic](../03-exposed-basic/README.md): DSL과 DAO 패턴 기초 예제로 넘어갑니다.

--- a/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/mapping/OrderSchema.kt
+++ b/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/mapping/OrderSchema.kt
@@ -17,14 +17,42 @@ import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import java.io.Serializable
 import java.time.LocalDate
 
+/**
+ * 주문(Order) 도메인의 테이블 정의와 DAO 엔티티, 데이터 클래스를 포함하는 스키마 객체.
+ *
+ * 이 스키마는 주문, 주문 상세, 아이템, 주문 라인, 사용자 테이블로 구성되며
+ * 매핑 관련 테스트에서 샘플 데이터와 함께 사용됩니다.
+ *
+ * 포함된 테이블:
+ * - [OrderTable]: 주문 정보
+ * - [OrderDetailTable]: 주문 상세 정보
+ * - [ItemTable]: 아이템 정보
+ * - [OrderLineTable]: 주문 라인 정보
+ * - [UserTable]: 사용자 정보 (자기 참조 계층 구조)
+ */
 object OrderSchema {
 
+    /** 모든 주문 관련 테이블의 배열. 테이블 생성/삭제 시 사용됩니다. */
     val allOrderTables = arrayOf(OrderTable, OrderDetailTable, ItemTable, OrderLineTable, UserTable)
 
+    /**
+     * 주문 정보를 저장하는 테이블.
+     *
+     * - `id`: 자동 생성되는 Long 타입 기본 키
+     * - `order_date`: 주문 날짜
+     */
     object OrderTable: LongIdTable("orders") {
         val orderDate = date("order_date")
     }
 
+    /**
+     * 주문 상세 정보를 저장하는 테이블.
+     *
+     * - `order_id`: [OrderTable]을 참조하는 외래 키
+     * - `line_number`: 주문 내 라인 번호
+     * - `description`: 상품 설명
+     * - `quantity`: 수량
+     */
     object OrderDetailTable: LongIdTable("order_details") {
         val orderId = reference("order_id", OrderTable)
         val lineNumber = integer("line_number")
@@ -32,10 +60,23 @@ object OrderSchema {
         val quantity = integer("quantity")
     }
 
+    /**
+     * 아이템(상품) 정보를 저장하는 테이블.
+     *
+     * - `description`: 아이템 설명
+     */
     object ItemTable: LongIdTable("items") {
         val description = varchar("description", 255)
     }
 
+    /**
+     * 주문과 아이템 간의 연결 정보를 저장하는 주문 라인 테이블.
+     *
+     * - `order_id`: [OrderTable]을 참조하는 외래 키
+     * - `item_id`: [ItemTable]을 참조하는 선택적 외래 키 (NULL 허용)
+     * - `line_number`: 주문 내 라인 번호
+     * - `quantity`: 수량
+     */
     object OrderLineTable: LongIdTable("order_lines") {
         val orderId = reference("order_id", OrderTable)
         val itemId = optReference("item_id", ItemTable)
@@ -43,11 +84,26 @@ object OrderSchema {
         val quantity = integer("quantity")
     }
 
+    /**
+     * 사용자 정보를 저장하는 테이블.
+     *
+     * 자기 참조(self-reference)를 통해 계층적 사용자 구조를 표현합니다.
+     *
+     * - `user_name`: 사용자 이름
+     * - `parent_id`: 부모 사용자를 참조하는 선택적 외래 키 (NULL 허용)
+     */
     object UserTable: LongIdTable("users") {
         val userName = varchar("user_name", 255)
         val parentId = reference("parent_id", UserTable).nullable()
     }
 
+    /**
+     * 주문(Order) DAO 엔티티 클래스.
+     *
+     * @param id 엔티티 식별자
+     * @property details 이 주문에 속한 [OrderDetail] 목록
+     * @property orderDate 주문 날짜
+     */
     class Order(id: EntityID<Long>): LongEntity(id), Serializable {
         companion object: LongEntityClass<Order>(OrderTable)
 
@@ -61,6 +117,16 @@ object OrderSchema {
             .toString()
     }
 
+    /**
+     * 주문 상세(OrderDetail) DAO 엔티티 클래스.
+     *
+     * @param id 엔티티 식별자
+     * @property order 연결된 [Order] 엔티티
+     * @property lineNumber 주문 내 라인 번호
+     * @property description 상품 설명
+     * @property quantity 수량
+     * @property orderId 주문 ID (읽기 전용)
+     */
     class OrderDetail(id: EntityID<Long>): LongEntity(id), Serializable {
         companion object: LongEntityClass<OrderDetail>(OrderDetailTable)
 
@@ -81,6 +147,12 @@ object OrderSchema {
             .toString()
     }
 
+    /**
+     * 아이템(Item) DAO 엔티티 클래스.
+     *
+     * @param id 엔티티 식별자
+     * @property description 아이템 설명
+     */
     class Item(id: EntityID<Long>): LongEntity(id), Serializable {
         companion object: LongEntityClass<Item>(ItemTable)
 
@@ -93,6 +165,15 @@ object OrderSchema {
             .toString()
     }
 
+    /**
+     * 주문 라인(OrderLine) DAO 엔티티 클래스.
+     *
+     * @param id 엔티티 식별자
+     * @property order 연결된 [Order] 엔티티
+     * @property item 연결된 [Item] 엔티티 (선택적, NULL 가능)
+     * @property lineNumber 주문 내 라인 번호
+     * @property quantity 수량
+     */
     class OrderLine(id: EntityID<Long>): LongEntity(id), Serializable {
         companion object: LongEntityClass<OrderLine>(OrderLineTable)
 
@@ -111,6 +192,15 @@ object OrderSchema {
             .toString()
     }
 
+    /**
+     * 사용자(User) DAO 엔티티 클래스.
+     *
+     * 계층적 사용자 구조를 지원하며, `parent` 속성으로 부모 사용자를 참조합니다.
+     *
+     * @param id 엔티티 식별자
+     * @property userName 사용자 이름
+     * @property parent 부모 사용자 엔티티 (선택적, NULL 가능)
+     */
     class User(id: EntityID<Long>): LongEntity(id), Serializable {
         companion object: LongEntityClass<User>(UserTable)
 
@@ -125,6 +215,17 @@ object OrderSchema {
             .toString()
     }
 
+    /**
+     * 주문 조회 결과를 담는 데이터 클래스.
+     *
+     * 주문 ID, 아이템 ID, 수량, 설명을 포함하며
+     * 정렬 시 orderId, itemId 순서로 비교합니다.
+     *
+     * @property orderId 주문 ID (선택적)
+     * @property itemId 아이템 ID (선택적)
+     * @property quantity 수량 (선택적)
+     * @property description 상품 설명 (선택적)
+     */
     data class OrderRecord(
         val orderId: Long? = null,
         val itemId: Long? = null,
@@ -137,6 +238,15 @@ object OrderSchema {
                 ?: 0
     }
 
+    /**
+     * 주문 관련 테이블을 생성하고 샘플 데이터를 삽입한 후 테스트 블록을 실행합니다.
+     *
+     * 테스트 완료 후 모든 테이블을 자동으로 삭제합니다.
+     * 샘플 데이터로 주문 2건, 아이템 4개, 주문 라인 5개, 사용자 4명이 생성됩니다.
+     *
+     * @param testDB 테스트에 사용할 데이터베이스 종류
+     * @param statement 테이블 참조와 함께 실행할 트랜잭션 코드 블록
+     */
     @Suppress("UnusedReceiverParameter")
     fun AbstractExposedTest.withOrdersTables(
         testDB: TestDB,

--- a/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/repository/model/MovieSchema.kt
+++ b/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/repository/model/MovieSchema.kt
@@ -29,19 +29,52 @@ import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.select
 import java.time.LocalDate
 
+/**
+ * 영화(Movie) 도메인의 테이블 정의와 DAO 엔티티를 포함하는 스키마 객체.
+ *
+ * 영화, 배우, 영화-배우 관계 테이블로 구성되며
+ * 리포지토리 패턴 테스트에서 샘플 데이터와 함께 사용됩니다.
+ *
+ * 포함된 테이블:
+ * - [MovieTable]: 영화 정보
+ * - [ActorTable]: 배우 정보
+ * - [ActorInMovieTable]: 영화-배우 다대다 관계 테이블
+ */
 object MovieSchema: KLogging() {
+
+    /**
+     * 영화 정보를 저장하는 테이블.
+     *
+     * - `name`: 영화 제목 (최대 255자)
+     * - `producer_name`: 제작자 이름 (최대 255자)
+     * - `release_date`: 개봉일
+     */
     object MovieTable: LongIdTable("movies") {
         val name = varchar("name", 255)
         val producerName = varchar("producer_name", 255)
         val releaseDate = date("release_date")
     }
 
+    /**
+     * 배우 정보를 저장하는 테이블.
+     *
+     * - `first_name`: 배우 이름 (최대 255자)
+     * - `last_name`: 배우 성 (최대 255자)
+     * - `birthday`: 생년월일 (선택적, NULL 허용)
+     */
     object ActorTable: LongIdTable("actors") {
         val firstName = varchar("first_name", 255)
         val lastName = varchar("last_name", 255)
         val birthday = date("birthday").nullable()
     }
 
+    /**
+     * 영화와 배우 간의 다대다(N:M) 관계를 표현하는 중간 테이블.
+     *
+     * - `movie_id`: [MovieTable]을 참조하는 외래 키 (삭제 시 CASCADE)
+     * - `actor_id`: [ActorTable]을 참조하는 외래 키 (삭제 시 CASCADE)
+     * - 복합 기본 키: (movieId, actorId)
+     */
     object ActorInMovieTable: Table("actors_in_movies") {
         val movieId: Column<EntityID<Long>> = reference("movie_id", MovieTable, onDelete = ReferenceOption.CASCADE)
         val actorId: Column<EntityID<Long>> = reference("actor_id", ActorTable, onDelete = ReferenceOption.CASCADE)
@@ -49,6 +82,17 @@ object MovieSchema: KLogging() {
         override val primaryKey = PrimaryKey(movieId, actorId)
     }
 
+    /**
+     * 영화(Movie) DAO 엔티티 클래스.
+     *
+     * [ActorInMovieTable]을 통해 배우 목록과 다대다 관계를 맺습니다.
+     *
+     * @param id 엔티티 식별자
+     * @property name 영화 제목
+     * @property producerName 제작자 이름
+     * @property releaseDate 개봉일
+     * @property actors 이 영화에 출연한 [ActorEntity] 목록
+     */
     class MovieEntity(
         id: EntityID<Long>,
     ): LongEntity(id) {
@@ -72,6 +116,17 @@ object MovieSchema: KLogging() {
                 .toString()
     }
 
+    /**
+     * 배우(Actor) DAO 엔티티 클래스.
+     *
+     * [ActorInMovieTable]을 통해 영화 목록과 다대다 관계를 맺습니다.
+     *
+     * @param id 엔티티 식별자
+     * @property firstName 배우 이름
+     * @property lastName 배우 성
+     * @property birthday 생년월일 (선택적)
+     * @property movies 이 배우가 출연한 [MovieEntity] 목록
+     */
     class ActorEntity(
         id: EntityID<Long>,
     ): LongEntity(id) {
@@ -95,6 +150,15 @@ object MovieSchema: KLogging() {
                 .toString()
     }
 
+    /**
+     * 영화 및 배우 테이블을 생성하고 샘플 데이터를 삽입한 후 동기 트랜잭션 블록을 실행합니다.
+     *
+     * 테스트 완료 후 모든 테이블을 자동으로 삭제합니다.
+     * 사전에 정의된 샘플 배우와 영화 데이터를 [populateSampleData]를 통해 삽입합니다.
+     *
+     * @param testDB 테스트에 사용할 데이터베이스 종류
+     * @param statement 샘플 데이터 삽입 후 실행할 트랜잭션 코드 블록
+     */
     @Suppress("UnusedReceiverParameter")
     fun AbstractExposedTest.withMovieAndActors(
         testDB: TestDB,
@@ -106,6 +170,15 @@ object MovieSchema: KLogging() {
         }
     }
 
+    /**
+     * 영화 및 배우 테이블을 생성하고 샘플 데이터를 삽입한 후 서스펜딩 트랜잭션 블록을 실행합니다.
+     *
+     * 코루틴 환경에서 사용하는 [withMovieAndActors]의 서스펜딩 버전입니다.
+     * 테스트 완료 후 모든 테이블을 자동으로 삭제합니다.
+     *
+     * @param testDB 테스트에 사용할 데이터베이스 종류
+     * @param statement 샘플 데이터 삽입 후 실행할 서스펜딩 트랜잭션 코드 블록
+     */
     @Suppress("UnusedReceiverParameter")
     suspend fun AbstractExposedTest.withSuspendedMovieAndActors(
         testDB: TestDB,
@@ -122,6 +195,12 @@ object MovieSchema: KLogging() {
         }
     }
 
+    /**
+     * 영화 및 배우 샘플 데이터를 데이터베이스에 삽입합니다.
+     *
+     * 9명의 배우와 4편의 영화를 삽입하고, 각 영화에 출연한 배우들의 관계를 설정합니다.
+     * 내부적으로만 사용되는 private 메서드입니다.
+     */
     private fun Transaction.populateSampleData() {
         log.info { "Inserting sample actors and movies ..." }
 

--- a/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/repository/model/movie-mappers.kt
+++ b/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/repository/model/movie-mappers.kt
@@ -6,6 +6,13 @@ import exposed.shared.repository.model.MovieSchema.MovieTable
 import org.jetbrains.exposed.v1.core.ResultRow
 
 
+/**
+ * [ResultRow]를 [ActorRecord]로 변환하는 확장 함수.
+ *
+ * [ActorTable]의 컬럼 값을 읽어 [ActorRecord] 데이터 클래스로 매핑합니다.
+ *
+ * @return 변환된 [ActorRecord] 인스턴스
+ */
 fun ResultRow.toActorRecord() = ActorRecord(
     id = this[ActorTable.id].value,
     firstName = this[ActorTable.firstName],
@@ -13,6 +20,13 @@ fun ResultRow.toActorRecord() = ActorRecord(
     birthday = this[ActorTable.birthday]?.toString()
 )
 
+/**
+ * [MovieSchema.ActorEntity] DAO 엔티티를 [ActorRecord]로 변환하는 확장 함수.
+ *
+ * DAO 엔티티의 프로퍼티를 읽어 [ActorRecord] 데이터 클래스로 매핑합니다.
+ *
+ * @return 변환된 [ActorRecord] 인스턴스
+ */
 fun MovieSchema.ActorEntity.toActorRecord() = ActorRecord(
     id = this.id.value,
     firstName = this.firstName,
@@ -20,6 +34,13 @@ fun MovieSchema.ActorEntity.toActorRecord() = ActorRecord(
     birthday = this.birthday?.toString()
 )
 
+/**
+ * [ResultRow]를 [MovieRecord]로 변환하는 확장 함수.
+ *
+ * [MovieTable]의 컬럼 값을 읽어 [MovieRecord] 데이터 클래스로 매핑합니다.
+ *
+ * @return 변환된 [MovieRecord] 인스턴스
+ */
 fun ResultRow.toMovieRecord() = MovieRecord(
     name = this[MovieTable.name],
     producerName = this[MovieTable.producerName],
@@ -27,6 +48,14 @@ fun ResultRow.toMovieRecord() = MovieRecord(
     id = this[MovieTable.id].value
 )
 
+/**
+ * [ResultRow]를 배우 목록과 함께 [MovieWithActorRecord]로 변환하는 확장 함수.
+ *
+ * [MovieTable]의 컬럼 값과 별도로 조회한 배우 목록을 조합하여 [MovieWithActorRecord]를 생성합니다.
+ *
+ * @param actors 이 영화에 출연한 배우 목록
+ * @return 변환된 [MovieWithActorRecord] 인스턴스
+ */
 fun ResultRow.toMovieWithActorRecord(actors: List<ActorRecord>) = MovieWithActorRecord(
     name = this[MovieTable.name],
     producerName = this[MovieTable.producerName],
@@ -35,6 +64,14 @@ fun ResultRow.toMovieWithActorRecord(actors: List<ActorRecord>) = MovieWithActor
     id = this[MovieTable.id].value
 )
 
+/**
+ * [MovieRecord]를 배우 목록과 함께 [MovieWithActorRecord]로 변환하는 확장 함수.
+ *
+ * 기존 [MovieRecord]의 기본 정보에 배우 목록을 추가하여 [MovieWithActorRecord]를 생성합니다.
+ *
+ * @param actors 이 영화에 출연한 배우 목록
+ * @return 변환된 [MovieWithActorRecord] 인스턴스
+ */
 fun MovieRecord.toMovieWithActorRecord(actors: List<ActorRecord>) = MovieWithActorRecord(
     name = this.name,
     producerName = this.producerName,
@@ -43,6 +80,14 @@ fun MovieRecord.toMovieWithActorRecord(actors: List<ActorRecord>) = MovieWithAct
     id = this.id
 )
 
+/**
+ * [MovieSchema.MovieEntity] DAO 엔티티를 [MovieRecord]로 변환하는 확장 함수.
+ *
+ * DAO 엔티티의 프로퍼티를 읽어 [MovieRecord] 데이터 클래스로 매핑합니다.
+ * 배우 정보는 포함되지 않습니다.
+ *
+ * @return 변환된 [MovieRecord] 인스턴스
+ */
 fun MovieSchema.MovieEntity.toMovieRecord() = MovieRecord(
     name = this.name,
     producerName = this.producerName,
@@ -50,6 +95,14 @@ fun MovieSchema.MovieEntity.toMovieRecord() = MovieRecord(
     id = this.id.value
 )
 
+/**
+ * [MovieSchema.MovieEntity] DAO 엔티티를 배우 목록을 포함한 [MovieWithActorRecord]로 변환하는 확장 함수.
+ *
+ * DAO 엔티티의 `actors` 연관 관계를 함께 로드하여 [MovieWithActorRecord]를 생성합니다.
+ * 이 함수는 N+1 쿼리 문제를 유발할 수 있으므로 주의가 필요합니다.
+ *
+ * @return 배우 목록이 포함된 [MovieWithActorRecord] 인스턴스
+ */
 fun MovieSchema.MovieEntity.toMovieWithActorRecord() = MovieWithActorRecord(
     name = this.name,
     producerName = this.producerName,
@@ -59,6 +112,13 @@ fun MovieSchema.MovieEntity.toMovieWithActorRecord() = MovieWithActorRecord(
 )
 
 
+/**
+ * [ResultRow]를 영화-제작 배우 정보를 담은 [MovieWithProducingActorRecord]로 변환하는 확장 함수.
+ *
+ * [MovieTable]과 [ActorTable]을 조인한 결과 행에서 영화 제목과 제작 배우 이름을 추출합니다.
+ *
+ * @return 변환된 [MovieWithProducingActorRecord] 인스턴스
+ */
 fun ResultRow.toMovieWithProducingActorRecord() = MovieWithProducingActorRecord(
     movieName = this[MovieTable.name],
     producerActorName = this[ActorTable.firstName] + " " + this[ActorTable.lastName]

--- a/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/repository/repository/ActorRepository.kt
+++ b/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/repository/repository/ActorRepository.kt
@@ -13,13 +13,46 @@ import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import java.time.LocalDate
 
+/**
+ * 배우(Actor) 데이터에 대한 JDBC 기반 리포지토리 구현체.
+ *
+ * [JdbcRepository]를 구현하며 [ActorTable]을 대상으로
+ * 배우 조회, 검색, 저장 기능을 제공합니다.
+ *
+ * 트랜잭션 컨텍스트 내에서 사용해야 합니다.
+ *
+ * @see ActorTable
+ * @see ActorRecord
+ * @see JdbcRepository
+ */
 class ActorRepository: JdbcRepository<Long, ActorTable, ActorRecord> {
 
     companion object: KLogging()
 
+    /** 이 리포지토리가 대상으로 하는 [ActorTable] 참조 */
     override val table = ActorTable
+
+    /**
+     * [ResultRow]를 [ActorRecord]로 변환합니다.
+     *
+     * @return 변환된 [ActorRecord] 인스턴스
+     */
     override fun ResultRow.toEntity(): ActorRecord = toActorRecord()
 
+    /**
+     * 주어진 파라미터 맵을 기반으로 배우를 동적으로 검색합니다.
+     *
+     * 지원되는 파라미터 키:
+     * - `id`: 배우 ID로 필터링
+     * - `firstName`: 배우 이름으로 필터링
+     * - `lastName`: 배우 성으로 필터링
+     * - `birthday`: 생년월일로 필터링 (ISO 날짜 형식: `yyyy-MM-dd`)
+     *
+     * 파라미터 값이 `null`인 경우 해당 조건은 무시됩니다.
+     *
+     * @param params 검색 조건을 담은 맵 (컬럼 이름 -> 값)
+     * @return 검색 조건에 일치하는 [ActorRecord] 목록
+     */
     fun searchActors(params: Map<String, String?>): List<ActorRecord> {
         val query = ActorTable.selectAll()
 
@@ -41,6 +74,15 @@ class ActorRepository: JdbcRepository<Long, ActorTable, ActorRecord> {
         return query.map { it.toEntity() }
     }
 
+    /**
+     * 새로운 배우 정보를 데이터베이스에 저장합니다.
+     *
+     * 저장 후 데이터베이스에서 생성된 ID를 포함한 [ActorRecord]를 반환합니다.
+     * `birthday` 값이 유효하지 않은 날짜 형식인 경우 `null`로 저장됩니다.
+     *
+     * @param actor 저장할 배우 정보 ([ActorRecord])
+     * @return 데이터베이스에서 생성된 ID가 설정된 [ActorRecord]
+     */
     fun save(actor: ActorRecord): ActorRecord {
         log.debug { "Create new actor. actor: $actor" }
 

--- a/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/AbstractExposedTest.kt
+++ b/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/AbstractExposedTest.kt
@@ -7,15 +7,41 @@ import org.jetbrains.exposed.v1.core.Schema
 import org.jetbrains.exposed.v1.core.statements.StatementInterceptor
 import java.util.*
 
+/**
+ * 모든 Exposed 테스트의 기반 추상 클래스.
+ *
+ * 이 클래스는 Exposed 프레임워크를 사용하는 모든 테스트 모듈에서 공통으로 사용되는
+ * 기본 설정과 유틸리티 메서드를 제공합니다.
+ *
+ * - 기본 타임존을 UTC로 설정합니다.
+ * - Faker 인스턴스를 제공하여 테스트 데이터 생성을 지원합니다.
+ * - 활성화된 데이터베이스 방언(Dialect) 목록을 제공합니다.
+ *
+ * @see TestDB
+ * @see withTables
+ */
 abstract class AbstractExposedTest {
 
     companion object: KLogging() {
+        /** Faker 라이브러리 인스턴스. 테스트 데이터 생성에 사용됩니다. */
         @JvmStatic
         val faker = Fakers.faker
 
+        /**
+         * 현재 활성화된 데이터베이스 방언 목록을 반환합니다.
+         *
+         * JUnit 5의 `@MethodSource` 어노테이션과 함께 파라미터화 테스트에 사용됩니다.
+         *
+         * @return 활성화된 [TestDB] 목록
+         */
         @JvmStatic
         fun enableDialects() = TestDB.enabledDialects()
 
+        /**
+         * `@MethodSource` 어노테이션에 사용할 메서드 이름 상수.
+         *
+         * 파라미터화 테스트에서 `@MethodSource(ENABLE_DIALECTS_METHOD)`로 참조합니다.
+         */
         const val ENABLE_DIALECTS_METHOD = "enableDialects"
     }
 
@@ -23,18 +49,38 @@ abstract class AbstractExposedTest {
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
     }
 
+    /**
+     * 트랜잭션 커밋 시 [TestDB] 관련 사용자 데이터를 유지하는 인터셉터.
+     *
+     * 커밋 후에도 현재 테스트 DB 정보가 트랜잭션 스토어에 남아있도록 합니다.
+     */
     private object CurrentTestDBInterceptor: StatementInterceptor {
         override fun keepUserDataInTransactionStoreOnCommit(userData: Map<Key<*>, Any?>): Map<Key<*>, Any?> {
             return userData.filterValues { it is TestDB }
         }
     }
 
+    /**
+     * 현재 데이터베이스 방언이 `IF NOT EXISTS` 구문을 지원하는 경우 해당 문자열을 반환합니다.
+     *
+     * DDL 구문 생성 시 데이터베이스 호환성을 위해 사용됩니다.
+     *
+     * @return `IF NOT EXISTS ` 문자열 또는 빈 문자열
+     */
     fun addIfNotExistsIfSupported() = if (currentDialectTest.supportsIfNotExists) {
         "IF NOT EXISTS "
     } else {
         ""
     }
 
+    /**
+     * 테스트용 스키마 객체를 생성합니다.
+     *
+     * Oracle 스타일의 테이블스페이스 설정이 포함된 스키마를 생성합니다.
+     *
+     * @param schemaName 생성할 스키마의 이름
+     * @return 설정이 적용된 [Schema] 객체
+     */
     protected fun prepareSchemaForTest(schemaName: String): Schema = Schema(
         schemaName,
         defaultTablespace = "USERS",

--- a/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/Slf4jLogger.kt
+++ b/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/Slf4jLogger.kt
@@ -3,4 +3,10 @@ package exposed.shared.tests
 import io.bluetape4k.logging.KotlinLogging
 import org.slf4j.Logger
 
+/**
+ * 이 패키지 내에서 공용으로 사용하는 SLF4J 로거 인스턴스.
+ *
+ * [KotlinLogging]을 통해 지연 초기화되며, Exposed 테스트 인프라의
+ * 로그 출력에 사용됩니다.
+ */
 internal val logger: Logger by lazy { KotlinLogging.logger { } }

--- a/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/WithDBSuspending.kt
+++ b/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/WithDBSuspending.kt
@@ -11,11 +11,32 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transactionManager
 import java.util.concurrent.Semaphore
 import kotlin.coroutines.CoroutineContext
 
+/**
+ * 코루틴 환경에서 [TestDB]의 세마포어를 비동기적으로 획득합니다.
+ *
+ * [Dispatchers.IO]를 사용하여 블로킹 세마포어 획득을 IO 스레드 풀에서 실행합니다.
+ *
+ * @param testDB 세마포어를 획득할 데이터베이스 종류
+ */
 private suspend fun acquireSemaphoreSuspending(testDB: TestDB) =
     withContext(Dispatchers.IO) {
         testDbSemaphores.computeIfAbsent(testDB) { Semaphore(1, true) }.acquire()
     }
 
+/**
+ * 지정된 [TestDB]에 연결하여 코루틴 기반 서스펜딩 트랜잭션 블록을 실행합니다.
+ *
+ * - 세마포어를 사용하여 동일 데이터베이스에 대한 동시 접근을 직렬화합니다.
+ * - 최초 호출 시 데이터베이스에 연결하고 JVM 종료 시 정리 훅을 등록합니다.
+ * - `@ParameterizedTest`와 코루틴을 함께 사용할 때 발생할 수 있는 TestDB 혼용 문제를 방지합니다.
+ * - 새로운 설정(`configure`)이 제공된 경우, 테스트 완료 후 이전 설정으로 복원합니다.
+ *
+ * @param testDB 테스트에 사용할 데이터베이스 종류
+ * @param context 트랜잭션을 실행할 코루틴 컨텍스트. 기본값은 [Dispatchers.IO]
+ * @param configure 데이터베이스 설정을 커스터마이즈하는 빌더 람다. `null`이면 기본 설정 사용
+ * @param statement 서스펜딩 트랜잭션 내에서 실행할 코드 블록. [TestDB]를 인자로 받습니다
+ * @see withDb
+ */
 @Suppress("DEPRECATION")
 suspend fun withDbSuspending(
     testDB: TestDB,
@@ -67,6 +88,17 @@ suspend fun withDbSuspending(
     }
 }
 
+/**
+ * [withDbSuspending]의 이전 버전 호환을 위한 deprecated 함수.
+ *
+ * 새로운 코드에서는 [withDbSuspending]을 사용하세요.
+ *
+ * @param testDB 테스트에 사용할 데이터베이스 종류
+ * @param context 트랜잭션을 실행할 코루틴 컨텍스트. 기본값은 [Dispatchers.IO]
+ * @param configure 데이터베이스 설정을 커스터마이즈하는 빌더 람다. `null`이면 기본 설정 사용
+ * @param statement 서스펜딩 트랜잭션 내에서 실행할 코드 블록
+ * @see withDbSuspending
+ */
 @Deprecated(
     message = "Use withDbSuspending() instead.",
     replaceWith = ReplaceWith(

--- a/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/WithDb.kt
+++ b/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/WithDb.kt
@@ -12,17 +12,49 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transactionManager
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Semaphore
 
+/**
+ * JVM 종료 시 정리(cleanup)가 등록된 [TestDB] 인스턴스의 집합.
+ *
+ * 중복 등록을 방지하기 위해 스레드 안전한 [ConcurrentHashMap] 기반 Set으로 관리됩니다.
+ */
 internal val registeredOnShutdown = ConcurrentHashMap.newKeySet<TestDB>()
+
+/**
+ * 각 [TestDB]에 대한 동시 접근을 제어하는 세마포어 맵.
+ *
+ * 동일한 데이터베이스에 대한 병렬 테스트 실행을 방지하여 테스트 격리를 보장합니다.
+ */
 internal val testDbSemaphores = ConcurrentHashMap<TestDB, Semaphore>()
 
+/**
+ * 현재 트랜잭션 스코프에서 사용 중인 [TestDB]를 나타내는 변수.
+ *
+ * 트랜잭션 컨텍스트에 바인딩되어 있으며, 트랜잭션 외부에서는 `null`입니다.
+ */
 var currentTestDB by nullableTransactionScope<TestDB>()
 
+/**
+ * 트랜잭션 커밋 시 [TestDB] 관련 사용자 데이터를 유지하는 인터셉터.
+ *
+ * 커밋 후에도 현재 테스트 DB 정보가 트랜잭션 스토어에 남아있도록 합니다.
+ */
 object CurrentTestDBInterceptor: StatementInterceptor {
     override fun keepUserDataInTransactionStoreOnCommit(userData: Map<Key<*>, Any?>): Map<Key<*>, Any?> {
         return userData.filterValues { it is TestDB }
     }
 }
 
+/**
+ * 지정된 [TestDB]에 연결하여 동기 트랜잭션 블록을 실행합니다.
+ *
+ * - 세마포어를 사용하여 동일 데이터베이스에 대한 동시 접근을 직렬화합니다.
+ * - 최초 호출 시 데이터베이스에 연결하고 JVM 종료 시 정리 훅을 등록합니다.
+ * - 새로운 설정(`configure`)이 제공된 경우, 테스트 완료 후 이전 설정으로 복원합니다.
+ *
+ * @param testDB 테스트에 사용할 데이터베이스 종류
+ * @param configure 데이터베이스 설정을 커스터마이즈하는 빌더 람다. `null`이면 기본 설정 사용
+ * @param statement 트랜잭션 내에서 실행할 코드 블록. [TestDB]를 인자로 받습니다
+ */
 fun withDb(
     testDB: TestDB,
     configure: (DatabaseConfig.Builder.() -> Unit)? = null,

--- a/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/WithSchemas.kt
+++ b/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/WithSchemas.kt
@@ -5,6 +5,25 @@ import org.jetbrains.exposed.v1.core.Schema
 import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 
+/**
+ * 지정된 스키마를 생성하고 동기 트랜잭션 블록을 실행한 후 스키마를 삭제합니다.
+ *
+ * 현재 데이터베이스 방언이 스키마 생성을 지원하는 경우에만 실행됩니다.
+ * 테스트 완료 후 cascade 옵션으로 스키마와 하위 객체를 모두 삭제하여 테스트 격리를 보장합니다.
+ *
+ * 실행 흐름:
+ * 1. [SchemaUtils.createSchema]로 지정된 스키마를 생성합니다.
+ * 2. [statement] 블록을 실행합니다.
+ * 3. 커밋하여 변경사항을 영속화합니다.
+ * 4. [SchemaUtils.dropSchema]로 스키마를 삭제합니다.
+ *
+ * @param dialect 테스트에 사용할 데이터베이스 방언 ([TestDB])
+ * @param schemas 생성 및 삭제할 [Schema] 목록
+ * @param configure 데이터베이스 설정을 커스터마이즈하는 빌더 람다. 기본값은 빈 설정
+ * @param statement 스키마 생성 후 실행할 트랜잭션 코드 블록
+ * @see withDb
+ * @see SchemaUtils
+ */
 fun withSchemas(
     dialect: TestDB,
     vararg schemas: Schema,

--- a/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/WithSchemasSuspending.kt
+++ b/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/WithSchemasSuspending.kt
@@ -7,6 +7,26 @@ import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import kotlin.coroutines.CoroutineContext
 
+/**
+ * 지정된 스키마를 생성하고 코루틴 기반 서스펜딩 트랜잭션 블록을 실행한 후 스키마를 삭제합니다.
+ *
+ * 현재 데이터베이스 방언이 스키마 생성을 지원하는 경우에만 실행됩니다.
+ * 테스트 완료 후 cascade 옵션으로 스키마와 하위 객체를 모두 삭제하여 테스트 격리를 보장합니다.
+ *
+ * 실행 흐름:
+ * 1. [SchemaUtils.createSchema]로 지정된 스키마를 생성합니다.
+ * 2. [statement] 서스펜딩 블록을 실행합니다.
+ * 3. 커밋하여 변경사항을 영속화합니다.
+ * 4. [SchemaUtils.dropSchema]로 스키마를 삭제합니다.
+ *
+ * @param dialect 테스트에 사용할 데이터베이스 방언 ([TestDB])
+ * @param schemas 생성 및 삭제할 [Schema] 목록
+ * @param configure 데이터베이스 설정을 커스터마이즈하는 빌더 람다. 기본값은 빈 설정
+ * @param context 트랜잭션을 실행할 코루틴 컨텍스트. 기본값은 [Dispatchers.IO]
+ * @param statement 스키마 생성 후 실행할 서스펜딩 트랜잭션 코드 블록
+ * @see withDbSuspending
+ * @see SchemaUtils
+ */
 suspend fun withSchemasSuspending(
     dialect: TestDB,
     vararg schemas: Schema,

--- a/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/SpringMvcApplication.kt
+++ b/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/SpringMvcApplication.kt
@@ -5,11 +5,26 @@ import org.springframework.boot.WebApplicationType
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
+/**
+ * Spring MVC + Exposed 통합 예제 애플리케이션.
+ *
+ * Spring Boot 기반의 서블릿(블로킹) 웹 애플리케이션으로,
+ * Jetbrains Exposed DSL/DAO를 사용하여 데이터베이스에 접근하는 방법을 보여줍니다.
+ *
+ * @see ExposedDatabaseConfig
+ */
 @SpringBootApplication
 class SpringMvcApplication {
     companion object: KLogging()
 }
 
+/**
+ * Spring MVC 애플리케이션 진입점.
+ *
+ * [WebApplicationType.SERVLET] 타입으로 서블릿 기반 웹 서버를 시작합니다.
+ *
+ * @param args 커맨드라인 인수
+ */
 fun main(vararg args: String) {
     runApplication<SpringMvcApplication>(*args) {
         webApplicationType = WebApplicationType.SERVLET

--- a/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/config/ExposedDatabaseConfig.kt
+++ b/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/config/ExposedDatabaseConfig.kt
@@ -14,12 +14,34 @@ import org.springframework.context.annotation.Profile
 import org.springframework.transaction.annotation.EnableTransactionManagement
 import javax.sql.DataSource
 
+/**
+ * Exposed 데이터베이스 연결 설정 클래스.
+ *
+ * 활성 Spring 프로파일에 따라 적절한 [DataSource]를 구성하고,
+ * Exposed [Database] 인스턴스를 빈으로 등록합니다.
+ *
+ * 지원 프로파일:
+ * - `h2`: 인메모리 H2 데이터베이스 (PostgreSQL 호환 모드)
+ * - `mysql`: Testcontainers 기반 MySQL 8 데이터베이스
+ * - `postgres`: Testcontainers 기반 PostgreSQL 데이터베이스
+ *
+ * Spring 트랜잭션 관리(@EnableTransactionManagement)를 활성화하여
+ * @Transactional 어노테이션을 통한 선언적 트랜잭션 처리를 지원합니다.
+ */
 @Configuration
 @EnableTransactionManagement
 class ExposedDatabaseConfig {
 
     companion object: KLogging()
 
+    /**
+     * H2 인메모리 데이터베이스용 [DataSource]를 생성합니다.
+     *
+     * `h2` 프로파일이 활성화된 경우에만 빈으로 등록됩니다.
+     * PostgreSQL 호환 모드로 실행되어 PostgreSQL 문법을 사용할 수 있습니다.
+     *
+     * @return HikariCP 커넥션 풀로 감싼 H2 [DataSource]
+     */
     @Bean
     @Profile("h2")
     fun dataSourceH2(): DataSource {
@@ -34,6 +56,13 @@ class ExposedDatabaseConfig {
         return HikariDataSource(config)
     }
 
+    /**
+     * Testcontainers로 구동되는 MySQL 8 데이터베이스용 [DataSource]를 생성합니다.
+     *
+     * `mysql` 프로파일이 활성화된 경우에만 빈으로 등록됩니다.
+     *
+     * @return MySQL 8 컨테이너에 연결된 [DataSource]
+     */
     @Bean
     @Profile("mysql")
     fun dataSourceMySql(): DataSource {
@@ -43,6 +72,13 @@ class ExposedDatabaseConfig {
         return mysql.getDataSource()
     }
 
+    /**
+     * Testcontainers로 구동되는 PostgreSQL 데이터베이스용 [DataSource]를 생성합니다.
+     *
+     * `postgres` 프로파일이 활성화된 경우에만 빈으로 등록됩니다.
+     *
+     * @return PostgreSQL 컨테이너에 연결된 [DataSource]
+     */
     @Bean
     @Profile("postgres")
     fun dataSourcePostgres(): DataSource {
@@ -52,6 +88,14 @@ class ExposedDatabaseConfig {
         return postgres.getDataSource()
     }
 
+    /**
+     * Exposed [Database] 인스턴스를 생성하여 Spring 빈으로 등록합니다.
+     *
+     * 주입된 [DataSource]를 사용하여 Exposed 프레임워크의 데이터베이스 연결을 초기화합니다.
+     *
+     * @param dataSource 데이터베이스 연결에 사용할 [DataSource]
+     * @return Exposed [Database] 인스턴스
+     */
     @Bean
     fun database(dataSource: DataSource): Database {
         log.info { "Create Database instance with dataSource: $dataSource" }

--- a/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/controller/ActorController.kt
+++ b/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/controller/ActorController.kt
@@ -14,6 +14,14 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * 배우(Actor) 관련 REST API 컨트롤러.
+ *
+ * `/actors` 경로로 배우 정보의 조회, 생성, 삭제 기능을 제공합니다.
+ * 기본적으로 읽기 전용 트랜잭션으로 동작하며, 쓰기 작업은 별도로 트랜잭션을 지정합니다.
+ *
+ * @param actorRepository 배우 데이터 접근 레포지토리
+ */
 @RestController
 @Transactional(readOnly = true)
 @RequestMapping("/actors")
@@ -21,11 +29,29 @@ class ActorController(private val actorRepository: ActorRepository) {
 
     companion object: KLogging()
 
+    /**
+     * ID로 배우를 조회합니다.
+     *
+     * HTTP GET `/actors/{id}`
+     *
+     * @param actorId 조회할 배우의 고유 식별자
+     * @return 해당 ID의 [ActorRecord], 존재하지 않으면 null
+     */
     @GetMapping("/{id}")
     fun getActorById(@PathVariable("id") actorId: Long): ActorRecord? {
         return actorRepository.findById(actorId)
     }
 
+    /**
+     * 쿼리 파라미터를 기반으로 배우를 검색합니다.
+     *
+     * HTTP GET `/actors?firstName=...&lastName=...&birthday=...`
+     *
+     * 지원 필터: `id`, `firstName`, `lastName`, `birthday`
+     *
+     * @param request HTTP 서블릿 요청 (쿼리 파라미터 포함)
+     * @return 조건에 맞는 [ActorRecord] 목록
+     */
     @GetMapping
     fun searchActors(request: HttpServletRequest): List<ActorRecord> {
         val params = request.parameterMap.map { it.key to it.value.firstOrNull() }.toMap()
@@ -34,12 +60,28 @@ class ActorController(private val actorRepository: ActorRepository) {
         return actorRepository.searchActors(params)
     }
 
+    /**
+     * 새로운 배우를 생성합니다.
+     *
+     * HTTP POST `/actors`
+     *
+     * @param actor 생성할 배우 정보가 담긴 [ActorRecord] (id는 무시됨)
+     * @return 생성된 배우의 [ActorRecord] (서버에서 할당된 id 포함)
+     */
     @PostMapping
     @Transactional
     fun createActor(@RequestBody actor: ActorRecord): ActorRecord {
         return actorRepository.create(actor)
     }
 
+    /**
+     * ID로 배우를 삭제합니다.
+     *
+     * HTTP DELETE `/actors/{id}`
+     *
+     * @param actorId 삭제할 배우의 고유 식별자
+     * @return 삭제된 행 수 (성공 시 1, 존재하지 않으면 0)
+     */
     @DeleteMapping("/{id}")
     @Transactional
     fun deleteActorById(@PathVariable("id") actorId: Long): Int {

--- a/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/controller/IndexController.kt
+++ b/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/controller/IndexController.kt
@@ -7,6 +7,11 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * 인덱스(루트) 경로 REST 컨트롤러.
+ *
+ * `/` 경로로 애플리케이션 빌드 정보를 제공합니다.
+ */
 @RestController
 @RequestMapping("/")
 class IndexController {
@@ -14,7 +19,13 @@ class IndexController {
     @Autowired
     private val buildProperties: BuildProperties = uninitialized()
 
-
+    /**
+     * 애플리케이션 빌드 정보를 반환합니다.
+     *
+     * HTTP GET `/`
+     *
+     * @return 버전, 빌드 시간 등의 메타정보가 담긴 [BuildProperties]
+     */
     @GetMapping
     fun index(): BuildProperties {
         return buildProperties

--- a/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/controller/MovieActorsController.kt
+++ b/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/controller/MovieActorsController.kt
@@ -11,6 +11,15 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * 영화-배우 관계 조회 REST API 컨트롤러.
+ *
+ * `/movie-actors` 경로로 영화에 출연한 배우 정보, 출연 수 집계,
+ * 프로듀서 겸 배우 목록 등 복합 조회 기능을 제공합니다.
+ * 모든 요청은 읽기 전용 트랜잭션으로 처리됩니다.
+ *
+ * @param movieRepo 영화 데이터 접근 레포지토리
+ */
 @RestController
 @Transactional(readOnly = true)
 @RequestMapping("/movie-actors")
@@ -18,16 +27,38 @@ class MovieActorsController(private val movieRepo: MovieRepository) {
 
     companion object: KLogging()
 
+    /**
+     * 특정 영화와 출연 배우 목록을 함께 조회합니다.
+     *
+     * HTTP GET `/movie-actors/{movieId}`
+     *
+     * @param movieId 조회할 영화의 고유 식별자
+     * @return 영화 정보와 배우 목록이 담긴 [MovieWithActorRecord], 존재하지 않으면 null
+     */
     @GetMapping("/{movieId}")
     fun getMovieWithActors(@PathVariable movieId: Long): MovieWithActorRecord? {
         return movieRepo.getMovieWithActors(movieId)
     }
 
+    /**
+     * 영화별 출연 배우 수를 집계하여 반환합니다.
+     *
+     * HTTP GET `/movie-actors/count`
+     *
+     * @return 각 영화의 배우 출연 수 정보가 담긴 [MovieActorCountRecord] 목록
+     */
     @GetMapping("/count")
     fun getMovieActorsCount(): List<MovieActorCountRecord> {
         return movieRepo.getMovieActorsCount()
     }
 
+    /**
+     * 프로듀서가 직접 배우로도 출연한 영화 목록을 반환합니다.
+     *
+     * HTTP GET `/movie-actors/acting-producers`
+     *
+     * @return 프로듀서 겸 배우 정보가 담긴 [MovieWithProducingActorRecord] 목록
+     */
     @GetMapping("/acting-producers")
     fun findMoviesWithActingProducers(): List<MovieWithProducingActorRecord> {
         return movieRepo.findMoviesWithActingProducers()

--- a/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/controller/MovieController.kt
+++ b/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/controller/MovieController.kt
@@ -14,6 +14,14 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * 영화(Movie) 관련 REST API 컨트롤러.
+ *
+ * `/movies` 경로로 영화 정보의 조회, 생성, 삭제 기능을 제공합니다.
+ * 기본적으로 읽기 전용 트랜잭션으로 동작하며, 쓰기 작업은 별도로 트랜잭션을 지정합니다.
+ *
+ * @param movieRepository 영화 데이터 접근 레포지토리
+ */
 @RestController
 @Transactional(readOnly = true)
 @RequestMapping("/movies")
@@ -21,11 +29,29 @@ class MovieController(private val movieRepository: MovieRepository) {
 
     companion object: KLogging()
 
+    /**
+     * ID로 영화를 조회합니다.
+     *
+     * HTTP GET `/movies/{id}`
+     *
+     * @param movieId 조회할 영화의 고유 식별자
+     * @return 해당 ID의 [MovieRecord], 존재하지 않으면 null
+     */
     @GetMapping("/{id}")
     fun getMovieById(@PathVariable("id") movieId: Long): MovieRecord? {
         return movieRepository.findById(movieId)
     }
 
+    /**
+     * 쿼리 파라미터를 기반으로 영화를 검색합니다.
+     *
+     * HTTP GET `/movies?name=...&producerName=...`
+     *
+     * 지원 필터: `id`, `name`, `producerName`, `releaseDate`
+     *
+     * @param request HTTP 서블릿 요청 (쿼리 파라미터 포함)
+     * @return 조건에 맞는 [MovieRecord] 목록
+     */
     @GetMapping
     fun searchMovies(request: HttpServletRequest): List<MovieRecord> {
         val params = request.parameterMap.map { it.key to it.value.firstOrNull() }.toMap()
@@ -34,12 +60,28 @@ class MovieController(private val movieRepository: MovieRepository) {
         return movieRepository.searchMovies(params)
     }
 
+    /**
+     * 새로운 영화를 생성합니다.
+     *
+     * HTTP POST `/movies`
+     *
+     * @param movieRecord 생성할 영화 정보가 담긴 [MovieRecord] (id는 무시됨)
+     * @return 생성된 영화의 [MovieRecord] (서버에서 할당된 id 포함), 실패 시 null
+     */
     @Transactional
     @PostMapping
     fun createMovie(@RequestBody movieRecord: MovieRecord): MovieRecord? {
         return movieRepository.create(movieRecord)
     }
 
+    /**
+     * ID로 영화를 삭제합니다.
+     *
+     * HTTP DELETE `/movies/{id}`
+     *
+     * @param movieId 삭제할 영화의 고유 식별자
+     * @return 삭제된 행 수 (성공 시 1, 존재하지 않으면 0)
+     */
     @Transactional
     @DeleteMapping("/{id}")
     fun deleteMovieById(@PathVariable("id") movieId: Long): Int {

--- a/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/domain/DataInitializer.kt
+++ b/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/domain/DataInitializer.kt
@@ -19,11 +19,28 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
+/**
+ * 애플리케이션 시작 시 샘플 데이터를 데이터베이스에 초기화하는 컴포넌트.
+ *
+ * [ApplicationReadyEvent] 이벤트를 수신하여 애플리케이션이 완전히 시작된 후
+ * 배우(Actor)와 영화(Movie) 샘플 데이터를 삽입합니다.
+ * 이미 데이터가 존재하면 삽입을 건너뜁니다.
+ *
+ * @see MovieSchema.ActorTable
+ * @see MovieSchema.MovieTable
+ */
 @Component
 class DataInitializer: ApplicationListener<ApplicationReadyEvent> {
 
     companion object: KLogging()
 
+    /**
+     * 애플리케이션 준비 완료 이벤트 핸들러.
+     *
+     * 트랜잭션 내에서 샘플 데이터 초기화를 수행합니다.
+     *
+     * @param event 애플리케이션 준비 완료 이벤트
+     */
     @Transactional
     override fun onApplicationEvent(event: ApplicationReadyEvent) {
         log.info { "데이터베이스 샘플 데이터 추가" }

--- a/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/domain/model/MovieMappers.kt
+++ b/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/domain/model/MovieMappers.kt
@@ -2,6 +2,13 @@ package exposed.workshop.springmvc.domain.model
 
 import org.jetbrains.exposed.v1.core.ResultRow
 
+/**
+ * Exposed [ResultRow]를 [ActorRecord]로 변환합니다.
+ *
+ * [MovieSchema.ActorTable]의 컬럼 값을 읽어 데이터 레코드를 생성합니다.
+ *
+ * @return 변환된 [ActorRecord]
+ */
 fun ResultRow.toActorRecord() = ActorRecord(
     id = this[MovieSchema.ActorTable.id].value,
     firstName = this[MovieSchema.ActorTable.firstName],
@@ -9,6 +16,11 @@ fun ResultRow.toActorRecord() = ActorRecord(
     birthday = this[MovieSchema.ActorTable.birthday]?.toString()
 )
 
+/**
+ * Exposed DAO [MovieSchema.ActorEntity]를 [ActorRecord]로 변환합니다.
+ *
+ * @return 변환된 [ActorRecord]
+ */
 fun MovieSchema.ActorEntity.toActorRecord() = ActorRecord(
     id = this.id.value,
     firstName = this.firstName,
@@ -16,6 +28,13 @@ fun MovieSchema.ActorEntity.toActorRecord() = ActorRecord(
     birthday = this.birthday?.toString()
 )
 
+/**
+ * Exposed [ResultRow]를 [MovieRecord]로 변환합니다.
+ *
+ * [MovieSchema.MovieTable]의 컬럼 값을 읽어 데이터 레코드를 생성합니다.
+ *
+ * @return 변환된 [MovieRecord]
+ */
 fun ResultRow.toMovieRecord() = MovieRecord(
     name = this[MovieSchema.MovieTable.name],
     producerName = this[MovieSchema.MovieTable.producerName],
@@ -23,6 +42,12 @@ fun ResultRow.toMovieRecord() = MovieRecord(
     id = this[MovieSchema.MovieTable.id].value
 )
 
+/**
+ * Exposed [ResultRow]를 배우 목록과 함께 [MovieWithActorRecord]로 변환합니다.
+ *
+ * @param actors 영화에 출연한 배우 목록
+ * @return 배우 목록이 포함된 [MovieWithActorRecord]
+ */
 fun ResultRow.toMovieWithActorRecord(actors: List<ActorRecord>) = MovieWithActorRecord(
     name = this[MovieSchema.MovieTable.name],
     producerName = this[MovieSchema.MovieTable.producerName],
@@ -31,6 +56,12 @@ fun ResultRow.toMovieWithActorRecord(actors: List<ActorRecord>) = MovieWithActor
     id = this[MovieSchema.MovieTable.id].value
 )
 
+/**
+ * [MovieRecord]를 배우 목록과 함께 [MovieWithActorRecord]로 변환합니다.
+ *
+ * @param actors 영화에 출연한 배우 컬렉션
+ * @return 배우 목록이 포함된 [MovieWithActorRecord]
+ */
 fun MovieRecord.toMovieWithActorRecord(actors: Collection<ActorRecord>) = MovieWithActorRecord(
     name = this.name,
     producerName = this.producerName,
@@ -39,6 +70,11 @@ fun MovieRecord.toMovieWithActorRecord(actors: Collection<ActorRecord>) = MovieW
     id = this.id
 )
 
+/**
+ * Exposed DAO [MovieSchema.MovieEntity]를 [MovieRecord]로 변환합니다.
+ *
+ * @return 변환된 [MovieRecord]
+ */
 fun MovieSchema.MovieEntity.toMovieRecord() = MovieRecord(
     name = this.name,
     producerName = this.producerName,
@@ -46,6 +82,13 @@ fun MovieSchema.MovieEntity.toMovieRecord() = MovieRecord(
     id = this.id.value
 )
 
+/**
+ * Exposed DAO [MovieSchema.MovieEntity]를 배우 목록과 함께 [MovieWithActorRecord]로 변환합니다.
+ *
+ * 엔티티의 연관된 배우 목록을 함께 매핑합니다.
+ *
+ * @return 배우 목록이 포함된 [MovieWithActorRecord]
+ */
 fun MovieSchema.MovieEntity.toMovieWithActorRecord() = MovieWithActorRecord(
     name = this.name,
     producerName = this.producerName,
@@ -54,7 +97,13 @@ fun MovieSchema.MovieEntity.toMovieWithActorRecord() = MovieWithActorRecord(
     id = this.id.value
 )
 
-
+/**
+ * Exposed [ResultRow]를 [MovieWithProducingActorRecord]로 변환합니다.
+ *
+ * 영화 이름과 프로듀서 겸 배우의 전체 이름을 결합합니다.
+ *
+ * @return 변환된 [MovieWithProducingActorRecord]
+ */
 fun ResultRow.toMovieWithProducingActorRecord() = MovieWithProducingActorRecord(
     movieName = this[MovieSchema.MovieTable.name],
     producerActorName = this[MovieSchema.ActorTable.firstName] + " " + this[MovieSchema.ActorTable.lastName]

--- a/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/domain/model/MovieSchema.kt
+++ b/01-spring-boot/spring-mvc-exposed/src/main/kotlin/exposed/workshop/springmvc/domain/model/MovieSchema.kt
@@ -16,9 +16,19 @@ import org.jetbrains.exposed.v1.jdbc.SizedIterable
 import java.time.LocalDate
 import java.time.LocalDateTime
 
+/**
+ * 영화 도메인의 Exposed DSL 테이블 스키마 및 DAO 엔티티 정의.
+ *
+ * 다음 세 가지 테이블과 해당 DAO 엔티티를 포함합니다:
+ * - [MovieTable]: 영화 정보 테이블
+ * - [ActorTable]: 배우 정보 테이블
+ * - [ActorInMovieTable]: 영화-배우 다대다 관계 테이블
+ */
 object MovieSchema {
 
     /**
+     * 영화 정보를 저장하는 테이블.
+     *
      * ```sql
      * -- Postgres
      * CREATE TABLE IF NOT EXISTS movies (
@@ -36,6 +46,8 @@ object MovieSchema {
     }
 
     /**
+     * 배우 정보를 저장하는 테이블.
+     *
      * ```sql
      * -- Postgres
      * CREATE TABLE IF NOT EXISTS actors (

--- a/04-exposed-ddl/01-connection/src/test/kotlin/exposed/examples/connection/DataSourceStub.kt
+++ b/04-exposed-ddl/01-connection/src/test/kotlin/exposed/examples/connection/DataSourceStub.kt
@@ -5,6 +5,12 @@ import java.sql.Connection
 import java.util.logging.Logger
 import javax.sql.DataSource
 
+/**
+ * 테스트용 [DataSource] 스텁 구현체.
+ *
+ * [java.util.logging.Logger] import는 [javax.sql.DataSource] 인터페이스의
+ * [getParentLogger] 메서드 반환 타입으로 요구되어 포함됩니다.
+ */
 internal open class DataSourceStub: DataSource {
 
     override fun getLogWriter(): PrintWriter {

--- a/04-exposed-ddl/01-connection/src/test/kotlin/exposed/examples/connection/Ex02_ConnectionException.kt
+++ b/04-exposed-ddl/01-connection/src/test/kotlin/exposed/examples/connection/Ex02_ConnectionException.kt
@@ -8,6 +8,7 @@ import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldContainIgnoringCase
 import org.amshove.kluent.shouldHaveSize
 import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
@@ -87,20 +88,24 @@ class Ex02_ConnectionException {
         val wrappingDataSource = WrappingDataSource(TestDB.H2, connectionDecorator)
         val db = Database.connect(datasource = wrappingDataSource)
         try {
-            transaction(db = db, transactionIsolation = Connection.TRANSACTION_SERIALIZABLE) {
-                maxAttempts = 5
-                this.exec("BROKEN_SQL_THAT_CAUSES_EXCEPTION()")
-            }
-            fail("위의 Tx에서 예외를 발생 시켜야 합니다.")
-        } catch (e: SQLException) {
-            e.toString() shouldContainIgnoringCase "BROKEN_SQL_THAT_CAUSES_EXCEPTION"
-            wrappingDataSource.connections shouldHaveSize 5
+            try {
+                transaction(db = db, transactionIsolation = Connection.TRANSACTION_SERIALIZABLE) {
+                    maxAttempts = 5
+                    this.exec("BROKEN_SQL_THAT_CAUSES_EXCEPTION()")
+                }
+                fail("위의 Tx에서 예외를 발생 시켜야 합니다.")
+            } catch (e: SQLException) {
+                e.toString() shouldContainIgnoringCase "BROKEN_SQL_THAT_CAUSES_EXCEPTION"
+                wrappingDataSource.connections shouldHaveSize 5
 
-            wrappingDataSource.connections.forEach { connection ->
-                connection.commitCalled.shouldBeFalse()
-                connection.rollbackCalled.shouldBeTrue()
-                connection.closeCalled.shouldBeTrue()
+                wrappingDataSource.connections.forEach { connection ->
+                    connection.commitCalled.shouldBeFalse()
+                    connection.rollbackCalled.shouldBeTrue()
+                    connection.closeCalled.shouldBeTrue()
+                }
             }
+        } finally {
+            TransactionManager.closeAndUnregister(db)
         }
     }
 
@@ -119,18 +124,22 @@ class Ex02_ConnectionException {
         val db = Database.connect(wrappingDataSource)
 
         try {
-            transaction(db = db, transactionIsolation = Connection.TRANSACTION_SERIALIZABLE) {
-                maxAttempts = 5
-                this.exec("SELECT 1;")
-            }
-            fail("위의 Tx에서 예외를 발생 시켜야 합니다.")
-        } catch (_: CommitException) {
-            wrappingDataSource.connections shouldHaveSize 5
+            try {
+                transaction(db = db, transactionIsolation = Connection.TRANSACTION_SERIALIZABLE) {
+                    maxAttempts = 5
+                    this.exec("SELECT 1;")
+                }
+                fail("위의 Tx에서 예외를 발생 시켜야 합니다.")
+            } catch (_: CommitException) {
+                wrappingDataSource.connections shouldHaveSize 5
 
-            wrappingDataSource.connections.forEach { connection ->
-                connection.commitCalled.shouldBeTrue()
-                connection.closeCalled.shouldBeTrue()
+                wrappingDataSource.connections.forEach { connection ->
+                    connection.commitCalled.shouldBeTrue()
+                    connection.closeCalled.shouldBeTrue()
+                }
             }
+        } finally {
+            TransactionManager.closeAndUnregister(db)
         }
     }
 
@@ -149,17 +158,21 @@ class Ex02_ConnectionException {
         val db = Database.connect(wrappingDataSource)
 
         try {
-            transaction(db = db, transactionIsolation = Connection.TRANSACTION_SERIALIZABLE) {
-                maxAttempts = 5
-                this.exec("SELECT 1;")
+            try {
+                transaction(db = db, transactionIsolation = Connection.TRANSACTION_SERIALIZABLE) {
+                    maxAttempts = 5
+                    this.exec("SELECT 1;")
+                }
+                fail("위의 Tx에서 예외를 발생 시켜야 합니다.")
+            } catch (_: CommitException) {
+                wrappingDataSource.connections shouldHaveSize 5
+                wrappingDataSource.connections.forEach { connection ->
+                    connection.commitCalled.shouldBeTrue()
+                    connection.closeCalled.shouldBeTrue()
+                }
             }
-            fail("위의 Tx에서 예외를 발생 시켜야 합니다.")
-        } catch (_: CommitException) {
-            wrappingDataSource.connections shouldHaveSize 5
-            wrappingDataSource.connections.forEach { connection ->
-                connection.commitCalled.shouldBeTrue()
-                connection.closeCalled.shouldBeTrue()
-            }
+        } finally {
+            TransactionManager.closeAndUnregister(db)
         }
     }
 

--- a/05-exposed-dml/04-transactions/src/test/kotlin/exposed/examples/transactions/Ex05_NestedTransactions.kt
+++ b/05-exposed-dml/04-transactions/src/test/kotlin/exposed/examples/transactions/Ex05_NestedTransactions.kt
@@ -21,18 +21,21 @@ import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.inTopLevelTransaction
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.transactions.transactionManager
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.sql.SQLException
 import kotlin.test.fail
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class Ex05_NestedTransactions: AbstractExposedTest() {
 
     companion object: KLogging()
 
-    private val db by lazy {
+    private val dbLazy = lazy {
         Database.connect(
             url = "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;",
             driver = "org.h2.Driver",
@@ -44,8 +47,16 @@ class Ex05_NestedTransactions: AbstractExposedTest() {
             }
         )
     }
+    private val db by dbLazy
 
     val cities = DMLTestData.Cities
+
+    @AfterAll
+    fun tearDown() {
+        if (dbLazy.isInitialized()) {
+            TransactionManager.closeAndUnregister(db)
+        }
+    }
 
     private fun cityCounts(): Int = cities.selectAll().count().toInt()
 

--- a/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/Ex01_JsonColumn.kt
+++ b/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/Ex01_JsonColumn.kt
@@ -59,6 +59,7 @@ import org.junit.jupiter.params.provider.MethodSource
 /**
  * JSON 컬럼에 Kotlinx Serialization을 이용하여 JSON 객체를 저장/조회하는 예제
  */
+// NOTE: Exposed의 레거시 JSON API를 사용하여 교육 목적으로 유지
 @Suppress("DEPRECATION")
 class Ex01_JsonColumn: AbstractExposedJsonTest() {
 

--- a/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/Ex02_JsonBColumn.kt
+++ b/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/Ex02_JsonBColumn.kt
@@ -60,6 +60,7 @@ import org.junit.jupiter.params.provider.MethodSource
 /**
  * `jsonb` 컬럼 사용 예제
  */
+// NOTE: Exposed의 레거시 JSONB API를 사용하여 교육 목적으로 유지
 @Suppress("DEPRECATION")
 class Ex02_JsonBColumn: AbstractExposedJsonTest() {
 

--- a/06-advanced/06-custom-columns/src/test/kotlin/exposed/examples/custom/columns/compress/CompressedBinaryColumnTypeTest.kt
+++ b/06-advanced/06-custom-columns/src/test/kotlin/exposed/examples/custom/columns/compress/CompressedBinaryColumnTypeTest.kt
@@ -87,9 +87,9 @@ class CompressedBinaryColumnTypeTest: AbstractExposedTest() {
             entityCache.clear()
 
             val row = T1.selectAll().where { T1.id eq id }.single()
-            row[T1.lzData]!!.toUtf8String() shouldBeEqualTo text
-            row[T1.snappyData]!!.toUtf8String() shouldBeEqualTo text
-            row[T1.zstdData]!!.toUtf8String() shouldBeEqualTo text
+            row[T1.lzData].shouldNotBeNull().toUtf8String() shouldBeEqualTo text
+            row[T1.snappyData].shouldNotBeNull().toUtf8String() shouldBeEqualTo text
+            row[T1.zstdData].shouldNotBeNull().toUtf8String() shouldBeEqualTo text
         }
     }
 

--- a/06-advanced/06-custom-columns/src/test/kotlin/exposed/examples/custom/columns/compress/CompressedBlobColumnTypeTest.kt
+++ b/06-advanced/06-custom-columns/src/test/kotlin/exposed/examples/custom/columns/compress/CompressedBlobColumnTypeTest.kt
@@ -86,9 +86,9 @@ class CompressedBlobColumnTypeTest: AbstractExposedTest() {
             entityCache.clear()
 
             val row = T1.selectAll().where { T1.id eq id }.single()
-            row[T1.lzData]!!.toUtf8String() shouldBeEqualTo text
-            row[T1.snappyData]!!.toUtf8String() shouldBeEqualTo text
-            row[T1.zstdData]!!.toUtf8String() shouldBeEqualTo text
+            row[T1.lzData].shouldNotBeNull().toUtf8String() shouldBeEqualTo text
+            row[T1.snappyData].shouldNotBeNull().toUtf8String() shouldBeEqualTo text
+            row[T1.zstdData].shouldNotBeNull().toUtf8String() shouldBeEqualTo text
         }
     }
 

--- a/06-advanced/08-exposed-jackson/src/test/kotlin/exposed/examples/jackson/JacksonColumnTest.kt
+++ b/06-advanced/08-exposed-jackson/src/test/kotlin/exposed/examples/jackson/JacksonColumnTest.kt
@@ -196,7 +196,11 @@ class JacksonColumnTest: AbstractExposedTest() {
             val tester = object: Table("tester") {
                 val jCol = jackson<Fake>("j_col")
             }
-            SchemaUtils.create(tester)
+            try {
+                SchemaUtils.create(tester)
+            } finally {
+                SchemaUtils.drop(tester)
+            }
         }
     }
 

--- a/06-advanced/09-exposed-fastjson2/src/test/kotlin/exposed/examples/fastjson2/FastjsonColumnTest.kt
+++ b/06-advanced/09-exposed-fastjson2/src/test/kotlin/exposed/examples/fastjson2/FastjsonColumnTest.kt
@@ -199,7 +199,11 @@ class FastjsonColumnTest: AbstractExposedTest() {
             val tester = object: Table("tester") {
                 val jCol = fastjson<Fake>("j_col")
             }
-            SchemaUtils.create(tester)
+            try {
+                SchemaUtils.create(tester)
+            } finally {
+                SchemaUtils.drop(tester)
+            }
         }
     }
 

--- a/06-advanced/11-exposed-jackson3/src/test/kotlin/exposed/examples/jackson3/JacksonColumnTest.kt
+++ b/06-advanced/11-exposed-jackson3/src/test/kotlin/exposed/examples/jackson3/JacksonColumnTest.kt
@@ -196,7 +196,11 @@ class JacksonColumnTest: AbstractExposedTest() {
             val tester = object: Table("tester") {
                 val jCol = jackson<Fake>("j_col")
             }
-            SchemaUtils.create(tester)
+            try {
+                SchemaUtils.create(tester)
+            } finally {
+                SchemaUtils.drop(tester)
+            }
         }
     }
 

--- a/09-spring/03-spring-transaction/src/test/kotlin/exposed/examples/spring/transaction/mock/DataSourceSpy.kt
+++ b/09-spring/03-spring-transaction/src/test/kotlin/exposed/examples/spring/transaction/mock/DataSourceSpy.kt
@@ -7,6 +7,12 @@ import java.sql.DriverManager
 import java.util.logging.Logger
 import javax.sql.DataSource
 
+/**
+ * 테스트용 [DataSource] 스파이 구현체. 커넥션 획득 시 [connectionSpy] 람다로 래핑하여 동작을 검증한다.
+ *
+ * [java.util.logging.Logger] import는 [javax.sql.DataSource] 인터페이스의
+ * [getParentLogger] 메서드 반환 타입으로 요구되어 포함됩니다.
+ */
 class DataSourceSpy(connectionSpy: (Connection) -> Connection): DataSource {
 
     var con: Connection = connectionSpy(

--- a/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/ExposedRepositoryApp.kt
+++ b/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/ExposedRepositoryApp.kt
@@ -5,11 +5,22 @@ import org.springframework.boot.WebApplicationType
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
+/**
+ * Spring MVC 기반의 Exposed 리포지토리 예제 애플리케이션.
+ *
+ * Exposed DAO/DSL을 Spring MVC와 통합하여 REST API를 제공하는 예제입니다.
+ * SERVLET 웹 애플리케이션 타입으로 실행됩니다.
+ */
 @SpringBootApplication
 class ExposedRepositoryApp {
     companion object: KLogging()
 }
 
+/**
+ * 애플리케이션 진입점.
+ *
+ * @param args 커맨드라인 인자
+ */
 fun main(vararg args: String) {
     runApplication<ExposedRepositoryApp>(*args) {
         webApplicationType = WebApplicationType.SERVLET

--- a/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/controller/ActorController.kt
+++ b/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/controller/ActorController.kt
@@ -14,6 +14,14 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * 배우(Actor) 정보를 관리하는 REST 컨트롤러.
+ *
+ * 배우 조회, 검색, 생성, 삭제 기능을 HTTP 엔드포인트로 제공합니다.
+ * 기본적으로 읽기 전용 트랜잭션을 사용하며, 쓰기 작업은 별도의 트랜잭션을 적용합니다.
+ *
+ * @property actorRepository 배우 데이터 접근을 위한 Exposed 리포지토리
+ */
 @RestController
 @Transactional(readOnly = true)
 @RequestMapping("/actors")
@@ -21,11 +29,23 @@ class ActorController(private val actorRepository: ActorExposedRepository) {
 
     companion object: KLogging()
 
+    /**
+     * ID로 배우를 조회합니다.
+     *
+     * @param actorId 조회할 배우의 ID
+     * @return 조회된 배우 레코드, 존재하지 않으면 null
+     */
     @GetMapping("/{id}")
     fun getActorById(@PathVariable("id") actorId: Long): ActorRecord? {
         return actorRepository.findByIdOrNull(actorId)
     }
 
+    /**
+     * 쿼리 파라미터를 기반으로 배우를 검색합니다.
+     *
+     * @param request 검색 조건이 담긴 HTTP 요청
+     * @return 검색 조건에 맞는 배우 레코드 목록
+     */
     @GetMapping
     fun searchActors(request: HttpServletRequest): List<ActorRecord> {
         val params = request.parameterMap.map { it.key to it.value.firstOrNull() }.toMap()
@@ -34,12 +54,24 @@ class ActorController(private val actorRepository: ActorExposedRepository) {
         return actorRepository.searchActors(params)
     }
 
+    /**
+     * 새로운 배우를 생성합니다.
+     *
+     * @param actor 생성할 배우 정보
+     * @return 생성된 배우 레코드 (ID 포함)
+     */
     @PostMapping
     @Transactional
     fun createActor(@RequestBody actor: ActorRecord): ActorRecord {
         return actorRepository.create(actor)
     }
 
+    /**
+     * ID로 배우를 삭제합니다.
+     *
+     * @param actorId 삭제할 배우의 ID
+     * @return 삭제된 레코드 수
+     */
     @DeleteMapping("/{id}")
     @Transactional
     fun deleteById(@PathVariable("id") actorId: Long): Int {

--- a/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/controller/IndexController.kt
+++ b/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/controller/IndexController.kt
@@ -7,6 +7,11 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * 애플리케이션 루트 경로를 처리하는 REST 컨트롤러.
+ *
+ * 빌드 정보를 반환하는 인덱스 엔드포인트를 제공합니다.
+ */
 @RestController
 @RequestMapping("/")
 class IndexController {
@@ -14,7 +19,11 @@ class IndexController {
     @Autowired
     private val buildProperties: BuildProperties = uninitialized()
 
-
+    /**
+     * 애플리케이션 빌드 정보를 반환합니다.
+     *
+     * @return 빌드 버전, 시간 등의 정보를 담은 [BuildProperties]
+     */
     @GetMapping
     fun index(): BuildProperties {
         return buildProperties

--- a/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/controller/MovieActorsController.kt
+++ b/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/controller/MovieActorsController.kt
@@ -11,6 +11,13 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * 영화와 배우 연관 관계를 조회하는 REST 컨트롤러.
+ *
+ * 영화에 출연한 배우 목록, 영화별 배우 수, 제작자 겸 배우 정보 등을 제공합니다.
+ *
+ * @property movieRepository 영화 데이터 접근을 위한 Exposed 리포지토리
+ */
 @RestController
 @Transactional(readOnly = true)
 @RequestMapping("/movie-actors")
@@ -18,16 +25,32 @@ class MovieActorsController(private val movieRepository: MovieExposedRepository)
 
     companion object: KLogging()
 
+    /**
+     * 특정 영화에 출연한 배우 목록을 포함한 영화 정보를 반환합니다.
+     *
+     * @param movieId 조회할 영화의 ID
+     * @return 배우 목록이 포함된 영화 레코드, 존재하지 않으면 null
+     */
     @GetMapping("/{movieId}")
     fun getMovieWithActors(@PathVariable movieId: Long): MovieWithActorRecord? {
         return movieRepository.getMovieWithActors(movieId)
     }
 
+    /**
+     * 각 영화별 출연 배우 수를 반환합니다.
+     *
+     * @return 영화별 배우 수 정보 목록
+     */
     @GetMapping("/count")
     fun getMovieActorsCount(): List<MovieActorCountRecord> {
         return movieRepository.getMovieActorsCount()
     }
 
+    /**
+     * 제작자가 직접 출연한 영화 목록을 반환합니다.
+     *
+     * @return 제작자 겸 배우 정보가 포함된 영화 레코드 목록
+     */
     @GetMapping("/acting-producers")
     fun findMoviesWithActingProducers(): List<MovieWithProducingActorRecord> {
         return movieRepository.findMoviesWithActingProducers()

--- a/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/controller/MovieController.kt
+++ b/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/controller/MovieController.kt
@@ -14,6 +14,14 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * 영화(Movie) 정보를 관리하는 REST 컨트롤러.
+ *
+ * 영화 조회, 검색, 생성, 삭제 기능을 HTTP 엔드포인트로 제공합니다.
+ * 기본적으로 읽기 전용 트랜잭션을 사용하며, 쓰기 작업은 별도의 트랜잭션을 적용합니다.
+ *
+ * @property movieRepository 영화 데이터 접근을 위한 Exposed 리포지토리
+ */
 @RestController
 @Transactional(readOnly = true)
 @RequestMapping("/movies")
@@ -21,11 +29,23 @@ class MovieController(private val movieRepository: MovieExposedRepository) {
 
     companion object: KLogging()
 
+    /**
+     * ID로 영화를 조회합니다.
+     *
+     * @param movieId 조회할 영화의 ID
+     * @return 조회된 영화 레코드, 존재하지 않으면 null
+     */
     @GetMapping("/{id}")
     fun getMovieById(@PathVariable("id") movieId: Long): MovieRecord? {
         return movieRepository.findByIdOrNull(movieId)
     }
 
+    /**
+     * 쿼리 파라미터를 기반으로 영화를 검색합니다.
+     *
+     * @param request 검색 조건이 담긴 HTTP 요청
+     * @return 검색 조건에 맞는 영화 레코드 목록
+     */
     @GetMapping
     fun searchMovies(request: HttpServletRequest): List<MovieRecord> {
         val params = request.parameterMap.map { it.key to it.value.firstOrNull() }.toMap()
@@ -34,12 +54,24 @@ class MovieController(private val movieRepository: MovieExposedRepository) {
         return movieRepository.searchMovies(params)
     }
 
+    /**
+     * 새로운 영화를 생성합니다.
+     *
+     * @param movieRecord 생성할 영화 정보
+     * @return 생성된 영화 레코드 (ID 포함)
+     */
     @Transactional
     @PostMapping
     fun createMovie(@RequestBody movieRecord: MovieRecord): MovieRecord {
         return movieRepository.create(movieRecord)
     }
 
+    /**
+     * ID로 영화를 삭제합니다.
+     *
+     * @param movieId 삭제할 영화의 ID
+     * @return 삭제된 레코드 수
+     */
     @Transactional
     @DeleteMapping("/{id}")
     fun deleteMovieById(@PathVariable("id") movieId: Long): Int {

--- a/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/domain/model/MovieMappers.kt
+++ b/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/domain/model/MovieMappers.kt
@@ -5,6 +5,11 @@ import exposed.examples.springmvc.domain.model.MovieSchema.ActorTable
 import exposed.examples.springmvc.domain.model.MovieSchema.MovieEntity
 import org.jetbrains.exposed.v1.core.ResultRow
 
+/**
+ * [ResultRow]를 [ActorRecord]로 변환합니다.
+ *
+ * @return 변환된 배우 레코드
+ */
 fun ResultRow.toActorRecord() = ActorRecord(
     id = this[ActorTable.id].value,
     firstName = this[ActorTable.firstName],
@@ -12,6 +17,11 @@ fun ResultRow.toActorRecord() = ActorRecord(
     birthday = this[ActorTable.birthday]?.toString()
 )
 
+/**
+ * [ActorEntity]를 [ActorRecord]로 변환합니다.
+ *
+ * @return 변환된 배우 레코드
+ */
 fun ActorEntity.toActorRecord() = ActorRecord(
     id = this.id.value,
     firstName = this.firstName,
@@ -19,6 +29,11 @@ fun ActorEntity.toActorRecord() = ActorRecord(
     birthday = this.birthday?.toString()
 )
 
+/**
+ * [ResultRow]를 [MovieRecord]로 변환합니다.
+ *
+ * @return 변환된 영화 레코드
+ */
 fun ResultRow.toMovieRecord() = MovieRecord(
     name = this[MovieSchema.MovieTable.name],
     producerName = this[MovieSchema.MovieTable.producerName],
@@ -26,6 +41,12 @@ fun ResultRow.toMovieRecord() = MovieRecord(
     id = this[MovieSchema.MovieTable.id].value
 )
 
+/**
+ * [ResultRow]를 배우 목록과 함께 [MovieWithActorRecord]로 변환합니다.
+ *
+ * @param actors 영화에 출연한 배우 레코드 목록
+ * @return 배우 목록이 포함된 영화 레코드
+ */
 fun ResultRow.toMovieWithActorRecord(actors: List<ActorRecord>) = MovieWithActorRecord(
     name = this[MovieSchema.MovieTable.name],
     producerName = this[MovieSchema.MovieTable.producerName],
@@ -34,6 +55,12 @@ fun ResultRow.toMovieWithActorRecord(actors: List<ActorRecord>) = MovieWithActor
     id = this[MovieSchema.MovieTable.id].value
 )
 
+/**
+ * [MovieRecord]를 배우 컬렉션과 함께 [MovieWithActorRecord]로 변환합니다.
+ *
+ * @param actors 영화에 출연한 배우 레코드 컬렉션
+ * @return 배우 목록이 포함된 영화 레코드
+ */
 fun MovieRecord.toMovieWithActorRecord(actors: Collection<ActorRecord>) = MovieWithActorRecord(
     name = this.name,
     producerName = this.producerName,
@@ -42,6 +69,11 @@ fun MovieRecord.toMovieWithActorRecord(actors: Collection<ActorRecord>) = MovieW
     id = this.id
 )
 
+/**
+ * [MovieEntity]를 [MovieRecord]로 변환합니다.
+ *
+ * @return 변환된 영화 레코드
+ */
 fun MovieEntity.toMovieRecord() = MovieRecord(
     name = this.name,
     producerName = this.producerName,
@@ -49,6 +81,11 @@ fun MovieEntity.toMovieRecord() = MovieRecord(
     id = this.id.value
 )
 
+/**
+ * [MovieEntity]를 출연 배우 목록과 함께 [MovieWithActorRecord]로 변환합니다.
+ *
+ * @return 배우 목록이 포함된 영화 레코드
+ */
 fun MovieEntity.toMovieWithActorRecord() = MovieWithActorRecord(
     name = this.name,
     producerName = this.producerName,
@@ -57,7 +94,11 @@ fun MovieEntity.toMovieWithActorRecord() = MovieWithActorRecord(
     id = this.id.value
 )
 
-
+/**
+ * [ResultRow]를 제작자 겸 배우 정보가 포함된 [MovieWithProducingActorRecord]로 변환합니다.
+ *
+ * @return 제작자 겸 배우 정보가 포함된 영화 레코드
+ */
 fun ResultRow.toMovieWithProducingActorRecord() = MovieWithProducingActorRecord(
     movieName = this[MovieSchema.MovieTable.name],
     producerActorName = this[ActorTable.firstName] + " " + this[ActorTable.lastName]

--- a/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/domain/model/MovieSchema.kt
+++ b/09-spring/04-exposed-repository/src/main/kotlin/exposed/examples/springmvc/domain/model/MovieSchema.kt
@@ -14,20 +14,40 @@ import org.jetbrains.exposed.v1.javatime.date
 import org.jetbrains.exposed.v1.jdbc.SizedIterable
 import java.time.LocalDate
 
+/**
+ * 영화 도메인의 Exposed 스키마 정의.
+ *
+ * 영화(Movie), 배우(Actor), 영화-배우 연관 테이블 및 해당 DAO 엔티티 클래스를 포함합니다.
+ */
 object MovieSchema {
 
+    /**
+     * 영화 정보를 저장하는 테이블.
+     *
+     * `movies` 테이블에 매핑되며, 영화 이름, 제작자, 개봉일을 관리합니다.
+     */
     object MovieTable: LongIdTable("movies") {
         val name: Column<String> = varchar("name", 255)
         val producerName: Column<String> = varchar("producer_name", 255)
         val releaseDate: Column<LocalDate> = date("release_date")
     }
 
+    /**
+     * 배우 정보를 저장하는 테이블.
+     *
+     * `actors` 테이블에 매핑되며, 배우의 이름과 생년월일을 관리합니다.
+     */
     object ActorTable: LongIdTable("actors") {
         val firstName: Column<String> = varchar("first_name", 255)
         val lastName: Column<String> = varchar("last_name", 255)
         val birthday: Column<LocalDate?> = date("birthday").nullable()
     }
 
+    /**
+     * 영화와 배우의 다대다 연관 관계를 저장하는 테이블.
+     *
+     * `actors_in_movies` 테이블에 매핑되며, 영화 삭제 시 연관 데이터도 함께 삭제(CASCADE)됩니다.
+     */
     object ActorInMovieTable: Table("actors_in_movies") {
         val movieId: Column<EntityID<Long>> = reference("movie_id", MovieTable, onDelete = CASCADE)
         val actorId: Column<EntityID<Long>> = reference("actor_id", ActorTable, onDelete = CASCADE)
@@ -35,6 +55,13 @@ object MovieSchema {
         override val primaryKey = PrimaryKey(movieId, actorId)
     }
 
+    /**
+     * 영화 DAO 엔티티.
+     *
+     * [MovieTable]에 매핑되며, 출연 배우 목록을 [ActorInMovieTable]을 통해 참조합니다.
+     *
+     * @param id 엔티티 식별자
+     */
     class MovieEntity(id: EntityID<Long>): LongEntity(id) {
         companion object: LongEntityClass<MovieEntity>(MovieTable)
 
@@ -53,6 +80,13 @@ object MovieSchema {
             .toString()
     }
 
+    /**
+     * 배우 DAO 엔티티.
+     *
+     * [ActorTable]에 매핑되며, 출연 영화 목록을 [ActorInMovieTable]을 통해 참조합니다.
+     *
+     * @param id 엔티티 식별자
+     */
     class ActorEntity(id: EntityID<Long>): LongEntity(id) {
         companion object: LongEntityClass<ActorEntity>(ActorTable)
 

--- a/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/CoroutineExposedRepositoryApp.kt
+++ b/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/CoroutineExposedRepositoryApp.kt
@@ -5,11 +5,22 @@ import org.springframework.boot.WebApplicationType
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
+/**
+ * Spring WebFlux 기반의 코루틴 Exposed 리포지토리 예제 애플리케이션.
+ *
+ * Exposed DAO/DSL을 코루틴과 Spring WebFlux와 통합하여 비동기 REST API를 제공하는 예제입니다.
+ * REACTIVE 웹 애플리케이션 타입으로 실행됩니다.
+ */
 @SpringBootApplication
 class CoroutineExposedRepositoryApp {
     companion object: KLoggingChannel()
 }
 
+/**
+ * 애플리케이션 진입점.
+ *
+ * @param args 커맨드라인 인자
+ */
 fun main(vararg args: String) {
     runApplication<CoroutineExposedRepositoryApp>(*args) {
         webApplicationType = WebApplicationType.REACTIVE

--- a/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/controller/ActorController.kt
+++ b/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/controller/ActorController.kt
@@ -16,6 +16,15 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * 배우(Actor) 정보를 관리하는 코루틴 기반 REST 컨트롤러.
+ *
+ * Spring WebFlux 환경에서 코루틴 suspend 함수를 사용하여 비동기적으로
+ * 배우 조회, 검색, 생성, 삭제 기능을 HTTP 엔드포인트로 제공합니다.
+ * [newSuspendedTransaction]을 통해 Exposed 트랜잭션을 코루틴과 통합합니다.
+ *
+ * @property actorRepository 배우 데이터 접근을 위한 Exposed 리포지토리
+ */
 @Suppress("DEPRECATION")
 @RestController
 @RequestMapping("/actors")
@@ -25,12 +34,24 @@ class ActorController(
 
     companion object: KLoggingChannel()
 
+    /**
+     * ID로 배우를 조회합니다.
+     *
+     * @param actorId 조회할 배우의 ID
+     * @return 조회된 배우 레코드, 존재하지 않으면 null
+     */
     @GetMapping("/{id}")
     suspend fun getActorById(@PathVariable("id") actorId: Long): ActorRecord? =
         newSuspendedTransaction(readOnly = true) {
             actorRepository.findByIdOrNull(actorId)
         }
 
+    /**
+     * 쿼리 파라미터를 기반으로 배우를 검색합니다.
+     *
+     * @param request 검색 조건이 담긴 서버 HTTP 요청
+     * @return 검색 조건에 맞는 배우 레코드 목록, 파라미터가 없으면 빈 목록
+     */
     @GetMapping
     suspend fun searchActors(request: ServerHttpRequest): List<ActorRecord> {
         val params = request.queryParams.map { it.key to it.value.first() }.toMap()
@@ -43,12 +64,24 @@ class ActorController(
         }
     }
 
+    /**
+     * 새로운 배우를 생성합니다.
+     *
+     * @param actor 생성할 배우 정보
+     * @return 생성된 배우 레코드 (ID 포함)
+     */
     @PostMapping
     suspend fun createActor(@RequestBody actor: ActorRecord): ActorRecord =
         newSuspendedTransaction {
             actorRepository.create(actor)
         }
 
+    /**
+     * ID로 배우를 삭제합니다.
+     *
+     * @param actorId 삭제할 배우의 ID
+     * @return 삭제된 레코드 수
+     */
     @DeleteMapping("/{id}")
     suspend fun deleteActor(@PathVariable("id") actorId: Long): Int =
         newSuspendedTransaction {

--- a/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/controller/IndexController.kt
+++ b/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/controller/IndexController.kt
@@ -8,6 +8,11 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * 애플리케이션 루트 경로를 처리하는 코루틴 기반 REST 컨트롤러.
+ *
+ * 빌드 정보를 반환하는 인덱스 엔드포인트를 제공합니다.
+ */
 @RestController
 @RequestMapping("/")
 class IndexController {
@@ -17,7 +22,11 @@ class IndexController {
     @Autowired
     private val buildProperties: BuildProperties = uninitialized()
 
-
+    /**
+     * 애플리케이션 빌드 정보를 반환합니다.
+     *
+     * @return 빌드 버전, 시간 등의 정보를 담은 [BuildProperties]
+     */
     @GetMapping
     suspend fun index(): BuildProperties {
         return buildProperties

--- a/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/controller/MovieActorsController.kt
+++ b/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/controller/MovieActorsController.kt
@@ -14,6 +14,14 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * 영화와 배우 연관 관계를 조회하는 코루틴 기반 REST 컨트롤러.
+ *
+ * Spring WebFlux 환경에서 코루틴 suspend 함수를 사용하여 비동기적으로
+ * 영화에 출연한 배우 목록, 영화별 배우 수, 제작자 겸 배우 정보를 제공합니다.
+ *
+ * @property movieRepository 영화 데이터 접근을 위한 Exposed 리포지토리
+ */
 @Suppress("DEPRECATION")
 @RestController
 @RequestMapping("/movie-actors")
@@ -23,18 +31,34 @@ class MovieActorsController(
 
     companion object: KLoggingChannel()
 
+    /**
+     * 특정 영화에 출연한 배우 목록을 포함한 영화 정보를 반환합니다.
+     *
+     * @param movieId 조회할 영화의 ID
+     * @return 배우 목록이 포함된 영화 레코드, 존재하지 않으면 null
+     */
     @GetMapping("/{movieId}")
     suspend fun getMovieWithActors(@PathVariable movieId: Long): MovieWithActorRecord? =
         newSuspendedTransaction(readOnly = true) {
             movieRepository.getMovieWithActors(movieId)
         }
 
+    /**
+     * 각 영화별 출연 배우 수를 반환합니다.
+     *
+     * @return 영화별 배우 수 정보 목록
+     */
     @GetMapping("/count")
     suspend fun getMovieActorsCount(): List<MovieActorCountRecord> =
         newSuspendedTransaction(readOnly = true) {
             movieRepository.getMovieActorsCount()
         }
 
+    /**
+     * 제작자가 직접 출연한 영화 목록을 반환합니다.
+     *
+     * @return 제작자 겸 배우 정보가 포함된 영화 레코드 목록
+     */
     @GetMapping("/acting-producers")
     suspend fun findMoviesWithActingProducers(): List<MovieWithProducingActorRecord> =
         newSuspendedTransaction(readOnly = true) {

--- a/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/controller/MovieController.kt
+++ b/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/controller/MovieController.kt
@@ -16,6 +16,15 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * 영화(Movie) 정보를 관리하는 코루틴 기반 REST 컨트롤러.
+ *
+ * Spring WebFlux 환경에서 코루틴 suspend 함수를 사용하여 비동기적으로
+ * 영화 조회, 검색, 생성, 삭제 기능을 HTTP 엔드포인트로 제공합니다.
+ * [newSuspendedTransaction]을 통해 Exposed 트랜잭션을 코루틴과 통합합니다.
+ *
+ * @property movieRepository 영화 데이터 접근을 위한 Exposed 리포지토리
+ */
 @Suppress("DEPRECATION")
 @RestController
 @RequestMapping("/movies")
@@ -25,12 +34,24 @@ class MovieController(
 
     companion object: KLoggingChannel()
 
+    /**
+     * ID로 영화를 조회합니다.
+     *
+     * @param movieId 조회할 영화의 ID
+     * @return 조회된 영화 레코드, 존재하지 않으면 null
+     */
     @GetMapping("/{id}")
     suspend fun getMovieById(@PathVariable("id") movieId: Long): MovieRecord? =
         newSuspendedTransaction(readOnly = true) {
             movieRepository.findByIdOrNull(movieId)
         }
 
+    /**
+     * 쿼리 파라미터를 기반으로 영화를 검색합니다.
+     *
+     * @param request 검색 조건이 담긴 서버 HTTP 요청
+     * @return 검색 조건에 맞는 영화 레코드 목록, 파라미터가 없으면 빈 목록
+     */
     @GetMapping
     suspend fun searchMovies(request: ServerHttpRequest): List<MovieRecord> {
         val params = request.queryParams.map { it.key to it.value.first() }.toMap()
@@ -42,12 +63,24 @@ class MovieController(
         }
     }
 
+    /**
+     * 새로운 영화를 생성합니다.
+     *
+     * @param movie 생성할 영화 정보
+     * @return 생성된 영화 레코드 (ID 포함)
+     */
     @PostMapping
     suspend fun createMovie(@RequestBody movie: MovieRecord): MovieRecord =
         newSuspendedTransaction {
             movieRepository.create(movie)
         }
 
+    /**
+     * ID로 영화를 삭제합니다.
+     *
+     * @param movieId 삭제할 영화의 ID
+     * @return 삭제된 레코드 수
+     */
     @DeleteMapping("/{id}")
     suspend fun deleteMovie(@PathVariable("id") movieId: Long): Int =
         newSuspendedTransaction {

--- a/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/domain/model/MovieMappers.kt
+++ b/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/domain/model/MovieMappers.kt
@@ -6,6 +6,11 @@ import exposed.examples.springwebflux.domain.model.MovieSchema.MovieEntity
 import exposed.examples.springwebflux.domain.model.MovieSchema.MovieTable
 import org.jetbrains.exposed.v1.core.ResultRow
 
+/**
+ * [ResultRow]를 [ActorRecord]로 변환합니다.
+ *
+ * @return 변환된 배우 레코드
+ */
 fun ResultRow.toActorRecord() = ActorRecord(
     id = this[ActorTable.id].value,
     firstName = this[ActorTable.firstName],
@@ -13,6 +18,11 @@ fun ResultRow.toActorRecord() = ActorRecord(
     birthday = this[ActorTable.birthday]?.toString()
 )
 
+/**
+ * [ActorEntity]를 [ActorRecord]로 변환합니다.
+ *
+ * @return 변환된 배우 레코드
+ */
 fun ActorEntity.toActorRecord() = ActorRecord(
     id = this.id.value,
     firstName = this.firstName,
@@ -20,6 +30,11 @@ fun ActorEntity.toActorRecord() = ActorRecord(
     birthday = this.birthday?.toString()
 )
 
+/**
+ * [ResultRow]를 [MovieRecord]로 변환합니다.
+ *
+ * @return 변환된 영화 레코드
+ */
 fun ResultRow.toMovieRecord() = MovieRecord(
     id = this[MovieTable.id].value,
     name = this[MovieTable.name],
@@ -27,6 +42,12 @@ fun ResultRow.toMovieRecord() = MovieRecord(
     releaseDate = this[MovieTable.releaseDate].toString(),
 )
 
+/**
+ * [ResultRow]를 배우 목록과 함께 [MovieWithActorRecord]로 변환합니다.
+ *
+ * @param actors 영화에 출연한 배우 레코드 목록
+ * @return 배우 목록이 포함된 영화 레코드
+ */
 fun ResultRow.toMovieWithActorRecord(actors: List<ActorRecord>) =
     MovieWithActorRecord(
         id = this[MovieTable.id].value,
@@ -36,6 +57,12 @@ fun ResultRow.toMovieWithActorRecord(actors: List<ActorRecord>) =
         actors = actors,
     )
 
+/**
+ * [MovieRecord]를 배우 컬렉션과 함께 [MovieWithActorRecord]로 변환합니다.
+ *
+ * @param actors 영화에 출연한 배우 레코드 컬렉션
+ * @return 배우 목록이 포함된 영화 레코드
+ */
 fun MovieRecord.toMovieWithActorRecord(actors: Collection<ActorRecord>) =
     MovieWithActorRecord(
         id = this.id,
@@ -45,6 +72,11 @@ fun MovieRecord.toMovieWithActorRecord(actors: Collection<ActorRecord>) =
         actors = actors.toList(),
     )
 
+/**
+ * [MovieEntity]를 [MovieRecord]로 변환합니다.
+ *
+ * @return 변환된 영화 레코드
+ */
 fun MovieEntity.toMovieRecord() = MovieRecord(
     id = this.id.value,
     name = this.name,
@@ -52,6 +84,11 @@ fun MovieEntity.toMovieRecord() = MovieRecord(
     releaseDate = this.releaseDate.toString(),
 )
 
+/**
+ * [MovieEntity]를 출연 배우 목록과 함께 [MovieWithActorRecord]로 변환합니다.
+ *
+ * @return 배우 목록이 포함된 영화 레코드
+ */
 fun MovieEntity.toMovieWithActorRecord() = MovieWithActorRecord(
     id = this.id.value,
     name = this.name,
@@ -60,7 +97,11 @@ fun MovieEntity.toMovieWithActorRecord() = MovieWithActorRecord(
     actors = this.actors.map { it.toActorRecord() }.toList(),
 )
 
-
+/**
+ * [ResultRow]를 제작자 겸 배우 정보가 포함된 [MovieWithProducingActorRecord]로 변환합니다.
+ *
+ * @return 제작자 겸 배우 정보가 포함된 영화 레코드
+ */
 fun ResultRow.toMovieWithProducingActorRecord() = MovieWithProducingActorRecord(
     movieName = this[MovieTable.name],
     producerActorName = this[ActorTable.firstName] + " " + this[ActorTable.lastName]

--- a/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/domain/model/MovieSchema.kt
+++ b/09-spring/05-exposed-repository-coroutines/src/main/kotlin/exposed/examples/springwebflux/domain/model/MovieSchema.kt
@@ -13,20 +13,41 @@ import org.jetbrains.exposed.v1.javatime.date
 import org.jetbrains.exposed.v1.jdbc.SizedIterable
 import java.time.LocalDate
 
+/**
+ * 영화 도메인의 Exposed 스키마 정의 (코루틴 지원 버전).
+ *
+ * 영화(Movie), 배우(Actor), 영화-배우 연관 테이블 및 해당 DAO 엔티티 클래스를 포함합니다.
+ * Spring WebFlux 환경에서 코루틴과 함께 사용하도록 설계되었습니다.
+ */
 object MovieSchema {
 
+    /**
+     * 영화 정보를 저장하는 테이블.
+     *
+     * `movies` 테이블에 매핑되며, 영화 이름과 제작자에 인덱스가 설정되어 있습니다.
+     */
     object MovieTable: LongIdTable("movies") {
         val name = varchar("name", 255).index()
         val producerName = varchar("producer_name", 255).index()
         val releaseDate = date("release_date")
     }
 
+    /**
+     * 배우 정보를 저장하는 테이블.
+     *
+     * `actors` 테이블에 매핑되며, 배우의 이름에 인덱스가 설정되어 있습니다.
+     */
     object ActorTable: LongIdTable("actors") {
         val firstName = varchar("first_name", 255).index()
         val lastName = varchar("last_name", 255).index()
         val birthday = date("birthday").nullable()
     }
 
+    /**
+     * 영화와 배우의 다대다 연관 관계를 저장하는 테이블.
+     *
+     * `actors_in_movies` 테이블에 매핑되며, 영화 또는 배우 삭제 시 연관 데이터도 함께 삭제(CASCADE)됩니다.
+     */
     object ActorInMovieTable: Table("actors_in_movies") {
         val movieId = reference("movie_id", MovieTable, onDelete = ReferenceOption.CASCADE)
         val actorId = reference("actor_id", ActorTable, onDelete = ReferenceOption.CASCADE)
@@ -34,6 +55,13 @@ object MovieSchema {
         override val primaryKey = PrimaryKey(movieId, actorId)
     }
 
+    /**
+     * 영화 DAO 엔티티.
+     *
+     * [MovieTable]에 매핑되며, 출연 배우 목록을 [ActorInMovieTable]을 통해 참조합니다.
+     *
+     * @param id 엔티티 식별자
+     */
     class MovieEntity(id: EntityID<Long>): LongEntity(id) {
         companion object: LongEntityClass<MovieEntity>(MovieTable)
 
@@ -52,6 +80,13 @@ object MovieSchema {
             .toString()
     }
 
+    /**
+     * 배우 DAO 엔티티.
+     *
+     * [ActorTable]에 매핑되며, 출연 영화 목록을 [ActorInMovieTable]을 통해 참조합니다.
+     *
+     * @param id 엔티티 식별자
+     */
     class ActorEntity(id: EntityID<Long>): LongEntity(id) {
         companion object: LongEntityClass<ActorEntity>(ActorTable)
 

--- a/09-spring/06-spring-cache/src/main/kotlin/exposed/examples/springcache/SpringCacheApplication.kt
+++ b/09-spring/06-spring-cache/src/main/kotlin/exposed/examples/springcache/SpringCacheApplication.kt
@@ -5,15 +5,27 @@ import io.bluetape4k.testcontainers.storage.RedisServer
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
+/**
+ * Spring Cache와 Redis를 활용한 Exposed 캐시 예제 애플리케이션.
+ *
+ * Spring의 캐시 추상화(@Cacheable, @CacheEvict 등)를 Exposed와 통합하는 예제입니다.
+ * 테스트 환경에서 Redis 서버를 자동으로 시작합니다.
+ */
 @SpringBootApplication
 class SpringCacheApplication {
 
     companion object: KLogging() {
+        /** 테스트용 Redis 서버 인스턴스 */
         @JvmStatic
         val redisServer = RedisServer.Launcher.redis
     }
 }
 
+/**
+ * 애플리케이션 진입점.
+ *
+ * @param args 커맨드라인 인자
+ */
 fun main(vararg args: String) {
     runApplication<SpringCacheApplication>(*args)
 }

--- a/09-spring/06-spring-cache/src/main/kotlin/exposed/examples/springcache/domain/CountrySchema.kt
+++ b/09-spring/06-spring-cache/src/main/kotlin/exposed/examples/springcache/domain/CountrySchema.kt
@@ -9,13 +9,25 @@ import org.jetbrains.exposed.v1.dao.IntEntity
 import org.jetbrains.exposed.v1.dao.IntEntityClass
 import java.io.Serializable
 
+/**
+ * 국가 정보를 저장하는 테이블.
+ *
+ * `countries` 테이블에 매핑되며, 2자리 국가 코드에 유니크 인덱스가 설정되어 있습니다.
+ */
 object CountryTable: IntIdTable("countries") {
     val code = char("code", 2).uniqueIndex()
     val name = varchar("name", 50)
     val description = text("description").nullable()
 }
 
-// 예제에서는 사용하지 않고, [Country] Record 를 사용합니다.
+/**
+ * 국가 DAO 엔티티.
+ *
+ * [CountryTable]에 매핑됩니다.
+ * 예제에서는 사용하지 않고, [CountryRecord]를 사용합니다.
+ *
+ * @param id 엔티티 식별자
+ */
 class Country(id: EntityID<Int>): IntEntity(id) {
     companion object: IntEntityClass<Country>(CountryTable)
 
@@ -32,8 +44,17 @@ class Country(id: EntityID<Int>): IntEntity(id) {
         .toString()
 }
 
+/**
+ * 국가 정보를 담는 데이터 레코드.
+ *
+ * Spring Cache의 캐시 키/값으로 사용하기 위해 [Serializable]을 구현합니다.
+ *
+ * @property code 2자리 국가 코드 (예: "KR", "US")
+ * @property name 국가 이름
+ * @property description 국가 설명 (선택적)
+ */
 data class CountryRecord(
     val code: String,
     val name: String,
     val description: String? = null,
-): Serializable 
+): Serializable

--- a/09-spring/06-spring-cache/src/main/kotlin/exposed/examples/springcache/domain/DataPopulator.kt
+++ b/09-spring/06-spring-cache/src/main/kotlin/exposed/examples/springcache/domain/DataPopulator.kt
@@ -8,10 +8,17 @@ import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.ApplicationListener
 import org.springframework.stereotype.Component
 
+/**
+ * 애플리케이션 시작 시 국가 데이터를 데이터베이스에 초기화하는 컴포넌트.
+ *
+ * [ApplicationReadyEvent] 이벤트를 수신하여 [CountryTable]에 국가 코드 데이터를
+ * 일괄 삽입(batch insert)합니다.
+ */
 @Component
 class DataPopulator: ApplicationListener<ApplicationReadyEvent> {
 
     companion object: KLogging() {
+        /** ISO 3166-1 alpha-2 형식의 국가 코드 목록 */
         val COUNTRY_CODES: List<String> =
             listOf(
                 "AF", "AX",
@@ -37,6 +44,11 @@ class DataPopulator: ApplicationListener<ApplicationReadyEvent> {
             )
     }
 
+    /**
+     * 애플리케이션 준비 완료 이벤트 수신 시 국가 데이터를 일괄 삽입합니다.
+     *
+     * @param event 애플리케이션 준비 완료 이벤트
+     */
     override fun onApplicationEvent(event: ApplicationReadyEvent) {
         log.info { "Populate country data ..." }
         transaction {

--- a/09-spring/07-spring-suspended-cache/src/main/kotlin/exposed/examples/suspendedcache/SpringSuspendedCacheApplication.kt
+++ b/09-spring/07-spring-suspended-cache/src/main/kotlin/exposed/examples/suspendedcache/SpringSuspendedCacheApplication.kt
@@ -8,20 +8,37 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
 
+/**
+ * 코루틴 기반의 Lettuce Redis 캐시를 활용한 Exposed 캐시 예제 애플리케이션.
+ *
+ * Spring WebFlux 환경에서 코루틴 suspend 함수와 Lettuce Redis 클라이언트를 통합하여
+ * 비동기 캐시를 구현하는 예제입니다. 테스트 환경에서 Redis 서버를 자동으로 시작합니다.
+ */
 @SpringBootApplication
 class SpringSuspendedCacheApplication {
 
     companion object: KLoggingChannel() {
+        /** 테스트용 Redis 서버 인스턴스 */
         @JvmStatic
         val redisServer = RedisServer.Launcher.redis
     }
 
+    /**
+     * Lettuce Redis 클라이언트 Bean을 생성합니다.
+     *
+     * @return 테스트용 Redis 서버에 연결된 [RedisClient] 인스턴스
+     */
     @Bean
     fun redisClient(): RedisClient {
         return RedisClient.create(RedisURI.create(redisServer.url))
     }
 }
 
+/**
+ * 애플리케이션 진입점.
+ *
+ * @param args 커맨드라인 인자
+ */
 fun main(vararg args: String) {
     runApplication<SpringSuspendedCacheApplication>(*args)
 }

--- a/09-spring/07-spring-suspended-cache/src/main/kotlin/exposed/examples/suspendedcache/domain/CountrySchema.kt
+++ b/09-spring/07-spring-suspended-cache/src/main/kotlin/exposed/examples/suspendedcache/domain/CountrySchema.kt
@@ -9,13 +9,25 @@ import org.jetbrains.exposed.v1.dao.IntEntity
 import org.jetbrains.exposed.v1.dao.IntEntityClass
 import java.io.Serializable
 
+/**
+ * 국가 정보를 저장하는 테이블.
+ *
+ * `countries` 테이블에 매핑되며, 2자리 국가 코드에 유니크 인덱스가 설정되어 있습니다.
+ */
 object CountryTable: IntIdTable("countries") {
     val code = char("code", 2).uniqueIndex()
     val name = varchar("name", 50)
     val description = text("description").nullable()
 }
 
-// 예제에서는 사용하지 않고, [Country] Record 를 사용합니다.
+/**
+ * 국가 DAO 엔티티.
+ *
+ * [CountryTable]에 매핑됩니다.
+ * 예제에서는 사용하지 않고, [CountryRecord]를 사용합니다.
+ *
+ * @param id 엔티티 식별자
+ */
 class Country(id: EntityID<Int>): IntEntity(id) {
     companion object: IntEntityClass<Country>(CountryTable)
 
@@ -32,6 +44,15 @@ class Country(id: EntityID<Int>): IntEntity(id) {
         .toString()
 }
 
+/**
+ * 국가 정보를 담는 데이터 레코드.
+ *
+ * Lettuce Redis를 통한 캐시의 키/값으로 사용하기 위해 [Serializable]을 구현합니다.
+ *
+ * @property code 2자리 국가 코드 (예: "KR", "US")
+ * @property name 국가 이름
+ * @property description 국가 설명 (선택적)
+ */
 data class CountryRecord(
     val code: String,
     val name: String,

--- a/09-spring/07-spring-suspended-cache/src/main/kotlin/exposed/examples/suspendedcache/domain/DataPopulator.kt
+++ b/09-spring/07-spring-suspended-cache/src/main/kotlin/exposed/examples/suspendedcache/domain/DataPopulator.kt
@@ -8,10 +8,17 @@ import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.ApplicationListener
 import org.springframework.stereotype.Component
 
+/**
+ * 애플리케이션 시작 시 국가 데이터를 데이터베이스에 초기화하는 컴포넌트.
+ *
+ * [ApplicationReadyEvent] 이벤트를 수신하여 [CountryTable]에 국가 코드 데이터를
+ * 일괄 삽입(batch insert)합니다.
+ */
 @Component
 class DataPopulator: ApplicationListener<ApplicationReadyEvent> {
 
     companion object: KLoggingChannel() {
+        /** ISO 3166-1 alpha-2 형식의 국가 코드 목록 */
         val COUNTRY_CODES: List<String> =
             listOf(
                 "AF", "AX",
@@ -37,6 +44,11 @@ class DataPopulator: ApplicationListener<ApplicationReadyEvent> {
             )
     }
 
+    /**
+     * 애플리케이션 준비 완료 이벤트 수신 시 국가 데이터를 일괄 삽입합니다.
+     *
+     * @param event 애플리케이션 준비 완료 이벤트
+     */
     override fun onApplicationEvent(event: ApplicationReadyEvent) {
         log.info { "Populate country data ..." }
         transaction {

--- a/09-spring/07-spring-suspended-cache/src/main/kotlin/exposed/examples/suspendedcache/lettuce/LettuceSuspendedCache.kt
+++ b/09-spring/07-spring-suspended-cache/src/main/kotlin/exposed/examples/suspendedcache/lettuce/LettuceSuspendedCache.kt
@@ -5,6 +5,19 @@ import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
 import kotlinx.coroutines.flow.chunked
 
+/**
+ * Lettuce Redis 코루틴 API를 사용하는 suspend 함수 기반 캐시 구현체.
+ *
+ * Redis를 백엔드 저장소로 사용하며, 코루틴 suspend 함수를 통해 비동기적으로
+ * 캐시 데이터를 조회, 저장, 삭제할 수 있습니다.
+ * 캐시 키는 `{name}:{key}` 형식으로 Redis에 저장됩니다.
+ *
+ * @param K 캐시 키의 타입
+ * @param V 캐시 값의 타입
+ * @property name 캐시 이름 (Redis 키 접두사로 사용)
+ * @property commands Lettuce 코루틴 Redis 커맨드 인터페이스
+ * @param ttlSeconds 캐시 항목의 TTL(초). null이면 만료 없이 저장
+ */
 @OptIn(ExperimentalLettuceCoroutinesApi::class)
 class LettuceSuspendedCache<K: Any, V: Any>(
     val name: String,
@@ -14,10 +27,30 @@ class LettuceSuspendedCache<K: Any, V: Any>(
 
     companion object: KLoggingChannel()
 
+    /**
+     * 캐시 키를 Redis 저장 키 문자열로 변환합니다.
+     *
+     * @param key 캐시 키
+     * @return `{name}:{key}` 형식의 Redis 키 문자열
+     */
     private fun keyStr(key: K): String = "$name:$key"
 
+    /**
+     * 캐시에서 키에 해당하는 값을 조회합니다.
+     *
+     * @param key 조회할 캐시 키
+     * @return 캐시에 저장된 값, 존재하지 않으면 null
+     */
     suspend fun get(key: K): V? = commands.get(keyStr(key))
 
+    /**
+     * 캐시에 키-값 쌍을 저장합니다.
+     *
+     * TTL이 설정된 경우 만료 시간과 함께 저장하고, 설정되지 않은 경우 만료 없이 저장합니다.
+     *
+     * @param key 캐시 키
+     * @param value 저장할 값
+     */
     suspend fun put(key: K, value: V) {
         if (ttlSeconds != null) {
             commands.setex(keyStr(key), ttlSeconds, value)
@@ -26,10 +59,20 @@ class LettuceSuspendedCache<K: Any, V: Any>(
         }
     }
 
+    /**
+     * 캐시에서 특정 키의 항목을 삭제합니다.
+     *
+     * @param key 삭제할 캐시 키
+     */
     suspend fun evict(key: K) {
         commands.del(keyStr(key))
     }
 
+    /**
+     * 이 캐시의 모든 항목을 삭제합니다.
+     *
+     * `{name}:*` 패턴과 일치하는 모든 Redis 키를 100개씩 묶어 삭제합니다.
+     */
     suspend fun clear() {
         commands.keys("$name:*")
             .chunked(100)

--- a/09-spring/07-spring-suspended-cache/src/main/kotlin/exposed/examples/suspendedcache/lettuce/LettuceSuspendedCacheManager.kt
+++ b/09-spring/07-spring-suspended-cache/src/main/kotlin/exposed/examples/suspendedcache/lettuce/LettuceSuspendedCacheManager.kt
@@ -8,6 +8,16 @@ import io.lettuce.core.api.coroutines
 import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
 import java.util.concurrent.ConcurrentHashMap
 
+/**
+ * Lettuce Redis 클라이언트를 사용하여 [LettuceSuspendedCache] 인스턴스를 관리하는 캐시 매니저.
+ *
+ * 이름별로 캐시 인스턴스를 생성하고 재사용합니다. 각 캐시는 별도의 Redis 연결을 가지며,
+ * 코루틴 API를 통해 비동기 캐시 작업을 지원합니다.
+ *
+ * @property redisClient Lettuce Redis 클라이언트
+ * @property ttlSeconds 기본 캐시 TTL(초). null이면 만료 없음
+ * @property codec 기본 직렬화 코덱. null이면 기본 코덱 사용
+ */
 class LettuceSuspendedCacheManager(
     val redisClient: RedisClient,
     val ttlSeconds: Long? = null,
@@ -18,6 +28,18 @@ class LettuceSuspendedCacheManager(
 
     private val caches = ConcurrentHashMap<String, LettuceSuspendedCache<out Any, out Any>>()
 
+    /**
+     * 이름으로 캐시를 조회하거나 존재하지 않으면 새로 생성합니다.
+     *
+     * 동일한 이름으로 호출하면 기존에 생성된 캐시 인스턴스를 반환합니다.
+     *
+     * @param K 캐시 키의 타입
+     * @param V 캐시 값의 타입
+     * @param name 캐시 이름 (Redis 키 접두사로 사용)
+     * @param ttlSeconds 이 캐시의 TTL(초). null이면 매니저의 기본 TTL 사용
+     * @param codec 이 캐시의 직렬화 코덱. null이면 매니저의 기본 코덱 사용
+     * @return 이름에 해당하는 [LettuceSuspendedCache] 인스턴스
+     */
     @Suppress("UNCHECKED_CAST")
     @OptIn(ExperimentalLettuceCoroutinesApi::class)
     fun <K: Any, V: Any> getOrCreate(

--- a/10-multi-tenant/01-multitenant-spring-web/src/main/kotlin/exposed/multitenant/springweb/tenant/SchemaSupport.kt
+++ b/10-multi-tenant/01-multitenant-spring-web/src/main/kotlin/exposed/multitenant/springweb/tenant/SchemaSupport.kt
@@ -2,6 +2,14 @@ package exposed.multitenant.springweb.tenant
 
 import org.jetbrains.exposed.v1.core.Schema
 
+/**
+ * 테넌트 정보를 기반으로 Exposed [Schema] 정의를 생성합니다.
+ *
+ * 테넌트 ID를 스키마 이름으로 사용하며, Oracle 데이터베이스의 테이블스페이스 설정을 포함합니다.
+ *
+ * @param tenant 스키마를 생성할 테넌트 정보
+ * @return 테넌트에 해당하는 Exposed [Schema] 정의
+ */
 internal fun getSchemaDefinition(tenant: Tenants.Tenant): Schema =
     Schema(
         tenant.id,

--- a/10-multi-tenant/01-multitenant-spring-web/src/main/kotlin/exposed/multitenant/springweb/tenant/TenantSchemaAspect.kt
+++ b/10-multi-tenant/01-multitenant-spring-web/src/main/kotlin/exposed/multitenant/springweb/tenant/TenantSchemaAspect.kt
@@ -10,6 +10,16 @@ import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 
+/**
+ * 멀티테넌시 지원을 위한 Spring AOP 애스펙트.
+ *
+ * `@Transactional`이 적용된 클래스나 메서드가 실행되기 전에 현재 테넌트에 해당하는
+ * 데이터베이스 스키마를 설정합니다. [TenantContext]에서 현재 테넌트 정보를 읽어
+ * Exposed의 [SchemaUtils.setSchema]를 통해 스키마를 전환합니다.
+ *
+ * @see TenantContext
+ * @see SchemaUtils
+ */
 @Aspect
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE + 1)

--- a/11-high-performance/01-cache-strategies/src/main/kotlin/exposed/examples/cache/utils/DataFakers.kt
+++ b/11-high-performance/01-cache-strategies/src/main/kotlin/exposed/examples/cache/utils/DataFakers.kt
@@ -2,4 +2,5 @@ package exposed.examples.cache.utils
 
 import net.datafaker.Faker
 
+/** 테스트 데이터 생성을 위한 [Faker] 인스턴스 */
 val faker = Faker()

--- a/11-high-performance/02-cache-strategies-coroutines/src/main/kotlin/exposed/examples/cache/coroutines/utils/DataFakers.kt
+++ b/11-high-performance/02-cache-strategies-coroutines/src/main/kotlin/exposed/examples/cache/coroutines/utils/DataFakers.kt
@@ -2,4 +2,5 @@ package exposed.examples.cache.coroutines.utils
 
 import net.datafaker.Faker
 
+/** 코루틴 기반 캐시 전략 테스트 데이터 생성을 위한 [Faker] 인스턴스 */
 val faker = Faker()


### PR DESCRIPTION
## Summary
- **HIGH 이슈 수정**: DB 연결 리소스 누수 수정 (TransactionManager.closeAndUnregister), SchemaUtils 라이프사이클 try/finally 보강, Ex05_NestedTransactions @AfterAll+PER_CLASS 적용
- **MEDIUM 이슈 수정**: `!!` 연산자를 `shouldNotBeNull()` assertion으로 교체, Deprecated API 교육 목적 유지 주석 추가
- **KDoc 최신화**: 00-shared, 01-spring-boot, 09-spring, 10-multi-tenant, 11-high-performance 총 47개 파일 한국어 KDoc 추가
- **README 신규 작성**: `00-shared/README.md` 섹션 인프라 문서 생성

## Test plan
- [x] 변경된 12개 모듈 전체 테스트 통과 (42 tests passing, `-PuseFastDB=true`)
- [x] 전체 프로젝트 컴파일 성공 (`compileKotlin`, `compileTestKotlin`)
- [x] 기존 실패 모듈(07-jpa, 11-high-perf, 06-spring-cache)은 Docker/Redis 환경 미가용으로 변경사항과 무관 확인 (git stash 검증 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)