### PR TITLE
Align workshop with exposed artifactId rename

### DIFF
--- a/00-shared/exposed-shared-tests/build.gradle.kts
+++ b/00-shared/exposed-shared-tests/build.gradle.kts
@@ -3,25 +3,25 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     // Bluetape4k Exposed
-    api(libs.bluetape4k.exposed.core)
-    api(libs.bluetape4k.exposed.dao)
-    api(libs.bluetape4k.exposed.jdbc)
-    implementation(libs.bluetape4k.exposed.jackson2)
-    implementation(libs.bluetape4k.exposed.fastjson2)
-
-    // Exposed
     api(libs.exposed.core)
     api(libs.exposed.dao)
     api(libs.exposed.jdbc)
-    implementation(libs.exposed.java.time)
-    implementation(libs.exposed.crypt)
-    implementation(libs.exposed.json)
-    implementation(libs.exposed.migration.jdbc)
-    implementation(libs.exposed.money)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.exposed.jackson2)
+    implementation(libs.exposed.fastjson2)
+
+    // Exposed
+    api(libs.jetbrains.exposed.core)
+    api(libs.jetbrains.exposed.dao)
+    api(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.crypt)
+    implementation(libs.jetbrains.exposed.json)
+    implementation(libs.jetbrains.exposed.migration.jdbc)
+    implementation(libs.jetbrains.exposed.money)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.junit5)

--- a/01-spring-boot/spring-mvc-exposed/build.gradle.kts
+++ b/01-spring-boot/spring-mvc-exposed/build.gradle.kts
@@ -25,15 +25,15 @@ dependencies {
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.java.time)
-    implementation(libs.exposed.migration.jdbc)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.migration.jdbc)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     // bluetape4k
-    implementation(libs.bluetape4k.exposed.core)
+    implementation(libs.exposed.core)
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.testcontainers)

--- a/01-spring-boot/spring-webflux-exposed/build.gradle.kts
+++ b/01-spring-boot/spring-webflux-exposed/build.gradle.kts
@@ -26,13 +26,13 @@ dependencies {
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.java.time)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     // bluetape4k
-    implementation(libs.bluetape4k.exposed.core)
+    implementation(libs.exposed.core)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.jdbc)

--- a/03-exposed-basic/exposed-dao-example/build.gradle.kts
+++ b/03-exposed-basic/exposed-dao-example/build.gradle.kts
@@ -3,13 +3,13 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
     testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.testcontainers)

--- a/03-exposed-basic/exposed-sql-example/build.gradle.kts
+++ b/03-exposed-basic/exposed-sql-example/build.gradle.kts
@@ -3,13 +3,13 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.jdbc)
     testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/04-exposed-ddl/01-connection/build.gradle.kts
+++ b/04-exposed-ddl/01-connection/build.gradle.kts
@@ -3,15 +3,15 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.dao)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
 
-    implementation(libs.bluetape4k.exposed.core)
+    implementation(libs.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testImplementation(libs.bluetape4k.testcontainers)

--- a/04-exposed-ddl/02-ddl/build.gradle.kts
+++ b/04-exposed-ddl/02-ddl/build.gradle.kts
@@ -3,16 +3,16 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.migration.jdbc)
+    implementation(libs.jetbrains.exposed.java.time)
     implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.migration.jdbc)
-    implementation(libs.exposed.java.time)
-    implementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/05-exposed-dml/01-dml/build.gradle.kts
+++ b/05-exposed-dml/01-dml/build.gradle.kts
@@ -3,15 +3,15 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.java.time)
     testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.java.time)
-    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.jdbc)
     testImplementation(libs.bluetape4k.idgenerators)

--- a/05-exposed-dml/02-types/build.gradle.kts
+++ b/05-exposed-dml/02-types/build.gradle.kts
@@ -3,15 +3,15 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
 
-    testImplementation(libs.bluetape4k.exposed.core)
+    testImplementation(libs.exposed.core)
     testImplementation(libs.bluetape4k.idgenerators)
 
     testImplementation(libs.bluetape4k.junit5)

--- a/05-exposed-dml/03-functions/build.gradle.kts
+++ b/05-exposed-dml/03-functions/build.gradle.kts
@@ -3,15 +3,15 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
 
