### PR TITLE
refactor: Exposed deprecated API를 대체재로 교체

### DIFF
--- a/05-exposed-dml/04-transactions/src/test/kotlin/exposed/examples/transactions/Ex05_NestedTransactions_Coroutines.kt
+++ b/05-exposed-dml/04-transactions/src/test/kotlin/exposed/examples/transactions/Ex05_NestedTransactions_Coroutines.kt
@@ -5,7 +5,9 @@ package exposed.examples.transactions
 import exposed.shared.dml.DMLTestData
 import exposed.shared.tests.AbstractExposedTest
 import exposed.shared.tests.TestDB
-import exposed.shared.tests.withSuspendedTables
+// NOTE: withSuspendedTables는 deprecated됨. withTablesSuspending()으로 대체 (exposed.shared.tests)
+// import exposed.shared.tests.withSuspendedTables
+import exposed.shared.tests.withTablesSuspending
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
@@ -142,7 +144,7 @@ class Ex05_NestedTransactions_Coroutines: AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `코루틴에서 중첩 트랜잭션 사용하기`(testDB: TestDB) = runSuspendIO {
-        withSuspendedTables(testDB, cities, configure = { useNestedTransactions = true }) {
+        withTablesSuspending(testDB, cities, configure = { useNestedTransactions = true }) {
             // 외부 트랜잭션
             cities.selectAll().shouldBeEmpty()
             cities.insert { it[name] = "city1" }
@@ -173,7 +175,7 @@ class Ex05_NestedTransactions_Coroutines: AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `코루틴에서 중첩 트랜잭션 실패 후 외부 트랜잭션으로 복귀한다`(testDB: TestDB) = runSuspendIO {
-        withSuspendedTables(testDB, cities) {
+        withTablesSuspending(testDB, cities) {
             TransactionManager.currentOrNull().shouldNotBeNull()
 
             try {

--- a/05-exposed-dml/05-entities/build.gradle.kts
+++ b/05-exposed-dml/05-entities/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     testImplementation(Libs.exposed_core)
     testImplementation(Libs.exposed_dao)
     testImplementation(Libs.exposed_jdbc)
+    testImplementation(Libs.exposed_migration_jdbc)
     testImplementation(Libs.exposed_java_time)
     testImplementation(Libs.bluetape4k_exposed)
 

--- a/05-exposed-dml/05-entities/src/test/kotlin/exposed/examples/entities/Ex10_CompositeIdTableEntity.kt
+++ b/05-exposed-dml/05-entities/src/test/kotlin/exposed/examples/entities/Ex10_CompositeIdTableEntity.kt
@@ -51,6 +51,7 @@ import org.jetbrains.exposed.v1.dao.load
 import org.jetbrains.exposed.v1.dao.with
 import org.jetbrains.exposed.v1.jdbc.Query
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.migration.jdbc.MigrationUtils
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -91,7 +92,9 @@ class Ex10_CompositeIdTableEntity: AbstractExposedTest() {
                 allTables.forEach { it.exists().shouldBeTrue() }
 
                 if (testDB !in TestDB.ALL_H2) {
-                    SchemaUtils.statementsRequiredToActualizeScheme(tables = allTables).shouldBeEmpty()
+                    // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
+                    // SchemaUtils.statementsRequiredToActualizeScheme(tables = allTables).shouldBeEmpty()
+                    MigrationUtils.statementsRequiredForDatabaseMigration(tables = allTables).shouldBeEmpty()
                 }
             } finally {
                 SchemaUtils.drop(tables = allTables)

--- a/06-advanced/02-exposed-javatime/src/test/kotlin/exposed/examples/java/time/Ex01_JavaTime.kt
+++ b/06-advanced/02-exposed-javatime/src/test/kotlin/exposed/examples/java/time/Ex01_JavaTime.kt
@@ -57,6 +57,7 @@ import org.jetbrains.exposed.v1.javatime.timestampWithTimeZone
 import org.jetbrains.exposed.v1.javatime.year
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.migration.jdbc.MigrationUtils
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -945,7 +946,9 @@ class Ex01_JavaTime : AbstractExposedTest() {
                 val date: Column<LocalDate> = date("date").index().defaultExpression(CurrentDate)
             }
         withTables(testDB, tester) {
-            SchemaUtils.statementsRequiredToActualizeScheme(tester).shouldBeEmpty()
+            // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
+            // SchemaUtils.statementsRequiredToActualizeScheme(tester).shouldBeEmpty()
+            MigrationUtils.statementsRequiredForDatabaseMigration(tester).shouldBeEmpty()
         }
     }
 }

--- a/06-advanced/03-exposed-kotlin-datetime/src/test/kotlin/exposed/examples/kotlin/datetime/Ex01_KotlinDateTime.kt
+++ b/06-advanced/03-exposed-kotlin-datetime/src/test/kotlin/exposed/examples/kotlin/datetime/Ex01_KotlinDateTime.kt
@@ -61,6 +61,7 @@ import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
 import org.jetbrains.exposed.v1.datetime.year
 import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.migration.jdbc.MigrationUtils
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.select
@@ -891,7 +892,9 @@ class Ex01_KotlinDateTime: AbstractExposedTest() {
             val date: Column<LocalDate> = date("date").index().defaultExpression(CurrentDate)
         }
         withTables(testDB, testTable) {
-            SchemaUtils.statementsRequiredToActualizeScheme(testTable).shouldBeEmpty()
+            // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
+            // SchemaUtils.statementsRequiredToActualizeScheme(testTable).shouldBeEmpty()
+            MigrationUtils.statementsRequiredForDatabaseMigration(testTable).shouldBeEmpty()
         }
     }
 }

--- a/06-advanced/03-exposed-kotlin-datetime/src/test/kotlin/exposed/examples/kotlin/datetime/Ex02_Defaults.kt
+++ b/06-advanced/03-exposed-kotlin-datetime/src/test/kotlin/exposed/examples/kotlin/datetime/Ex02_Defaults.kt
@@ -633,7 +633,9 @@ class Ex02_Defaults: AbstractExposedTest() {
         }
 
         withTables(testDB, tester) {
-            SchemaUtils.statementsRequiredToActualizeScheme(tester).shouldBeEmpty()
+            // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
+            // SchemaUtils.statementsRequiredToActualizeScheme(tester).shouldBeEmpty()
+            MigrationUtils.statementsRequiredForDatabaseMigration(tester).shouldBeEmpty()
         }
     }
 

--- a/06-advanced/04-exposed-json/build.gradle.kts
+++ b/06-advanced/04-exposed-json/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     testImplementation(Libs.exposed_core)
     testImplementation(Libs.exposed_dao)
     testImplementation(Libs.exposed_jdbc)
+    testImplementation(Libs.exposed_migration_jdbc)
 
     // Exposed Json 지원 라이브러리 (kotlinx.serialization 을 사용합니다)
     testImplementation(Libs.exposed_json)

--- a/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/Ex01_JsonColumn.kt
+++ b/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/Ex01_JsonColumn.kt
@@ -40,6 +40,7 @@ import org.jetbrains.exposed.v1.dao.flushCache
 import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.v1.jdbc.Query
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.migration.jdbc.MigrationUtils
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
@@ -753,7 +754,9 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
                 defaultTester.exists().shouldBeTrue()
 
                 // ensure defaults match returned metadata defaults
-                val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
+                // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
                 alters.shouldBeEmpty()
 
                 defaultTester.insert { }

--- a/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/Ex02_JsonBColumn.kt
+++ b/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/Ex02_JsonBColumn.kt
@@ -41,6 +41,7 @@ import org.jetbrains.exposed.v1.dao.flushCache
 import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.v1.jdbc.Query
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.migration.jdbc.MigrationUtils
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
@@ -629,7 +630,9 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
                 defaultTester.exists().shouldBeTrue()
 
                 // ensure defaults match returned metadata defaults
-                val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
+                // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
                 alters.shouldBeEmpty()
 
                 /**

--- a/06-advanced/07-custom-entities/src/test/kotlin/exposed/examples/custom/entities/KsuidMillisTableTest.kt
+++ b/06-advanced/07-custom-entities/src/test/kotlin/exposed/examples/custom/entities/KsuidMillisTableTest.kt
@@ -1,7 +1,9 @@
 package exposed.examples.custom.entities
 
 import exposed.shared.tests.TestDB
-import exposed.shared.tests.withSuspendedTables
+// NOTE: withSuspendedTables는 deprecated됨. withTablesSuspending()으로 대체 (exposed.shared.tests)
+// import exposed.shared.tests.withSuspendedTables
+import exposed.shared.tests.withTablesSuspending
 import exposed.shared.tests.withTables
 import io.bluetape4k.exposed.core.dao.id.KsuidMillisTable
 import io.bluetape4k.exposed.dao.entityToStringBuilder
@@ -112,7 +114,7 @@ class KsuidMillisTableTest: AbstractCustomIdTableTest() {
     @ParameterizedTest(name = "{0} - {1}개 레코드")
     @MethodSource(GET_TESTDB_AND_ENTITY_COUNT)
     fun `코루틴 환경에서 레코드를 배치로 생성한다`(testDB: TestDB, recordCount: Int) = runSuspendIO {
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val records = List(recordCount) {
                 Record(
                     name = faker.name().fullName(),
@@ -151,7 +153,7 @@ class KsuidMillisTableTest: AbstractCustomIdTableTest() {
     @ParameterizedTest(name = "{0} - {1}개 레코드")
     @MethodSource(GET_TESTDB_AND_ENTITY_COUNT)
     fun `코루틴 환경에서 엔티티를 생성한다`(testDB: TestDB, recordCount: Int) = runSuspendIO {
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val tasks = List(recordCount) {
                 suspendedTransactionAsync(Dispatchers.IO) {
                     E1.new {
@@ -179,7 +181,7 @@ class KsuidMillisTableTest: AbstractCustomIdTableTest() {
     fun `insertIgnore as flow`(testDB: TestDB, entityCount: Int) = runSuspendIO {
         Assumptions.assumeTrue { testDB in TestDB.ALL_MYSQL_MARIADB + TestDB.POSTGRESQL }
 
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val entities: Sequence<Pair<String, Int>> = generateSequence {
                 val name = faker.name().fullName()
                 val age = faker.number().numberBetween(8, 80)

--- a/06-advanced/07-custom-entities/src/test/kotlin/exposed/examples/custom/entities/KsuidTableTest.kt
+++ b/06-advanced/07-custom-entities/src/test/kotlin/exposed/examples/custom/entities/KsuidTableTest.kt
@@ -1,7 +1,9 @@
 package exposed.examples.custom.entities
 
 import exposed.shared.tests.TestDB
-import exposed.shared.tests.withSuspendedTables
+// NOTE: withSuspendedTables는 deprecated됨. withTablesSuspending()으로 대체 (exposed.shared.tests)
+// import exposed.shared.tests.withSuspendedTables
+import exposed.shared.tests.withTablesSuspending
 import exposed.shared.tests.withTables
 import io.bluetape4k.exposed.core.dao.id.KsuidTable
 import io.bluetape4k.exposed.dao.entityToStringBuilder
@@ -113,7 +115,7 @@ class KsuidTableTest: AbstractCustomIdTableTest() {
     @ParameterizedTest(name = "{0} - {1}개 레코드")
     @MethodSource(GET_TESTDB_AND_ENTITY_COUNT)
     fun `코루틴 환경에서 레코드를 배치로 생성한다`(testDB: TestDB, recordCount: Int) = runSuspendIO {
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val records = List(recordCount) {
                 Record(
                     name = faker.name().fullName(),
@@ -151,7 +153,7 @@ class KsuidTableTest: AbstractCustomIdTableTest() {
     @ParameterizedTest(name = "{0} - {1}개 레코드")
     @MethodSource(GET_TESTDB_AND_ENTITY_COUNT)
     fun `코루틴 환경에서 엔티티를 생성한다`(testDB: TestDB, recordCount: Int) = runSuspendIO {
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val tasks = List(recordCount) {
                 suspendedTransactionAsync(Dispatchers.IO) {
                     E1.new {
@@ -178,7 +180,7 @@ class KsuidTableTest: AbstractCustomIdTableTest() {
     fun `insertIgnore as flow`(testDB: TestDB, entityCount: Int) = runSuspendIO {
         Assumptions.assumeTrue { testDB in TestDB.ALL_MYSQL_MARIADB + TestDB.POSTGRESQL }
 
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val entities: Sequence<Pair<String, Int>> = generateSequence {
                 val name = faker.name().fullName()
                 val age = faker.number().numberBetween(8, 80)

--- a/06-advanced/07-custom-entities/src/test/kotlin/exposed/examples/custom/entities/SnowflakeIdTableTest.kt
+++ b/06-advanced/07-custom-entities/src/test/kotlin/exposed/examples/custom/entities/SnowflakeIdTableTest.kt
@@ -1,7 +1,9 @@
 package exposed.examples.custom.entities
 
 import exposed.shared.tests.TestDB
-import exposed.shared.tests.withSuspendedTables
+// NOTE: withSuspendedTables는 deprecated됨. withTablesSuspending()으로 대체 (exposed.shared.tests)
+// import exposed.shared.tests.withSuspendedTables
+import exposed.shared.tests.withTablesSuspending
 import exposed.shared.tests.withTables
 import io.bluetape4k.exposed.core.dao.id.SnowflakeIdTable
 import io.bluetape4k.exposed.dao.entityToStringBuilder
@@ -113,7 +115,7 @@ class SnowflakeIdTableTest: AbstractCustomIdTableTest() {
     @ParameterizedTest(name = "{0} - {1}개 레코드")
     @MethodSource(GET_TESTDB_AND_ENTITY_COUNT)
     fun `코루틴 환경에서 레코드를 배치로 생성한다`(testDB: TestDB, recordCount: Int) = runSuspendIO {
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val records = List(recordCount) {
                 Record(
                     name = faker.name().fullName(),
@@ -151,7 +153,7 @@ class SnowflakeIdTableTest: AbstractCustomIdTableTest() {
     @ParameterizedTest(name = "{0} - {1}개 레코드")
     @MethodSource(GET_TESTDB_AND_ENTITY_COUNT)
     fun `코루틴 환경에서 엔티티를 생성한다`(testDB: TestDB, recordCount: Int) = runSuspendIO {
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val tasks: List<Deferred<E1>> = List(recordCount) {
                 suspendedTransactionAsync(Dispatchers.IO) {
                     E1.new {
@@ -178,7 +180,7 @@ class SnowflakeIdTableTest: AbstractCustomIdTableTest() {
     fun `insertIgnore as flow`(testDB: TestDB, entityCount: Int) = runSuspendIO {
         Assumptions.assumeTrue { testDB in TestDB.ALL_MYSQL_MARIADB + TestDB.POSTGRESQL }
 
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val entities: Sequence<Pair<String, Int>> = generateSequence {
                 val name = faker.name().fullName()
                 val age = faker.number().numberBetween(8, 80)

--- a/06-advanced/07-custom-entities/src/test/kotlin/exposed/examples/custom/entities/TimebasedUUIDBase62TableTest.kt
+++ b/06-advanced/07-custom-entities/src/test/kotlin/exposed/examples/custom/entities/TimebasedUUIDBase62TableTest.kt
@@ -1,7 +1,9 @@
 package exposed.examples.custom.entities
 
 import exposed.shared.tests.TestDB
-import exposed.shared.tests.withSuspendedTables
+// NOTE: withSuspendedTables는 deprecated됨. withTablesSuspending()으로 대체 (exposed.shared.tests)
+// import exposed.shared.tests.withSuspendedTables
+import exposed.shared.tests.withTablesSuspending
 import exposed.shared.tests.withTables
 import io.bluetape4k.exposed.core.dao.id.TimebasedUUIDBase62Table
 import io.bluetape4k.exposed.dao.entityToStringBuilder
@@ -34,7 +36,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import kotlin.random.Random
 
-@Suppress("DEPRECATION")
 /**
  * Time-based UUID Base62 식별자를 사용하는 테이블/엔티티 동작을 검증한다.
  */
@@ -113,7 +114,7 @@ class TimebasedUUIDBase62TableTest: AbstractCustomIdTableTest() {
     @ParameterizedTest(name = "{0} - {1}개 레코드")
     @MethodSource(GET_TESTDB_AND_ENTITY_COUNT)
     fun `코루틴 환경에서 레코드를 배치로 생성한다`(testDB: TestDB, recordCount: Int) = runSuspendIO {
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val records = List(recordCount) {
                 Record(
                     name = faker.name().fullName(),
@@ -151,7 +152,7 @@ class TimebasedUUIDBase62TableTest: AbstractCustomIdTableTest() {
     @ParameterizedTest(name = "{0} - {1}개 레코드")
     @MethodSource(GET_TESTDB_AND_ENTITY_COUNT)
     fun `코루틴 환경에서 엔티티를 생성한다`(testDB: TestDB, recordCount: Int) = runSuspendIO {
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val tasks: List<Deferred<E1>> = List(recordCount) {
                 suspendedTransactionAsync(Dispatchers.IO) {
                     E1.new {
@@ -177,7 +178,7 @@ class TimebasedUUIDBase62TableTest: AbstractCustomIdTableTest() {
     fun `insertIgnore as flow`(testDB: TestDB, entityCount: Int) = runSuspendIO {
         Assumptions.assumeTrue { testDB in TestDB.ALL_MYSQL_MARIADB + TestDB.POSTGRESQL }
 
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val entities: Sequence<Pair<String, Int>> = generateSequence {
                 val name = faker.name().fullName()
                 val age = faker.number().numberBetween(8, 80)

--- a/06-advanced/07-custom-entities/src/test/kotlin/exposed/examples/custom/entities/TimebasedUUIDTableTest.kt
+++ b/06-advanced/07-custom-entities/src/test/kotlin/exposed/examples/custom/entities/TimebasedUUIDTableTest.kt
@@ -1,7 +1,9 @@
 package exposed.examples.custom.entities
 
 import exposed.shared.tests.TestDB
-import exposed.shared.tests.withSuspendedTables
+// NOTE: withSuspendedTables는 deprecated됨. withTablesSuspending()으로 대체 (exposed.shared.tests)
+// import exposed.shared.tests.withSuspendedTables
+import exposed.shared.tests.withTablesSuspending
 import exposed.shared.tests.withTables
 import io.bluetape4k.exposed.core.dao.id.TimebasedUUIDTable
 import io.bluetape4k.exposed.dao.entityToStringBuilder
@@ -114,7 +116,7 @@ class TimebasedUUIDTableTest: AbstractCustomIdTableTest() {
     @ParameterizedTest(name = "{0} - {1}개 레코드")
     @MethodSource(GET_TESTDB_AND_ENTITY_COUNT)
     fun `코루틴 환경에서 레코드를 배치로 생성한다`(testDB: TestDB, recordCount: Int) = runSuspendIO {
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val records = List(recordCount) {
                 Record(
                     name = faker.name().fullName(),
@@ -153,7 +155,7 @@ class TimebasedUUIDTableTest: AbstractCustomIdTableTest() {
     @ParameterizedTest(name = "{0} - {1}개 레코드")
     @MethodSource(GET_TESTDB_AND_ENTITY_COUNT)
     fun `코루틴 환경에서 엔티티를 생성한다`(testDB: TestDB, recordCount: Int) = runSuspendIO {
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val tasks: List<Deferred<E1>> = List(recordCount) {
                 suspendedTransactionAsync(Dispatchers.IO) {
                     E1.new {
@@ -180,7 +182,7 @@ class TimebasedUUIDTableTest: AbstractCustomIdTableTest() {
     fun `insertIgnore as flow`(testDB: TestDB, entityCount: Int) = runSuspendIO {
         Assumptions.assumeTrue { testDB in TestDB.ALL_MYSQL_MARIADB + TestDB.POSTGRESQL }
 
-        withSuspendedTables(testDB, T1) {
+        withTablesSuspending(testDB, T1) {
             val entities: Sequence<Pair<String, Int>> = generateSequence {
                 val name = faker.name().fullName()
                 val age = faker.number().numberBetween(8, 80)

--- a/06-advanced/08-exposed-jackson/build.gradle.kts
+++ b/06-advanced/08-exposed-jackson/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     testImplementation(Libs.exposed_core)
     testImplementation(Libs.exposed_dao)
     testImplementation(Libs.exposed_jdbc)
+    testImplementation(Libs.exposed_migration_jdbc)
 
     testImplementation(Libs.bluetape4k_exposed)
     testImplementation(Libs.bluetape4k_exposed_jackson2)

--- a/06-advanced/08-exposed-jackson/src/test/kotlin/exposed/examples/jackson/JacksonBColumnTest.kt
+++ b/06-advanced/08-exposed-jackson/src/test/kotlin/exposed/examples/jackson/JacksonBColumnTest.kt
@@ -35,6 +35,7 @@ import org.jetbrains.exposed.v1.core.stringParam
 import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.migration.jdbc.MigrationUtils
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
@@ -458,7 +459,9 @@ class JacksonBColumnTest: AbstractExposedTest() {
                 defaultTester.exists().shouldBeTrue()
 
                 // ensure defaults match returned metadata defaults
-                val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
+                // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
                 alters.shouldBeEmpty()
 
                 defaultTester.insert { }

--- a/06-advanced/08-exposed-jackson/src/test/kotlin/exposed/examples/jackson/JacksonColumnTest.kt
+++ b/06-advanced/08-exposed-jackson/src/test/kotlin/exposed/examples/jackson/JacksonColumnTest.kt
@@ -36,6 +36,7 @@ import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
 import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.migration.jdbc.MigrationUtils
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
@@ -579,7 +580,9 @@ class JacksonColumnTest: AbstractExposedTest() {
                 defaultTester.exists().shouldBeTrue()
 
                 // ensure defaults match returned metadata defaults
-                val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
+                // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
                 alters.shouldBeEmpty()
 
                 defaultTester.insert { }

--- a/06-advanced/09-exposed-fastjson2/build.gradle.kts
+++ b/06-advanced/09-exposed-fastjson2/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     testImplementation(Libs.exposed_core)
     testImplementation(Libs.exposed_dao)
     testImplementation(Libs.exposed_jdbc)
+    testImplementation(Libs.exposed_migration_jdbc)
 
     testImplementation(Libs.bluetape4k_exposed)
     testImplementation(Libs.bluetape4k_exposed_fastjson2)

--- a/06-advanced/09-exposed-fastjson2/src/test/kotlin/exposed/examples/fastjson2/FastjsonBColumnTest.kt
+++ b/06-advanced/09-exposed-fastjson2/src/test/kotlin/exposed/examples/fastjson2/FastjsonBColumnTest.kt
@@ -35,6 +35,7 @@ import org.jetbrains.exposed.v1.core.stringParam
 import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.migration.jdbc.MigrationUtils
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
@@ -458,7 +459,9 @@ class FastjsonBColumnTest: AbstractExposedTest() {
                 defaultTester.exists().shouldBeTrue()
 
                 // ensure defaults match returned metadata defaults
-                val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
+                // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
                 alters.shouldBeEmpty()
 
                 defaultTester.insert { }

--- a/06-advanced/09-exposed-fastjson2/src/test/kotlin/exposed/examples/fastjson2/FastjsonColumnTest.kt
+++ b/06-advanced/09-exposed-fastjson2/src/test/kotlin/exposed/examples/fastjson2/FastjsonColumnTest.kt
@@ -36,6 +36,7 @@ import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
 import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.migration.jdbc.MigrationUtils
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
@@ -582,7 +583,9 @@ class FastjsonColumnTest: AbstractExposedTest() {
                 defaultTester.exists().shouldBeTrue()
 
                 // ensure defaults match returned metadata defaults
-                val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
+                // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
                 alters.shouldBeEmpty()
 
                 defaultTester.insert { }

--- a/06-advanced/11-exposed-jackson3/build.gradle.kts
+++ b/06-advanced/11-exposed-jackson3/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     testImplementation(Libs.exposed_core)
     testImplementation(Libs.exposed_dao)
     testImplementation(Libs.exposed_jdbc)
+    testImplementation(Libs.exposed_migration_jdbc)
 
     testImplementation(Libs.bluetape4k_exposed)
     testImplementation(Libs.bluetape4k_exposed_jackson3)

--- a/06-advanced/11-exposed-jackson3/src/test/kotlin/exposed/examples/jackson3/JacksonBColumnTest.kt
+++ b/06-advanced/11-exposed-jackson3/src/test/kotlin/exposed/examples/jackson3/JacksonBColumnTest.kt
@@ -35,6 +35,7 @@ import org.jetbrains.exposed.v1.core.stringParam
 import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.migration.jdbc.MigrationUtils
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
@@ -458,7 +459,9 @@ class JacksonBColumnTest: AbstractExposedTest() {
                 defaultTester.exists().shouldBeTrue()
 
                 // ensure defaults match returned metadata defaults
-                val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
+                // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
                 alters.shouldBeEmpty()
 
                 defaultTester.insert { }

--- a/06-advanced/11-exposed-jackson3/src/test/kotlin/exposed/examples/jackson3/JacksonColumnTest.kt
+++ b/06-advanced/11-exposed-jackson3/src/test/kotlin/exposed/examples/jackson3/JacksonColumnTest.kt
@@ -36,6 +36,7 @@ import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
 import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.migration.jdbc.MigrationUtils
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
@@ -579,7 +580,9 @@ class JacksonColumnTest: AbstractExposedTest() {
                 defaultTester.exists().shouldBeTrue()
 
                 // ensure defaults match returned metadata defaults
-                val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
+                // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
                 alters.shouldBeEmpty()
 
                 defaultTester.insert { }

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex04_many_to_many/Ex02_ManyToMany_Member.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex04_many_to_many/Ex02_ManyToMany_Member.kt
@@ -8,7 +8,9 @@ import exposed.examples.jpa.ex05_relations.ex04_many_to_many.MemberSchema.UserSt
 import exposed.examples.jpa.ex05_relations.ex04_many_to_many.MemberSchema.UserTable
 import exposed.shared.tests.AbstractExposedTest
 import exposed.shared.tests.TestDB
-import exposed.shared.tests.withSuspendedTables
+// NOTE: withSuspendedTables는 deprecated됨. withTablesSuspending()으로 대체 (exposed.shared.tests)
+// import exposed.shared.tests.withSuspendedTables
+import exposed.shared.tests.withTablesSuspending
 import exposed.shared.tests.withTables
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
@@ -72,7 +74,7 @@ class Ex02_ManyToMany_Member: AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `coroutine support`(testDB: TestDB) = runSuspendIO {
-        withSuspendedTables(testDB, *MemberSchema.memberTables) {
+        withTablesSuspending(testDB, *MemberSchema.memberTables) {
             val prevCount = User.all().count()
 
             // rollback()을 호출하면 transaction은 롤백된다.

--- a/08-coroutines/01-coroutines-basic/src/test/kotlin/exposed/examples/coroutines/Ex01_Coroutines.kt
+++ b/08-coroutines/01-coroutines-basic/src/test/kotlin/exposed/examples/coroutines/Ex01_Coroutines.kt
@@ -2,7 +2,9 @@ package exposed.examples.coroutines
 
 import exposed.shared.tests.AbstractExposedTest
 import exposed.shared.tests.TestDB
-import exposed.shared.tests.withSuspendedTables
+// NOTE: withSuspendedTables는 deprecated됨. withTablesSuspending()으로 대체 (exposed.shared.tests)
+// import exposed.shared.tests.withSuspendedTables
+import exposed.shared.tests.withTablesSuspending
 import io.bluetape4k.collections.intRangeOf
 import io.bluetape4k.exposed.dao.idEquals
 import io.bluetape4k.exposed.dao.idHashCode
@@ -101,7 +103,7 @@ class Ex01_Coroutines : AbstractExposedTest() {
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `존재하지 않는 식별자로 조회하면 null을 반환한다`(testDB: TestDB) =
         runSuspendIO {
-            withSuspendedTables(testDB, Tester) {
+            withTablesSuspending(testDB, Tester) {
                 newSuspendedTransaction {
                     Tester.insert { }
                 }
@@ -132,7 +134,7 @@ class Ex01_Coroutines : AbstractExposedTest() {
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `suspended transaction으로 시퀀셜 작업 수행하기`(testDB: TestDB) =
         runSuspendIO {
-            withSuspendedTables(testDB, Tester) {
+            withTablesSuspending(testDB, Tester) {
                 // 새로운 트랜잭션을 만들고, 코루틴 환경에서 내부 코드를 실행한다
                 newSuspendedTransaction(context = singleThreadDispatcher) {
                     val id = Tester.insertAndGetId { }
@@ -157,7 +159,7 @@ class Ex01_Coroutines : AbstractExposedTest() {
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `suspendedTransactionAsync으로 동시 작업 수행하기`(testDB: TestDB) =
         runSuspendIO {
-            withSuspendedTables(testDB, TesterUnique) {
+            withTablesSuspending(testDB, TesterUnique) {
                 val originId = 1
                 val updatedId = 99
 
@@ -224,7 +226,7 @@ class Ex01_Coroutines : AbstractExposedTest() {
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `suspendedTransactionAsync 를 이용하여 여러 작업을 동시에 수행`(testDB: TestDB) =
         runSuspendIO {
-            withSuspendedTables(testDB, TesterUnique) {
+            withTablesSuspending(testDB, TesterUnique) {
                 val originId = 1
                 val updatedId = 99
 
@@ -283,7 +285,7 @@ class Ex01_Coroutines : AbstractExposedTest() {
                     Tester.insert { }
                 }
 
-            withSuspendedTables(testDB, Tester, context = Dispatchers.IO) {
+            withTablesSuspending(testDB, Tester, context = Dispatchers.IO) {
                 newSuspendedTransaction(db = db) {
                     connection.transactionIsolation = Connection.TRANSACTION_READ_COMMITTED
                     getTesterById(1).shouldBeNull()
@@ -305,7 +307,7 @@ class Ex01_Coroutines : AbstractExposedTest() {
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `중첩된 suspend transaction async 실행`(testDB: TestDB) =
         runSuspendIO {
-            withSuspendedTables(testDB, Tester, context = Dispatchers.IO) {
+            withTablesSuspending(testDB, Tester, context = Dispatchers.IO) {
                 val recordCount = 10
 
                 newSuspendedTransaction {
@@ -371,7 +373,7 @@ class Ex01_Coroutines : AbstractExposedTest() {
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `다수의 비동기 작업을 수행 후 대기`(testDB: TestDB) =
         runSuspendIO {
-            withSuspendedTables(testDB, Tester) {
+            withTablesSuspending(testDB, Tester) {
                 val recordCount = 10
 
                 // 복수의 INSERT 작업을 동시에 수행합니다.
@@ -394,7 +396,7 @@ class Ex01_Coroutines : AbstractExposedTest() {
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `suspended 와 일반 transaction 혼용하기`(testDB: TestDB) =
         runSuspendIO {
-            withSuspendedTables(testDB, Tester) {
+            withTablesSuspending(testDB, Tester) {
                 val db = this.db
                 var suspendedOk = true
                 var normalOk = true
@@ -439,7 +441,7 @@ class Ex01_Coroutines : AbstractExposedTest() {
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `coroutines with exception within`(testDB: TestDB) =
         runSuspendIO {
-            withSuspendedTables(testDB, Tester) {
+            withTablesSuspending(testDB, Tester) {
                 val database = this.db
                 val outerConn = this.connection
                 val id = TesterEntity.new { }.id


### PR DESCRIPTION
## Summary

- `SchemaUtils.statementsRequiredToActualizeScheme` → `MigrationUtils.statementsRequiredForDatabaseMigration` 교체 (12개 파일)
- `withSuspendedTables` → `withTablesSuspending` 교체 (8개 파일)
- 관련 모듈 `build.gradle.kts`에 `exposed_migration_jdbc` 의존성 추가 (5개 모듈)
- 이전 코드는 주석 처리하여 변경 이력 보존
- deprecated API를 「설명」하는 예제 파일(`Ex03_CreateMissingTableAndColumns.kt`)은 변경 제외

## Test plan

- [x] `04-transactions`: 65 passing, 21 pending
- [x] `02-exposed-javatime`: 149 passing, 10 pending
- [x] `01-convert-jpa-basic`: 197 passing, 2 pending
- [x] DML 모듈 (`01-dml`, `02-types`, `05-entities`): BUILD SUCCESSFUL
- [x] Advanced 모듈 (kotlin-datetime, jackson×2, fastjson2, json): BUILD SUCCESSFUL
- [x] `01-coroutines-basic`, `07-custom-entities`: BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)