### PR TITLE
[codex] Use version catalogs for bluetape4k dependencies

### DIFF
--- a/00-shared/exposed-shared-tests/build.gradle.kts
+++ b/00-shared/exposed-shared-tests/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
     implementation(platform(libs.exposed.bom))
 
     // Bluetape4k Exposed
-    api(libs.bluetape4k.exposed)
+    api(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.exposed.jackson2)
     implementation(libs.bluetape4k.exposed.fastjson2)
 
@@ -23,7 +23,6 @@ dependencies {
 
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.junit5)
-    implementation(libs.bluetape4k.assertions)
 
     runtimeOnly(libs.hikaricp)
 

--- a/01-spring-boot/spring-mvc-exposed/build.gradle.kts
+++ b/01-spring-boot/spring-mvc-exposed/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     implementation(libs.exposed.spring.boot.starter)
 
     // bluetape4k
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.testcontainers)

--- a/01-spring-boot/spring-webflux-exposed/build.gradle.kts
+++ b/01-spring-boot/spring-webflux-exposed/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation(libs.exposed.spring.boot.starter)
 
     // bluetape4k
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.jdbc)

--- a/03-exposed-basic/exposed-dao-example/build.gradle.kts
+++ b/03-exposed-basic/exposed-dao-example/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 
     testImplementation(libs.exposed.core)
     testImplementation(libs.exposed.dao)
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.testcontainers)

--- a/03-exposed-basic/exposed-sql-example/build.gradle.kts
+++ b/03-exposed-basic/exposed-sql-example/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 
     testImplementation(libs.exposed.core)
     testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/04-exposed-ddl/01-connection/build.gradle.kts
+++ b/04-exposed-ddl/01-connection/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation(libs.exposed.jdbc)
     implementation(libs.exposed.dao)
 
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testImplementation(libs.bluetape4k.testcontainers)

--- a/04-exposed-ddl/02-ddl/build.gradle.kts
+++ b/04-exposed-ddl/02-ddl/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation(libs.exposed.dao)
     implementation(libs.exposed.migration.jdbc)
     implementation(libs.exposed.java.time)
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/05-exposed-dml/01-dml/build.gradle.kts
+++ b/05-exposed-dml/01-dml/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     testImplementation(libs.exposed.jdbc)
     testImplementation(libs.exposed.dao)
     testImplementation(libs.exposed.java.time)
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.jdbc)
     testImplementation(libs.bluetape4k.idgenerators)

--- a/05-exposed-dml/02-types/build.gradle.kts
+++ b/05-exposed-dml/02-types/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     testImplementation(libs.exposed.dao)
     testImplementation(libs.exposed.jdbc)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
     testImplementation(libs.bluetape4k.idgenerators)
 
     testImplementation(libs.bluetape4k.junit5)

--- a/05-exposed-dml/03-functions/build.gradle.kts
+++ b/05-exposed-dml/03-functions/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     testImplementation(libs.exposed.dao)
     testImplementation(libs.exposed.jdbc)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/05-exposed-dml/04-transactions/build.gradle.kts
+++ b/05-exposed-dml/04-transactions/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     testImplementation(libs.exposed.core)
     testImplementation(libs.exposed.dao)
     testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/05-exposed-dml/05-entities/build.gradle.kts
+++ b/05-exposed-dml/05-entities/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     testImplementation(libs.exposed.jdbc)
     testImplementation(libs.exposed.migration.jdbc)
     testImplementation(libs.exposed.java.time)
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.idgenerators)
     testImplementation(libs.bluetape4k.junit5)

--- a/06-advanced/01-exposed-crypt/build.gradle.kts
+++ b/06-advanced/01-exposed-crypt/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     // 암호화 관련 라이브러리
     implementation(libs.exposed.crypt)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testImplementation(libs.bluetape4k.testcontainers)

--- a/06-advanced/02-exposed-javatime/build.gradle.kts
+++ b/06-advanced/02-exposed-javatime/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation(project(":exposed-shared-tests"))
 
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.exposed.core)
     implementation(libs.exposed.dao)
     implementation(libs.exposed.jdbc)