-    testImplementation(libs.bluetape4k.exposed.core)
+    testImplementation(libs.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/05-exposed-dml/04-transactions/build.gradle.kts
+++ b/05-exposed-dml/04-transactions/build.gradle.kts
@@ -3,14 +3,14 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
     testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/05-exposed-dml/05-entities/build.gradle.kts
+++ b/05-exposed-dml/05-entities/build.gradle.kts
@@ -3,16 +3,16 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.migration.jdbc)
+    testImplementation(libs.jetbrains.exposed.java.time)
     testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.exposed.migration.jdbc)
-    testImplementation(libs.exposed.java.time)
-    testImplementation(libs.bluetape4k.exposed.core)
 
     testImplementation(libs.bluetape4k.idgenerators)
     testImplementation(libs.bluetape4k.junit5)

--- a/06-advanced/01-exposed-crypt/build.gradle.kts
+++ b/06-advanced/01-exposed-crypt/build.gradle.kts
@@ -3,19 +3,19 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
 
     testImplementation(project(":exposed-shared-tests"))
 
-    testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
 
     // 암호화 관련 라이브러리
-    implementation(libs.exposed.crypt)
+    implementation(libs.jetbrains.exposed.crypt)
 
-    testImplementation(libs.bluetape4k.exposed.core)
+    testImplementation(libs.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testImplementation(libs.bluetape4k.testcontainers)

--- a/06-advanced/02-exposed-javatime/build.gradle.kts
+++ b/06-advanced/02-exposed-javatime/build.gradle.kts
@@ -7,25 +7,25 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.exposed.core)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.migration.jdbc)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.migration.jdbc)
 
     // java time 지원 라이브러리
-    implementation(libs.exposed.java.time)
+    implementation(libs.jetbrains.exposed.java.time)
 
     // Kotlin Serialization Json
-    implementation(libs.exposed.json)
+    implementation(libs.jetbrains.exposed.json)
     implementation(platform(libs.kotlinx.serialization.bom))
     implementation(libs.kotlinx.serialization.json)
 
-    testImplementation(libs.bluetape4k.exposed.core)
+    testImplementation(libs.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testImplementation(libs.bluetape4k.testcontainers)

--- a/06-advanced/03-exposed-kotlin-datetime/build.gradle.kts
+++ b/06-advanced/03-exposed-kotlin-datetime/build.gradle.kts
@@ -7,24 +7,24 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.exposed.json)
-    testImplementation(libs.exposed.migration.jdbc)
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.json)
+    testImplementation(libs.jetbrains.exposed.migration.jdbc)
 
     // java time 지원 라이브러리
-    testImplementation(libs.exposed.kotlin.datetime)
+    testImplementation(libs.jetbrains.exposed.kotlin.datetime)
 
     // Kotlin Serialization Json
     testImplementation(platform(libs.kotlinx.serialization.bom))
     testImplementation(libs.kotlinx.serialization.json)
 
-    testImplementation(libs.bluetape4k.exposed.core)
+    testImplementation(libs.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testImplementation(libs.bluetape4k.testcontainers)

--- a/06-advanced/04-exposed-json/build.gradle.kts
+++ b/06-advanced/04-exposed-json/build.gradle.kts
@@ -7,23 +7,23 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.exposed.migration.jdbc)
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.migration.jdbc)
 
     // Exposed Json 지원 라이브러리 (kotlinx.serialization 을 사용합니다)
-    testImplementation(libs.exposed.json)
+    testImplementation(libs.jetbrains.exposed.json)
 
     // Kotlin Serialization Json
     testImplementation(platform(libs.kotlinx.serialization.bom))
     testImplementation(libs.kotlinx.serialization.json)
 
-    testImplementation(libs.bluetape4k.exposed.core)
+    testImplementation(libs.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testImplementation(libs.bluetape4k.testcontainers)

--- a/06-advanced/05-exposed-money/build.gradle.kts
+++ b/06-advanced/05-exposed-money/build.gradle.kts
@@ -7,17 +7,17 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
     testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.bluetape4k.exposed.core)
 
     // Money
