### PR TITLE
chore: Redisson을 projects 기준선으로 정렬

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,13 @@ updates:
       - dependency-name: "org.springframework.boot:*"
         update-types:
           - "version-update:semver-major"
+      # Redis client major baselines follow bluetape4k-projects after validation.
+      - dependency-name: "io.lettuce:lettuce-core"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "org.redisson:*"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "develop"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ r2dbc-pool = "1.0.2.RELEASE"
 r2dbc-postgresql = "1.1.1.RELEASE"
 
 lettuce = "6.8.2.RELEASE"
-redisson = "4.3.0"
+redisson = "4.3.1"
 
 hibernate = "7.3.3.Final"
 hibernate-reactive = "4.3.3.Final"


### PR DESCRIPTION
## 요약
- Redisson을 `bluetape4k-projects` 기준선인 4.3.1로 맞췄습니다.
- Redis client major 업데이트는 `bluetape4k-projects`에서 먼저 검증하도록 Dependabot guard를 추가했습니다.

## 검증
- Ruby YAML parse 통과
- 중앙 version drift report에서 Redisson 4.3.1 정렬 확인
- git diff --check