@@ -25,7 +25,7 @@ dependencies {
     implementation(platform(libs.kotlinx.serialization.bom))
     implementation(libs.kotlinx.serialization.json)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testImplementation(libs.bluetape4k.testcontainers)

--- a/06-advanced/03-exposed-kotlin-datetime/build.gradle.kts
+++ b/06-advanced/03-exposed-kotlin-datetime/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     testImplementation(platform(libs.kotlinx.serialization.bom))
     testImplementation(libs.kotlinx.serialization.json)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testImplementation(libs.bluetape4k.testcontainers)

--- a/06-advanced/04-exposed-json/build.gradle.kts
+++ b/06-advanced/04-exposed-json/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     testImplementation(platform(libs.kotlinx.serialization.bom))
     testImplementation(libs.kotlinx.serialization.json)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testImplementation(libs.bluetape4k.testcontainers)

--- a/06-advanced/05-exposed-money/build.gradle.kts
+++ b/06-advanced/05-exposed-money/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     testImplementation(libs.exposed.core)
     testImplementation(libs.exposed.dao)
     testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
 
     // Money
     testImplementation(libs.exposed.money)

--- a/06-advanced/06-custom-columns/build.gradle.kts
+++ b/06-advanced/06-custom-columns/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     testImplementation(libs.exposed.core)
     testImplementation(libs.exposed.jdbc)
     testImplementation(libs.exposed.dao)
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
 
     implementation(libs.bluetape4k.io)
 

--- a/06-advanced/07-custom-entities/build.gradle.kts
+++ b/06-advanced/07-custom-entities/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     testImplementation(libs.exposed.core)
     testImplementation(libs.exposed.jdbc)
     testImplementation(libs.exposed.dao)
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
 
     // Id Generators
     // - Snowflake

--- a/06-advanced/08-exposed-jackson/build.gradle.kts
+++ b/06-advanced/08-exposed-jackson/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     testImplementation(libs.exposed.jdbc)
     testImplementation(libs.exposed.migration.jdbc)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
     testImplementation(libs.bluetape4k.exposed.jackson2)
 
     testImplementation(libs.bluetape4k.junit5)

--- a/06-advanced/09-exposed-fastjson2/build.gradle.kts
+++ b/06-advanced/09-exposed-fastjson2/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     testImplementation(libs.exposed.jdbc)
     testImplementation(libs.exposed.migration.jdbc)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
     testImplementation(libs.bluetape4k.exposed.fastjson2)
     testImplementation(libs.bluetape4k.junit5)
 

--- a/06-advanced/11-exposed-jackson3/build.gradle.kts
+++ b/06-advanced/11-exposed-jackson3/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     testImplementation(libs.exposed.jdbc)
     testImplementation(libs.exposed.migration.jdbc)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
     testImplementation(libs.bluetape4k.exposed.jackson3)
 
     // Jackson 3

--- a/07-jpa/01-convert-jpa-basic/build.gradle.kts
+++ b/07-jpa/01-convert-jpa-basic/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation(libs.jakarta.validation.api)
     implementation(libs.hibernate.validator)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/07-jpa/02-convert-jpa-advanced/build.gradle.kts
+++ b/07-jpa/02-convert-jpa-advanced/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     testImplementation(libs.exposed.dao)
     testImplementation(libs.exposed.java.time)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/08-coroutines/01-coroutines-basic/build.gradle.kts
+++ b/08-coroutines/01-coroutines-basic/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     testImplementation(libs.exposed.dao)
     testImplementation(libs.exposed.jdbc)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testRuntimeOnly(libs.h2.v2)

--- a/08-coroutines/02-virtualthreads-basic/build.gradle.kts
+++ b/08-coroutines/02-virtualthreads-basic/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     // Java 21 에서 Virtual Thread 를 사용할 때 (Java 25 에서는 jdk25 를 사용하세요)
     testRuntimeOnly(libs.bluetape4k.virtualthread.jdk21)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testRuntimeOnly(libs.h2.v2)

--- a/09-spring/01-springboot-autoconfigure/build.gradle.kts
+++ b/09-spring/01-springboot-autoconfigure/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     testImplementation(libs.exposed.java.time)
     testImplementation(libs.exposed.spring.boot.starter)
 
-    testImplementation(libs.bluetape4k.exposed)
+    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/09-spring/02-transactiontemplate/build.gradle.kts
+++ b/09-spring/02-transactiontemplate/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation(libs.exposed.spring.boot.starter)
 
     // Bluetape4k
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.io)
     testImplementation(libs.bluetape4k.junit5)
 

