### PR TITLE
[codex] Align exposed workshop test cleanup

### DIFF
--- a/05-exposed-dml/02-types/src/test/kotlin/exposed/examples/types/Ex05_ArrayColumnType.kt
+++ b/05-exposed-dml/02-types/src/test/kotlin/exposed/examples/types/Ex05_ArrayColumnType.kt
@@ -597,7 +597,7 @@ class Ex05_ArrayColumnType: AbstractExposedTest() {
             /**
              * ```sql
              * -- Postgres
-             * INSERT INTO array_test_table (byte_array) VALUES (ARRAY[ ,])
+             * INSERT INTO array_test_table (byte_array) VALUES (ARRAY[,])
              * ```
              */
             val testByteArrayList = listOf(byteArrayOf(0), byteArrayOf(1, 2, 3))

--- a/05-exposed-dml/02-types/src/test/kotlin/exposed/examples/types/Ex07_UnsignedColumnType.kt
+++ b/05-exposed-dml/02-types/src/test/kotlin/exposed/examples/types/Ex07_UnsignedColumnType.kt
@@ -8,7 +8,6 @@ import exposed.shared.tests.withDb
 import exposed.shared.tests.withTables
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeInRange
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContainSame
 import io.bluetape4k.assertions.shouldHaveSize

--- a/06-advanced/03-exposed-kotlin-datetime/src/test/kotlin/exposed/examples/kotlin/datetime/KotlinTimeAssertions.kt
+++ b/06-advanced/03-exposed-kotlin-datetime/src/test/kotlin/exposed/examples/kotlin/datetime/KotlinTimeAssertions.kt
@@ -77,7 +77,7 @@ internal infix fun Int.shouldFractionalPartEqualTo(nano2: Int) {
         // milliseconds
         is OracleDialect                                    -> nano1.nanoRoundToMilli() shouldBeEqualTo nano2.nanoRoundToMilli()
         is SQLiteDialect                                    -> nano1.nanoFloorToMilli() shouldBeEqualTo nano2.nanoFloorToMilli()
-        else                                                -> org.amshove.kluent.fail("Unknown dialect $db")
+        else                                                -> io.bluetape4k.assertions.fail("Unknown dialect $db")
     }
 }
 


### PR DESCRIPTION
## Summary
- finish remaining workshop test cleanup after develop sync
- remove stale Kluent reference in Kotlin time assertion helper
- keep the current develop-side assertion helper usage

## Validation
- git diff --check origin/develop...HEAD
- ./gradlew help --no-daemon