-    testImplementation(libs.exposed.money)
+    testImplementation(libs.jetbrains.exposed.money)
     testImplementation(libs.javax.money.api)
     testImplementation(libs.javamoney.moneta)
     testImplementation(libs.bluetape4k.money)

--- a/06-advanced/06-custom-columns/build.gradle.kts
+++ b/06-advanced/06-custom-columns/build.gradle.kts
@@ -3,14 +3,14 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.dao)
     testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.bluetape4k.exposed.core)
 
     implementation(libs.bluetape4k.io)
 

--- a/06-advanced/07-custom-entities/build.gradle.kts
+++ b/06-advanced/07-custom-entities/build.gradle.kts
@@ -7,14 +7,14 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.dao)
     testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.bluetape4k.exposed.core)
 
     // Id Generators
     // - Snowflake

--- a/06-advanced/08-exposed-jackson/build.gradle.kts
+++ b/06-advanced/08-exposed-jackson/build.gradle.kts
@@ -3,18 +3,18 @@ configurations {
 }
 
 dependencies {
-    testImplementation(platform(libs.exposed.bom))
+    testImplementation(platform(libs.jetbrains.exposed.bom))
     testImplementation(platform(libs.bluetape4k.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.exposed.migration.jdbc)
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.migration.jdbc)
 
-    testImplementation(libs.bluetape4k.exposed.core)
-    testImplementation(libs.bluetape4k.exposed.jackson2)
+    testImplementation(libs.exposed.core)
+    testImplementation(libs.exposed.jackson2)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/06-advanced/09-exposed-fastjson2/build.gradle.kts
+++ b/06-advanced/09-exposed-fastjson2/build.gradle.kts
@@ -3,18 +3,18 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
     implementation(platform(libs.bluetape4k.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.exposed.migration.jdbc)
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.migration.jdbc)
 
-    testImplementation(libs.bluetape4k.exposed.core)
-    testImplementation(libs.bluetape4k.exposed.fastjson2)
+    testImplementation(libs.exposed.core)
+    testImplementation(libs.exposed.fastjson2)
     testImplementation(libs.bluetape4k.junit5)
 
     testRuntimeOnly(libs.h2.v2)

--- a/06-advanced/11-exposed-jackson3/build.gradle.kts
+++ b/06-advanced/11-exposed-jackson3/build.gradle.kts
@@ -3,18 +3,18 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
     implementation(platform(libs.bluetape4k.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.exposed.migration.jdbc)
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.migration.jdbc)
 
-    testImplementation(libs.bluetape4k.exposed.core)
-    testImplementation(libs.bluetape4k.exposed.jackson3)
+    testImplementation(libs.exposed.core)
+    testImplementation(libs.exposed.jackson3)
 
     // Jackson 3
     testImplementation(libs.bluetape4k.jackson3)

--- a/06-advanced/12-exposed-tink/README.ko.md
+++ b/06-advanced/12-exposed-tink/README.ko.md
@@ -6,12 +6,12 @@ Google Tink 라이브러리를 활용하여 Exposed 컬럼 데이터를 투명�
 
 ## 개요
 
-`bluetape4k-exposed-tink`가 제공하는 확장 함수로 컬럼을 선언하면, INSERT 시 자동 암호화, SELECT 시 자동 복호화가 이루어집니다. Google Tink의 표준 AEAD 인터페이스를 기반으로 하여 무결성 검증(인증 태그)도 함께 수행합니다.
+`exposed-tink`가 제공하는 확장 함수로 컬럼을 선언하면, INSERT 시 자동 암호화, SELECT 시 자동 복호화가 이루어집니다. Google Tink의 표준 AEAD 인터페이스를 기반으로 하여 무결성 검증(인증 태그)도 함께 수행합니다.
 
 ## 학습 목표
 
 - Google Tink의 AEAD와 DAEAD 차이를 이해한다.
-- `bluetape4k-exposed-tink` 확장 함수로 암호화 컬럼을 선언한다.
+- `exposed-tink` 확장 함수로 암호화 컬럼을 선언한다.
 - DSL/DAO 양쪽에서 암호화 컬럼을 사용한다.
 - DAEAD 컬럼으로 암호화된 상태에서 WHERE 절 검색을 수행한다.
 

--- a/06-advanced/12-exposed-tink/README.md
+++ b/06-advanced/12-exposed-tink/README.md
@@ -6,12 +6,12 @@ A module that uses the Google Tink library to transparently encrypt and decrypt 
 
 ## Overview
 
-Declaring a column with extension functions provided by `bluetape4k-exposed-tink` enables automatic encryption on INSERT and automatic decryption on SELECT. Built on Google Tink's standard AEAD interface, it also performs integrity verification via authentication tags.
+Declaring a column with extension functions provided by `exposed-tink` enables automatic encryption on INSERT and automatic decryption on SELECT. Built on Google Tink's standard AEAD interface, it also performs integrity verification via authentication tags.
 
 ## Learning Objectives
 
 - Understand the difference between AEAD and DAEAD in Google Tink.
-- Declare encrypted columns using `bluetape4k-exposed-tink` extension functions.
+- Declare encrypted columns using `exposed-tink` extension functions.
 - Use encrypted columns in both DSL and DAO styles.
 - Perform WHERE clause searches on DAEAD columns while data remains encrypted.
 

--- a/06-advanced/12-exposed-tink/build.gradle.kts
+++ b/06-advanced/12-exposed-tink/build.gradle.kts
@@ -3,17 +3,17 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
     implementation(platform(libs.bluetape4k.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
 
-    testImplementation(libs.bluetape4k.exposed.jdbc)
-    testImplementation(libs.bluetape4k.exposed.tink)
+    testImplementation(libs.exposed.jdbc)
+    testImplementation(libs.exposed.tink)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/07-jpa/01-convert-jpa-basic/build.gradle.kts
+++ b/07-jpa/01-convert-jpa-basic/build.gradle.kts
@@ -7,20 +7,20 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.java.time)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.java.time)
 
     // Validator
     implementation(libs.jakarta.validation.api)
     implementation(libs.hibernate.validator)
 
-    testImplementation(libs.bluetape4k.exposed.core)
+    testImplementation(libs.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/07-jpa/02-convert-jpa-advanced/build.gradle.kts
+++ b/07-jpa/02-convert-jpa-advanced/build.gradle.kts
@@ -3,16 +3,16 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.jdbc)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.java.time)
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.java.time)
 
