### PR TITLE
chore: update bluetape4k artifact IDs to standardized convention

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -128,14 +128,14 @@ bluetape4k-jackson2 = { module = "io.github.bluetape4k:bluetape4k-jackson2" , ve
 bluetape4k-jackson3 = { module = "io.github.bluetape4k:bluetape4k-jackson3" , version.ref = "bluetape4k" }
 
 # exposed
-exposed-core = { module = "io.github.bluetape4k.exposed:exposed-core" , version.ref = "bluetape4k" }
-exposed-dao = { module = "io.github.bluetape4k.exposed:exposed-dao" , version.ref = "bluetape4k" }
-exposed-fastjson2 = { module = "io.github.bluetape4k.exposed:exposed-fastjson2" , version.ref = "bluetape4k" }
-exposed-jackson2 = { module = "io.github.bluetape4k.exposed:exposed-jackson2" , version.ref = "bluetape4k" }
-exposed-jackson3 = { module = "io.github.bluetape4k.exposed:exposed-jackson3" , version.ref = "bluetape4k" }
-exposed-jdbc = { module = "io.github.bluetape4k.exposed:exposed-jdbc" , version.ref = "bluetape4k" }
-exposed-jdbc-redisson = { module = "io.github.bluetape4k.exposed:exposed-jdbc-redisson" , version.ref = "bluetape4k" }
-exposed-tink = { module = "io.github.bluetape4k.exposed:exposed-tink" , version.ref = "bluetape4k" }
+exposed-core = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-core" , version.ref = "bluetape4k" }
+exposed-dao = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-dao" , version.ref = "bluetape4k" }
+exposed-fastjson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-fastjson2" , version.ref = "bluetape4k" }
+exposed-jackson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson2" , version.ref = "bluetape4k" }
+exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" , version.ref = "bluetape4k" }
+exposed-jdbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc" , version.ref = "bluetape4k" }
+exposed-jdbc-redisson = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-redisson" , version.ref = "bluetape4k" }
+exposed-tink = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-tink" , version.ref = "bluetape4k" }
 
 # bluetape4k hibernate
 bluetape4k-hibernate-reactive = { module = "io.github.bluetape4k:bluetape4k-hibernate-reactive" , version.ref = "bluetape4k" }


### PR DESCRIPTION
Update `gradle/libs.versions.toml` to use the new standardized artifact IDs.

## Changes
- `io.github.bluetape4k.exposed:exposed-*` → `bluetape4k-exposed-*`
- `io.github.bluetape4k.leader:leader-*` → `bluetape4k-leader-*`

## Reason
`bluetape4k-exposed` PR #132 and `bluetape4k-leader` PR #291 standardized all module artifact IDs to the `bluetape4k-<repo>-<module>` convention. This PR aligns dependencies accordingly.