--- a/09-spring/03-spring-transaction/build.gradle.kts
+++ b/09-spring/03-spring-transaction/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation(libs.exposed.spring.boot.starter)
 
     // Bluetape4k
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.spring.boot3.core)

--- a/09-spring/04-exposed-repository/build.gradle.kts
+++ b/09-spring/04-exposed-repository/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation(libs.exposed.spring.boot.starter)
 
     // Bluetape4k
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.testcontainers)

--- a/09-spring/05-exposed-repository-coroutines/build.gradle.kts
+++ b/09-spring/05-exposed-repository-coroutines/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     implementation(libs.exposed.spring.boot.starter)
 
     // Bluetape4k
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.testcontainers)

--- a/09-spring/07-spring-suspended-cache/build.gradle.kts
+++ b/09-spring/07-spring-suspended-cache/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     implementation(libs.bluetape4k.redis)
     implementation(libs.bluetape4k.testcontainers)
     // Exposed
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.exposed.core)
     implementation(libs.exposed.jdbc)
     implementation(libs.exposed.dao)

--- a/10-multi-tenant/01-multitenant-spring-web/build.gradle.kts
+++ b/10-multi-tenant/01-multitenant-spring-web/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.exposed.core)
     implementation(libs.exposed.jdbc)
     implementation(libs.exposed.dao)

--- a/10-multi-tenant/02-multitenant-spring-web-virtualthread/build.gradle.kts
+++ b/10-multi-tenant/02-multitenant-spring-web-virtualthread/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.exposed.core)
     implementation(libs.exposed.jdbc)
     implementation(libs.exposed.dao)

--- a/10-multi-tenant/03-multitenant-spring-webflux/build.gradle.kts
+++ b/10-multi-tenant/03-multitenant-spring-webflux/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     implementation(libs.exposed.spring.boot.starter)
 
     // bluetape4k
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.testcontainers)

--- a/11-high-performance/01-cache-strategies/build.gradle.kts
+++ b/11-high-performance/01-cache-strategies/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     implementation(libs.exposed.spring.boot.starter)
 
     // bluetape4k
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.exposed.jdbc.redisson)
     implementation(libs.bluetape4k.idgenerators)
     implementation(libs.bluetape4k.redis)

--- a/11-high-performance/02-cache-strategies-coroutines/build.gradle.kts
+++ b/11-high-performance/02-cache-strategies-coroutines/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     implementation(libs.exposed.spring.boot.starter)
 
     // bluetape4k