-    testImplementation(libs.bluetape4k.exposed.core)
+    testImplementation(libs.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/08-coroutines/01-coroutines-basic/build.gradle.kts
+++ b/08-coroutines/01-coroutines-basic/build.gradle.kts
@@ -3,15 +3,15 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
 
-    testImplementation(libs.bluetape4k.exposed.core)
+    testImplementation(libs.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testRuntimeOnly(libs.h2.v2)

--- a/08-coroutines/02-virtualthreads-basic/build.gradle.kts
+++ b/08-coroutines/02-virtualthreads-basic/build.gradle.kts
@@ -3,18 +3,18 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
-    testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.jdbc)
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.jdbc)
 
     // Java 21 에서 Virtual Thread 를 사용할 때 (Java 25 에서는 jdk25 를 사용하세요)
     testRuntimeOnly(libs.bluetape4k.virtualthread.jdk21)
 
-    testImplementation(libs.bluetape4k.exposed.core)
+    testImplementation(libs.exposed.core)
     testImplementation(libs.bluetape4k.junit5)
 
     testRuntimeOnly(libs.h2.v2)

--- a/09-spring/01-springboot-autoconfigure/build.gradle.kts
+++ b/09-spring/01-springboot-autoconfigure/build.gradle.kts
@@ -9,17 +9,17 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    testImplementation(libs.exposed.core)
-    testImplementation(libs.exposed.dao)
-    testImplementation(libs.exposed.java.time)
-    testImplementation(libs.exposed.spring.boot.starter)
+    testImplementation(libs.jetbrains.exposed.core)
+    testImplementation(libs.jetbrains.exposed.dao)
+    testImplementation(libs.jetbrains.exposed.java.time)
+    testImplementation(libs.jetbrains.exposed.spring.boot.starter)
 
-    testImplementation(libs.bluetape4k.exposed.core)
+    testImplementation(libs.exposed.core)
 
     testImplementation(libs.bluetape4k.junit5)
 

--- a/09-spring/02-transactiontemplate/build.gradle.kts
+++ b/09-spring/02-transactiontemplate/build.gradle.kts
@@ -10,17 +10,17 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     // Bluetape4k
-    implementation(libs.bluetape4k.exposed.core)
+    implementation(libs.exposed.core)
     implementation(libs.bluetape4k.io)
     testImplementation(libs.bluetape4k.junit5)
 

--- a/09-spring/03-spring-transaction/build.gradle.kts
+++ b/09-spring/03-spring-transaction/build.gradle.kts
@@ -10,18 +10,18 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     // Bluetape4k
-    implementation(libs.bluetape4k.exposed.core)
+    implementation(libs.exposed.core)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.spring.boot4.core)

--- a/09-spring/04-exposed-repository/build.gradle.kts
+++ b/09-spring/04-exposed-repository/build.gradle.kts
@@ -24,15 +24,15 @@ dependencies {
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.java.time)
-    implementation(libs.exposed.migration.jdbc)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.migration.jdbc)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     // Bluetape4k
-    implementation(libs.bluetape4k.exposed.core)
+    implementation(libs.exposed.core)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.testcontainers)

--- a/09-spring/05-exposed-repository-coroutines/build.gradle.kts
+++ b/09-spring/05-exposed-repository-coroutines/build.gradle.kts
@@ -26,15 +26,15 @@ dependencies {
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.java.time)
-    implementation(libs.exposed.migration.jdbc)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.migration.jdbc)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     // Bluetape4k
-    implementation(libs.bluetape4k.exposed.core)
+    implementation(libs.exposed.core)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.testcontainers)

--- a/09-spring/06-spring-cache/build.gradle.kts
+++ b/09-spring/06-spring-cache/build.gradle.kts
@@ -23,20 +23,20 @@ configurations {
 
 dependencies {
 
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
     testImplementation(project(":exposed-shared-tests"))
 
 
     // Exposed
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.java.time)
-    implementation(libs.exposed.migration.jdbc)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.migration.jdbc)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     // Bluetape4k
-    implementation(libs.bluetape4k.exposed.jdbc)
+    implementation(libs.exposed.jdbc)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.redis)

--- a/09-spring/07-spring-suspended-cache/build.gradle.kts
+++ b/09-spring/07-spring-suspended-cache/build.gradle.kts
@@ -31,13 +31,13 @@ dependencies {
     implementation(libs.bluetape4k.redis)
     implementation(libs.bluetape4k.testcontainers)
     // Exposed
-    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.java.time)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.java.time)
     testImplementation(libs.bluetape4k.junit5)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     // Database Drivers
     implementation(libs.hikaricp)

--- a/10-multi-tenant/01-multitenant-spring-web/build.gradle.kts
+++ b/10-multi-tenant/01-multitenant-spring-web/build.gradle.kts
@@ -25,13 +25,13 @@ dependencies {
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.java.time)
-    implementation(libs.exposed.migration.jdbc)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.migration.jdbc)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     // bluetape4k
     implementation(libs.bluetape4k.io)

--- a/10-multi-tenant/02-multitenant-spring-web-virtualthread/build.gradle.kts
+++ b/10-multi-tenant/02-multitenant-spring-web-virtualthread/build.gradle.kts
@@ -24,13 +24,13 @@ dependencies {
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    implementation(libs.bluetape4k.exposed.core)
     implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.java.time)
-    implementation(libs.exposed.migration.jdbc)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.migration.jdbc)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     // bluetape4k
     implementation(libs.bluetape4k.io)

--- a/10-multi-tenant/03-multitenant-spring-webflux/build.gradle.kts
+++ b/10-multi-tenant/03-multitenant-spring-webflux/build.gradle.kts
@@ -26,15 +26,15 @@ dependencies {
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.java.time)
-    implementation(libs.exposed.migration.jdbc)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.migration.jdbc)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     // bluetape4k
-    implementation(libs.bluetape4k.exposed.core)
+    implementation(libs.exposed.core)
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.testcontainers)

--- a/11-high-performance/01-cache-strategies/build.gradle.kts
+++ b/11-high-performance/01-cache-strategies/build.gradle.kts
@@ -24,19 +24,19 @@ configurations {
 
 dependencies {
 
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.java.time)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     // bluetape4k
-    implementation(libs.bluetape4k.exposed.core)
-    implementation(libs.bluetape4k.exposed.jdbc.redisson)
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.jdbc.redisson)
     implementation(libs.bluetape4k.idgenerators)
     implementation(libs.bluetape4k.redis)
     implementation(libs.bluetape4k.testcontainers)