-    implementation(libs.bluetape4k.exposed)
+    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.bluetape4k.exposed.jdbc.redisson)
     implementation(libs.bluetape4k.idgenerators)
     implementation(libs.bluetape4k.redis)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ allprojects {
         mavenCentral()
         google()
 
-        // bluetape4k-assertions 는 1.8.0-SNAPSHOT 에만 존재하므로 snapshot 저장소 사용
+        // bluetape4k snapshot 버전 사용 시만 사용하세요.
         maven {
             name = "central-snapshots"
             url = uri("https://central.sonatype.com/repository/maven-snapshots/")
@@ -42,9 +42,9 @@ allprojects {
     }
 
     // bluetape4k snapshot 버전 사용 시만 사용하세요.
-//    configurations.all {
-//        resolutionStrategy.cacheChangingModulesFor(1, TimeUnit.DAYS)
-//    }
+    configurations.all {
+        resolutionStrategy.cacheChangingModulesFor(0, TimeUnit.SECONDS)
+    }
 }
 
 subprojects {
@@ -225,7 +225,6 @@ subprojects {
         testImplementation(rootLibs.junit.jupiter)
         testRuntimeOnly(rootLibs.junit.platform.engine)
 
-        testImplementation(rootLibs.bluetape4k.assertions)
         testImplementation(rootLibs.mockk)
         testImplementation(rootLibs.awaitility.kotlin)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k = "1.7.0"
-bluetape4k-assertions-version = "1.8.0-SNAPSHOT"
+bluetape4k = "1.8.0-SNAPSHOT"
 
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.10.2"
@@ -112,41 +111,40 @@ jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.1.
 
 # bluetape4k
 bluetape4k-bom = { module = "io.github.bluetape4k:bluetape4k-bom", version.ref = "bluetape4k" }
-bluetape4k-core = { module = "io.github.bluetape4k:bluetape4k-core" }
-bluetape4k-coroutines = { module = "io.github.bluetape4k:bluetape4k-coroutines" }
-bluetape4k-logging = { module = "io.github.bluetape4k:bluetape4k-logging" }
-bluetape4k-assertions = { module = "io.github.bluetape4k:bluetape4k-assertions", version.ref = "bluetape4k-assertions-version" }
-bluetape4k-junit5 = { module = "io.github.bluetape4k:bluetape4k-junit5" }
-bluetape4k-testcontainers = { module = "io.github.bluetape4k:bluetape4k-testcontainers" }
-bluetape4k-idgenerators = { module = "io.github.bluetape4k:bluetape4k-idgenerators" }
-bluetape4k-io = { module = "io.github.bluetape4k:bluetape4k-io" }
-bluetape4k-jdbc = { module = "io.github.bluetape4k:bluetape4k-jdbc" }
-bluetape4k-money = { module = "io.github.bluetape4k:bluetape4k-money" }
-bluetape4k-redis = { module = "io.github.bluetape4k:bluetape4k-redis" }
-bluetape4k-vertx = { module = "io.github.bluetape4k:bluetape4k-vertx" }
-bluetape4k-grpc = { module = "io.github.bluetape4k:bluetape4k-grpc" }
-bluetape4k-jackson2 = { module = "io.github.bluetape4k:bluetape4k-jackson2" }
-bluetape4k-jackson3 = { module = "io.github.bluetape4k:bluetape4k-jackson3" }
+bluetape4k-core = { module = "io.github.bluetape4k:bluetape4k-core" , version.ref = "bluetape4k" }
+bluetape4k-coroutines = { module = "io.github.bluetape4k:bluetape4k-coroutines" , version.ref = "bluetape4k" }
+bluetape4k-logging = { module = "io.github.bluetape4k:bluetape4k-logging" , version.ref = "bluetape4k" }
+bluetape4k-junit5 = { module = "io.github.bluetape4k:bluetape4k-junit5" , version.ref = "bluetape4k" }
+bluetape4k-testcontainers = { module = "io.github.bluetape4k:bluetape4k-testcontainers" , version.ref = "bluetape4k" }
+bluetape4k-idgenerators = { module = "io.github.bluetape4k:bluetape4k-idgenerators" , version.ref = "bluetape4k" }
+bluetape4k-io = { module = "io.github.bluetape4k:bluetape4k-io" , version.ref = "bluetape4k" }
+bluetape4k-jdbc = { module = "io.github.bluetape4k:bluetape4k-jdbc" , version.ref = "bluetape4k" }
+bluetape4k-money = { module = "io.github.bluetape4k:bluetape4k-money" , version.ref = "bluetape4k" }
+bluetape4k-redis = { module = "io.github.bluetape4k:bluetape4k-redis" , version.ref = "bluetape4k" }
+bluetape4k-vertx = { module = "io.github.bluetape4k:bluetape4k-vertx" , version.ref = "bluetape4k" }
+bluetape4k-grpc = { module = "io.github.bluetape4k:bluetape4k-grpc" , version.ref = "bluetape4k" }
+bluetape4k-jackson2 = { module = "io.github.bluetape4k:bluetape4k-jackson2" , version.ref = "bluetape4k" }
+bluetape4k-jackson3 = { module = "io.github.bluetape4k:bluetape4k-jackson3" , version.ref = "bluetape4k" }
 
 # bluetape4k exposed
-bluetape4k-exposed = { module = "io.github.bluetape4k:bluetape4k-exposed" }
-bluetape4k-exposed-fastjson2 = { module = "io.github.bluetape4k:bluetape4k-exposed-fastjson2" }
-bluetape4k-exposed-jackson2 = { module = "io.github.bluetape4k:bluetape4k-exposed-jackson2" }
-bluetape4k-exposed-jackson3 = { module = "io.github.bluetape4k:bluetape4k-exposed-jackson3" }
-bluetape4k-exposed-jdbc = { module = "io.github.bluetape4k:bluetape4k-exposed-jdbc" }
-bluetape4k-exposed-jdbc-redisson = { module = "io.github.bluetape4k:bluetape4k-exposed-jdbc-redisson" }
-bluetape4k-exposed-tink = { module = "io.github.bluetape4k:bluetape4k-exposed-tink" }
+bluetape4k-exposed-core = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-core" , version.ref = "bluetape4k" }
+bluetape4k-exposed-fastjson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-fastjson2" , version.ref = "bluetape4k" }
+bluetape4k-exposed-jackson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson2" , version.ref = "bluetape4k" }
+bluetape4k-exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" , version.ref = "bluetape4k" }
+bluetape4k-exposed-jdbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc" , version.ref = "bluetape4k" }
+bluetape4k-exposed-jdbc-redisson = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-redisson" , version.ref = "bluetape4k" }
+bluetape4k-exposed-tink = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-tink" , version.ref = "bluetape4k" }
 
 # bluetape4k hibernate
-bluetape4k-hibernate-reactive = { module = "io.github.bluetape4k:bluetape4k-hibernate-reactive" }
+bluetape4k-hibernate-reactive = { module = "io.github.bluetape4k:bluetape4k-hibernate-reactive" , version.ref = "bluetape4k" }
 
 # bluetape4k spring-boot3
-bluetape4k-spring-boot3-core = { module = "io.github.bluetape4k:bluetape4k-spring-boot3-core" }
-bluetape4k-spring-boot3-r2dbc = { module = "io.github.bluetape4k:bluetape4k-spring-boot3-r2dbc" }
-bluetape4k-spring-boot3-redis = { module = "io.github.bluetape4k:bluetape4k-spring-boot3-redis" }
+bluetape4k-spring-boot3-core = { module = "io.github.bluetape4k:bluetape4k-spring-boot3-core" , version.ref = "bluetape4k" }
+bluetape4k-spring-boot3-r2dbc = { module = "io.github.bluetape4k:bluetape4k-spring-boot3-r2dbc" , version.ref = "bluetape4k" }
+bluetape4k-spring-boot3-redis = { module = "io.github.bluetape4k:bluetape4k-spring-boot3-redis" , version.ref = "bluetape4k" }
 
 # bluetape4k virtualthread
-bluetape4k-virtualthread-jdk21 = { module = "io.github.bluetape4k:bluetape4k-virtualthread-jdk21" }
+bluetape4k-virtualthread-jdk21 = { module = "io.github.bluetape4k:bluetape4k-virtualthread-jdk21" , version.ref = "bluetape4k" }
 
 # Kotlin
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }


### PR DESCRIPTION
## What changed

- Switched bluetape4k-exposed core usage to `libs.bluetape4k.exposed.core`.
- Updated bluetape4k-exposed catalog aliases to the `io.github.bluetape4k.exposed:*` group.
- Kept bluetape4k dependency declarations catalog-managed in Gradle scripts.

## Why

This prevents workshop modules from resolving stale or legacy bluetape4k-exposed coordinates outside the shared catalog/BOM alignment.

## Validation

- `./gradlew help --no-daemon`
- `rg` scan for direct bluetape4k build-script coordinates
- `git diff --check`

## Notes

Full module test suites were not run.