--- a/11-high-performance/02-cache-strategies-coroutines/build.gradle.kts
+++ b/11-high-performance/02-cache-strategies-coroutines/build.gradle.kts
@@ -23,19 +23,19 @@ configurations {
 
 dependencies {
 
-    implementation(platform(libs.exposed.bom))
+    implementation(platform(libs.jetbrains.exposed.bom))
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.java.time)
-    implementation(libs.exposed.spring.boot.starter)
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.java.time)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
 
     // bluetape4k
-    implementation(libs.bluetape4k.exposed.core)
-    implementation(libs.bluetape4k.exposed.jdbc.redisson)
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.jdbc.redisson)
     implementation(libs.bluetape4k.idgenerators)
     implementation(libs.bluetape4k.redis)
     implementation(libs.bluetape4k.testcontainers)

--- a/11-high-performance/03-routing-datasource/build.gradle.kts
+++ b/11-high-performance/03-routing-datasource/build.gradle.kts
@@ -26,9 +26,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 
-    implementation(platform(libs.exposed.bom))
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
+    implementation(platform(libs.jetbrains.exposed.bom))
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
 
     runtimeOnly(libs.h2.v2)
     implementation(libs.hikaricp)

--- a/11-high-performance/04-benchmark/build.gradle.kts
+++ b/11-high-performance/04-benchmark/build.gradle.kts
@@ -15,11 +15,11 @@ dependencies {
     implementation(libs.jmh.core)
 
     // Exposed
-    implementation(platform(libs.exposed.bom))
-    implementation(libs.exposed.core)
-    implementation(libs.exposed.jdbc)
-    implementation(libs.exposed.dao)
-    implementation(libs.exposed.java.time)
+    implementation(platform(libs.jetbrains.exposed.bom))
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.dao)
+    implementation(libs.jetbrains.exposed.java.time)
 
     // JPA / Hibernate
     implementation(libs.jakarta.persistence.api)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -273,8 +273,8 @@ subprojects {
         // 개발 시에는 logback 이 검증하기에 더 좋고, Production에서 비동기 로깅은 log4j2 가 성능이 좋다고 합니다.
         implementation(rootLibs.slf4j.api)
         implementation(rootLibs.bluetape4k.logging)
-        implementation(rootLibs.bluetape4k.exposed.dao)
-        implementation(rootLibs.bluetape4k.exposed.jdbc)
+        implementation(rootLibs.exposed.dao)
+        implementation(rootLibs.exposed.jdbc)
         implementation(rootLibs.jackson3.module.kotlin)
         implementation(rootLibs.jackson3.module.blackbird)
         implementation(rootLibs.logback)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -127,15 +127,15 @@ bluetape4k-grpc = { module = "io.github.bluetape4k:bluetape4k-grpc" , version.re
 bluetape4k-jackson2 = { module = "io.github.bluetape4k:bluetape4k-jackson2" , version.ref = "bluetape4k" }
 bluetape4k-jackson3 = { module = "io.github.bluetape4k:bluetape4k-jackson3" , version.ref = "bluetape4k" }
 
-# bluetape4k exposed
-bluetape4k-exposed-core = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-core" , version.ref = "bluetape4k" }
-bluetape4k-exposed-dao = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-dao" , version.ref = "bluetape4k" }
-bluetape4k-exposed-fastjson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-fastjson2" , version.ref = "bluetape4k" }
-bluetape4k-exposed-jackson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson2" , version.ref = "bluetape4k" }
-bluetape4k-exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" , version.ref = "bluetape4k" }
-bluetape4k-exposed-jdbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc" , version.ref = "bluetape4k" }
-bluetape4k-exposed-jdbc-redisson = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-redisson" , version.ref = "bluetape4k" }
-bluetape4k-exposed-tink = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-tink" , version.ref = "bluetape4k" }
+# exposed
+exposed-core = { module = "io.github.bluetape4k.exposed:exposed-core" , version.ref = "bluetape4k" }
+exposed-dao = { module = "io.github.bluetape4k.exposed:exposed-dao" , version.ref = "bluetape4k" }
+exposed-fastjson2 = { module = "io.github.bluetape4k.exposed:exposed-fastjson2" , version.ref = "bluetape4k" }
+exposed-jackson2 = { module = "io.github.bluetape4k.exposed:exposed-jackson2" , version.ref = "bluetape4k" }
+exposed-jackson3 = { module = "io.github.bluetape4k.exposed:exposed-jackson3" , version.ref = "bluetape4k" }
+exposed-jdbc = { module = "io.github.bluetape4k.exposed:exposed-jdbc" , version.ref = "bluetape4k" }
+exposed-jdbc-redisson = { module = "io.github.bluetape4k.exposed:exposed-jdbc-redisson" , version.ref = "bluetape4k" }
+exposed-tink = { module = "io.github.bluetape4k.exposed:exposed-tink" , version.ref = "bluetape4k" }
 
 # bluetape4k hibernate
 bluetape4k-hibernate-reactive = { module = "io.github.bluetape4k:bluetape4k-hibernate-reactive" , version.ref = "bluetape4k" }
@@ -216,18 +216,18 @@ reactor-test = { module = "io.projectreactor:reactor-test" }
 # Netty
 netty-bom = { module = "io.netty:netty-bom", version.ref = "netty" }
 
-# Exposed
-exposed-bom = { module = "org.jetbrains.exposed:exposed-bom", version.ref = "exposed" }
-exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
-exposed-crypt = { module = "org.jetbrains.exposed:exposed-crypt", version.ref = "exposed" }
-exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
-exposed-java-time = { module = "org.jetbrains.exposed:exposed-java-time", version.ref = "exposed" }
-exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
-exposed-json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "exposed" }
-exposed-kotlin-datetime = { module = "org.jetbrains.exposed:exposed-kotlin-datetime", version.ref = "exposed" }
-exposed-migration-jdbc = { module = "org.jetbrains.exposed:exposed-migration-jdbc", version.ref = "exposed" }
-exposed-money = { module = "org.jetbrains.exposed:exposed-money", version.ref = "exposed" }
-exposed-spring-boot-starter = { module = "org.jetbrains.exposed:exposed-spring-boot-starter", version.ref = "exposed" }
+# JetBrains Exposed
+jetbrains-exposed-bom = { module = "org.jetbrains.exposed:exposed-bom", version.ref = "exposed" }
+jetbrains-exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
+jetbrains-exposed-crypt = { module = "org.jetbrains.exposed:exposed-crypt", version.ref = "exposed" }
+jetbrains-exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
+jetbrains-exposed-java-time = { module = "org.jetbrains.exposed:exposed-java-time", version.ref = "exposed" }
+jetbrains-exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
+jetbrains-exposed-json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "exposed" }
+jetbrains-exposed-kotlin-datetime = { module = "org.jetbrains.exposed:exposed-kotlin-datetime", version.ref = "exposed" }
+jetbrains-exposed-migration-jdbc = { module = "org.jetbrains.exposed:exposed-migration-jdbc", version.ref = "exposed" }
+jetbrains-exposed-money = { module = "org.jetbrains.exposed:exposed-money", version.ref = "exposed" }
+jetbrains-exposed-spring-boot-starter = { module = "org.jetbrains.exposed:exposed-spring-boot-starter", version.ref = "exposed" }
 
 # Micrometer
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }


### PR DESCRIPTION
## Context\n\nFollows bluetape4k/bluetape4k-exposed#77 after exposed and dependencies snapshots were published.\n\n## Changes\n\n- Update bluetape4k Exposed coordinates/accessors to the new exposed-* artifactIds.\n- Move JetBrains Exposed catalog aliases under libs.jetbrains.exposed.* to avoid accessor collisions.\n- Keep Kotlin package imports io.bluetape4k.exposed unchanged.\n- Refresh current Tink README references.\n\n## Verification\n\n- ./gradlew :12-exposed-tink:test\n- rg old artifact/accessor patterns over Gradle/catalog/README files\n- git diff --check\n\nRefs bluetape4k/bluetape4k-exposed#77