### PR TITLE
feat: add Ktor architecture baseline example

### DIFF
--- a/12-production-integration/01-ktor-application-architecture/README.ko.md
+++ b/12-production-integration/01-ktor-application-architecture/README.ko.md
@@ -1,0 +1,56 @@
+# Ktor 애플리케이션 아키텍처
+
+[English](./README.md) | 한국어
+
+이 모듈은 12장의 첫 Ktor 예제입니다. 범위는 작게 유지합니다. Ktor route,
+JSON, 오류 매핑, service 경계, H2 기반 Exposed JDBC repository만 다룹니다.
+
+## 아키텍처
+
+```mermaid
+flowchart LR
+    Client[HTTP client] --> Routes[Ktor routes]
+    Routes --> Service[CustomerService]
+    Service --> Repository[CustomerRepository]
+    Repository --> IO[Dispatchers.IO transaction boundary]
+    IO --> Exposed[Exposed JDBC]
+    Exposed --> H2[(H2)]
+```
+
+## 학습 목표
+
+- Spring 인프라 없이 Ktor 애플리케이션을 조립합니다.
+- route는 얇게 유지하고 validation은 service 계층으로 둡니다.
+- blocking Exposed JDBC 작업은 repository가 소유한 `Dispatchers.IO` 경계 안에 둡니다.
+- validation, not-found, malformed JSON, oversized body, fallback 오류를 Ktor
+  `StatusPages`로 매핑합니다.
+- Ktor `testApplication`으로 route를 검증합니다.
+
+## 실행
+
+```bash
+./gradlew :01-ktor-application-architecture:run
+```
+
+```bash
+curl -X POST http://localhost:8080/customers \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Alice","email":"alice@example.com"}'
+```
+
+## 테스트
+
+```bash
+./gradlew :01-ktor-application-architecture:test
+```
+
+## 경계
+
+이 모듈은 blocking `exposed-workshop` 축과 맞추기 위해 Exposed JDBC를 사용합니다.
+blocking transaction은 `Dispatchers.IO`로 감쌉니다. non-blocking persistence는
+대응되는 R2DBC workshop 예제를 사용합니다.
+
+이 예제는 전체 production service가 아니라 architecture baseline입니다. 인증,
+인가, migration tooling, 외부 observability sink는 포함하지 않습니다. 서버 JSON
+응답은 compact JSON을 사용하고, fallback 500 응답은 sanitize하며, 예상하지 못한
+실패는 응답 전에 로그로 남깁니다.

--- a/12-production-integration/01-ktor-application-architecture/README.md
+++ b/12-production-integration/01-ktor-application-architecture/README.md
@@ -1,0 +1,59 @@
+# Ktor Application Architecture
+
+English | [한국어](./README.ko.md)
+
+This module is the first Ktor example for chapter 12. It keeps the surface small:
+Ktor routes, JSON, error mapping, a service boundary, and an Exposed JDBC
+repository backed by H2.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Client[HTTP client] --> Routes[Ktor routes]
+    Routes --> Service[CustomerService]
+    Service --> Repository[CustomerRepository]
+    Repository --> IO[Dispatchers.IO transaction boundary]
+    IO --> Exposed[Exposed JDBC]
+    Exposed --> H2[(H2)]
+```
+
+## Learning Goals
+
+- Compose a Ktor application without Spring infrastructure.
+- Keep routes thin and move validation into the service layer.
+- Keep blocking Exposed JDBC work behind a repository-owned `Dispatchers.IO`
+  boundary.
+- Map validation, not-found, malformed JSON, oversized body, and fallback errors
+  through Ktor `StatusPages`.
+- Verify routes with Ktor `testApplication`.
+
+## Run
+
+```bash
+./gradlew :01-ktor-application-architecture:run
+```
+
+```bash
+curl -X POST http://localhost:8080/customers \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Alice","email":"alice@example.com"}'
+```
+
+## Test
+
+```bash
+./gradlew :01-ktor-application-architecture:test
+```
+
+## Boundary Note
+
+This module intentionally uses Exposed JDBC so it can mirror the blocking
+`exposed-workshop` stack. Blocking transactions are wrapped in `Dispatchers.IO`.
+For non-blocking persistence, use the matching R2DBC workshop examples.
+
+This is an architecture baseline, not a complete production service. It does
+not include authentication, authorization, migration tooling, or external
+observability sinks. Server JSON responses use compact JSON, fallback 500
+responses are sanitized, and unexpected failures are logged before the response
+is returned.

--- a/12-production-integration/01-ktor-application-architecture/build.gradle.kts
+++ b/12-production-integration/01-ktor-application-architecture/build.gradle.kts
@@ -1,0 +1,35 @@
+plugins {
+    application
+    alias(libs.plugins.kotlin.serialization)
+}
+
+application {
+    mainClass.set("exposed.examples.ktor.architecture.KtorArchitectureApplicationKt")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    implementation(platform(libs.jetbrains.exposed.bom))
+
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.cio)
+    implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.server.status.pages)
+    implementation(libs.ktor.server.call.logging)
+    implementation(libs.ktor.server.call.id)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.kotlinx.serialization.json)
+
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.hikaricp)
+
+    runtimeOnly(libs.h2.v2)
+
+    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/KtorArchitectureApplication.kt
+++ b/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/KtorArchitectureApplication.kt
@@ -1,0 +1,480 @@
+package exposed.examples.ktor.architecture
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.error
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStopped
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.callid.CallId
+import io.ktor.server.plugins.callid.callId
+import io.ktor.server.plugins.callid.callIdMdc
+import io.ktor.server.plugins.callid.generate
+import io.ktor.server.plugins.calllogging.CallLogging
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.request.header
+import io.ktor.server.request.receiveChannel
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.utils.io.readAvailable
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.io.ByteArrayOutputStream
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+
+private const val DEFAULT_PORT = 8080
+private const val MAX_REQUEST_BODY_BYTES = 64 * 1024L
+private const val REQUEST_BODY_BUFFER_BYTES = 8 * 1024
+private const val HIKARI_MAX_POOL_SIZE = 4
+
+private val ApplicationJson = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+}
+
+private object KtorArchitectureLogger : KLogging()
+
+/**
+ * Starts the Ktor architecture example with an in-memory H2 database.
+ *
+ * ## Contract
+ * - The route layer stays thin and delegates to a service.
+ * - The repository owns every blocking Exposed JDBC transaction behind
+ *   `Dispatchers.IO`.
+ * - JSON errors are mapped to sanitized responses through `StatusPages`.
+ */
+fun main() {
+    embeddedServer(CIO, port = DEFAULT_PORT) {
+        ktorArchitectureModule()
+    }.start(wait = true)
+}
+
+/**
+ * Configures the Ktor + Exposed architecture example.
+ *
+ * The default persistence uses an in-memory H2 database for local execution.
+ * Tests pass a dedicated persistence instance with a unique JDBC URL per test.
+ */
+internal fun Application.ktorArchitectureModule(
+    persistence: CustomerPersistence = CustomerPersistence.inMemory(),
+) {
+    monitor.subscribe(ApplicationStopped) {
+        persistence.close()
+    }
+
+    installKtorPlugins()
+
+    val repository = ExposedCustomerRepository(persistence.database)
+    val service = CustomerService(repository)
+
+    routing {
+        get("/") {
+            call.respond(IndexResponse())
+        }
+        get("/health") {
+            call.respond(HealthResponse(status = "UP"))
+        }
+        customerRoutes(service)
+    }
+}
+
+private fun Application.installKtorPlugins() {
+    install(CallId) {
+        retrieveFromHeader(HttpHeaders.XRequestId)
+        generate { UUID.randomUUID().toString() }
+        replyToHeader(HttpHeaders.XRequestId)
+    }
+    install(CallLogging) {
+        callIdMdc("callId")
+    }
+    install(ContentNegotiation) {
+        json(ApplicationJson)
+    }
+    install(StatusPages) {
+        exception<PayloadTooLargeException> { call, _ ->
+            call.respond(
+                HttpStatusCode.PayloadTooLarge,
+                ErrorResponse(code = "PAYLOAD_TOO_LARGE", message = "Request body is too large")
+            )
+        }
+        exception<BadRequestException> { call, _ ->
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ErrorResponse(code = "BAD_REQUEST", message = "Malformed request body")
+            )
+        }
+        exception<CustomerValidationException> { call, cause ->
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ErrorResponse(code = "VALIDATION_FAILED", message = cause.message ?: "Invalid request")
+            )
+        }
+        exception<IllegalArgumentException> { call, _ ->
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ErrorResponse(code = "VALIDATION_FAILED", message = "Invalid request")
+            )
+        }
+        exception<NoSuchElementException> { call, cause ->
+            call.respond(
+                HttpStatusCode.NotFound,
+                ErrorResponse(code = "NOT_FOUND", message = cause.message ?: "Resource not found")
+            )
+        }
+        exception<Exception> { call, cause ->
+            if (cause is CancellationException) {
+                throw cause
+            }
+            KtorArchitectureLogger.log.error(cause) {
+                "Unhandled failure in Ktor architecture example"
+            }
+            call.respond(
+                HttpStatusCode.InternalServerError,
+                ErrorResponse(code = "INTERNAL_ERROR", message = "Internal server error")
+            )
+        }
+    }
+}
+
+/**
+ * Holds the JDBC resources owned by a Ktor application instance.
+ */
+internal class CustomerPersistence private constructor(
+    private val dataSource: HikariDataSource,
+) : AutoCloseable {
+
+    val database: Database = Database.connect(dataSource)
+
+    override fun close() {
+        dataSource.close()
+    }
+
+    companion object {
+        fun inMemory(name: String = "ktor_architecture_${UUID.randomUUID()}"): CustomerPersistence {
+            val config = HikariConfig().apply {
+                jdbcUrl = "jdbc:h2:mem:$name;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE"
+                username = "sa"
+                password = ""
+                driverClassName = "org.h2.Driver"
+                maximumPoolSize = HIKARI_MAX_POOL_SIZE
+                poolName = "ktor-architecture-$name"
+            }
+            return CustomerPersistence(HikariDataSource(config))
+        }
+    }
+}
+
+/**
+ * Customer persistence contract used by the service layer.
+ */
+internal interface CustomerRepository {
+    suspend fun create(command: CreateCustomerCommand): CustomerRecord
+    suspend fun findById(id: Long): CustomerRecord?
+    suspend fun findAll(): List<CustomerRecord>
+    suspend fun count(): Long
+}
+
+/**
+ * Exposed JDBC implementation that isolates blocking work on `Dispatchers.IO`.
+ */
+internal class ExposedCustomerRepository(
+    private val database: Database,
+) : CustomerRepository {
+
+    private val schemaReady = AtomicBoolean(false)
+    private val schemaMutex = Mutex()
+
+    override suspend fun create(command: CreateCustomerCommand): CustomerRecord {
+        ensureSchema()
+        return transactionIO {
+            val id = Customers.insertAndGetId {
+                it[name] = command.name
+                it[email] = command.email
+            }.value
+            CustomerRecord(id = id, name = command.name, email = command.email)
+        }
+    }
+
+    override suspend fun findById(id: Long): CustomerRecord? {
+        ensureSchema()
+        return transactionIO {
+            Customers
+                .selectAll()
+                .where { Customers.id eq id }
+                .singleOrNull()
+                ?.toRecord()
+        }
+    }
+
+    override suspend fun findAll(): List<CustomerRecord> {
+        ensureSchema()
+        return transactionIO {
+            Customers
+                .selectAll()
+                .orderBy(Customers.id)
+                .map { it.toRecord() }
+        }
+    }
+
+    override suspend fun count(): Long {
+        ensureSchema()
+        return transactionIO {
+            Customers.selectAll().count()
+        }
+    }
+
+    private suspend fun ensureSchema() {
+        if (schemaReady.get()) {
+            return
+        }
+        schemaMutex.withLock {
+            if (!schemaReady.get()) {
+                transactionIO {
+                    SchemaUtils.create(Customers)
+                }
+                schemaReady.set(true)
+            }
+        }
+    }
+
+    private suspend fun <T> transactionIO(block: () -> T): T =
+        withContext(Dispatchers.IO) {
+            transaction(database) {
+                block()
+            }
+        }
+}
+
+/**
+ * Customer use cases and caller input validation.
+ */
+internal class CustomerService(
+    private val repository: CustomerRepository,
+) {
+    suspend fun create(request: CreateCustomerRequest): CustomerResponse {
+        val command = CreateCustomerCommand(
+            name = request.name.normalizeName(),
+            email = request.email.normalizeEmail()
+        )
+        return repository.create(command).toResponse()
+    }
+
+    suspend fun find(id: Long): CustomerResponse =
+        repository.findById(id)?.toResponse()
+            ?: throw NoSuchElementException("Customer $id was not found")
+
+    suspend fun findAll(): CustomersResponse =
+        CustomersResponse(repository.findAll().map { it.toResponse() })
+
+    suspend fun count(): Long =
+        repository.count()
+
+    private fun String.normalizeName(): String {
+        val normalized = trim()
+        if (normalized.isBlank()) {
+            throw CustomerValidationException("name must not be blank")
+        }
+        if (normalized.length > 80) {
+            throw CustomerValidationException("name must be 80 characters or less")
+        }
+        return normalized
+    }
+
+    private fun String.normalizeEmail(): String {
+        val normalized = trim().lowercase()
+        if (normalized.isBlank()) {
+            throw CustomerValidationException("email must not be blank")
+        }
+        if (normalized.length > 120) {
+            throw CustomerValidationException("email must be 120 characters or less")
+        }
+        if ("@" !in normalized) {
+            throw CustomerValidationException("email must contain @")
+        }
+        return normalized
+    }
+}
+
+/**
+ * Registers customer routes for the architecture example.
+ */
+internal fun Route.customerRoutes(service: CustomerService) {
+    route("/customers") {
+        get {
+            call.respond(service.findAll())
+        }
+        post {
+            val request = call.receiveLimited<CreateCustomerRequest>()
+            call.respond(HttpStatusCode.Created, service.create(request))
+        }
+        get("/{id}") {
+            val id = call.parameters["id"]?.toLongOrNull()
+                ?: throw CustomerValidationException("id must be a number")
+            call.respond(service.find(id))
+        }
+    }
+}
+
+private suspend inline fun <reified T : Any> io.ktor.server.application.ApplicationCall.receiveLimited(): T {
+    val contentLength = request.header(HttpHeaders.ContentLength)?.toLongOrNull()
+    if (contentLength != null && contentLength > MAX_REQUEST_BODY_BYTES) {
+        throw PayloadTooLargeException()
+    }
+    val body = receiveLimitedBody()
+    return try {
+        ApplicationJson.decodeFromString(body)
+    } catch (e: SerializationException) {
+        throw BadRequestException("Malformed request body", e)
+    }
+}
+
+private suspend fun io.ktor.server.application.ApplicationCall.receiveLimitedBody(): String {
+    val channel = receiveChannel()
+    val buffer = ByteArray(REQUEST_BODY_BUFFER_BYTES)
+    val body = ByteArrayOutputStream(REQUEST_BODY_BUFFER_BYTES)
+    var totalBytes = 0L
+
+    while (true) {
+        val readBytes = channel.readAvailable(buffer, 0, buffer.size)
+        if (readBytes == -1) {
+            break
+        }
+        if (readBytes == 0) {
+            continue
+        }
+
+        totalBytes += readBytes
+        if (totalBytes > MAX_REQUEST_BODY_BYTES) {
+            throw PayloadTooLargeException()
+        }
+        body.write(buffer, 0, readBytes)
+    }
+
+    return String(body.toByteArray(), Charsets.UTF_8)
+}
+
+private object Customers : LongIdTable("customers") {
+    val name = varchar("name", 80)
+    val email = varchar("email", 120)
+}
+
+private fun ResultRow.toRecord(): CustomerRecord =
+    CustomerRecord(
+        id = this[Customers.id].value,
+        name = this[Customers.name],
+        email = this[Customers.email]
+    )
+
+private fun CustomerRecord.toResponse(): CustomerResponse =
+    CustomerResponse(id = id, name = name, email = email)
+
+private class PayloadTooLargeException : RuntimeException()
+
+private class CustomerValidationException(message: String) : RuntimeException(message)
+
+@Serializable
+internal data class IndexResponse(
+    val service: String = "ktor-application-architecture",
+    val endpoints: List<String> = listOf("/health", "/customers", "/customers/{id}"),
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+internal data class HealthResponse(
+    val status: String,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+internal data class CreateCustomerRequest(
+    val name: String,
+    val email: String,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class CreateCustomerCommand(
+    val name: String,
+    val email: String,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class CustomerRecord(
+    val id: Long,
+    val name: String,
+    val email: String,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+internal data class CustomerResponse(
+    val id: Long,
+    val name: String,
+    val email: String,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+internal data class CustomersResponse(
+    val customers: List<CustomerResponse>,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+internal data class ErrorResponse(
+    val code: String,
+    val message: String,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/12-production-integration/01-ktor-application-architecture/src/test/kotlin/exposed/examples/ktor/architecture/KtorArchitectureApplicationTest.kt
+++ b/12-production-integration/01-ktor-application-architecture/src/test/kotlin/exposed/examples/ktor/architecture/KtorArchitectureApplicationTest.kt
@@ -1,0 +1,162 @@
+package exposed.examples.ktor.architecture
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldHaveSize
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.UUID
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KtorArchitectureApplicationTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    @Test
+    fun `index and health endpoints describe the application`() = testApplicationWithPersistence { _, _ ->
+        val index = client.get("/")
+        index.status shouldBeEqualTo HttpStatusCode.OK
+        index.bodyAsText() shouldContain "ktor-application-architecture"
+
+        val health = json.decodeFromString<HealthResponse>(client.get("/health").bodyAsText())
+        health.status shouldBeEqualTo "UP"
+    }
+
+    @Test
+    fun `create customer then read by id and list`() = testApplicationWithPersistence { _, service ->
+        service.count() shouldBeEqualTo 0L
+
+        val created = createCustomer("Alice", "alice@example.com")
+        created.name shouldBeEqualTo "Alice"
+        created.email shouldBeEqualTo "alice@example.com"
+
+        val found = json.decodeFromString<CustomerResponse>(
+            client.get("/customers/${created.id}").bodyAsText()
+        )
+        found shouldBeEqualTo created
+
+        val list = json.decodeFromString<CustomersResponse>(
+            client.get("/customers").bodyAsText()
+        )
+        list.customers shouldHaveSize 1
+        list.customers.first() shouldBeEqualTo created
+    }
+
+    @Test
+    fun `unknown customer returns not found`() = testApplicationWithPersistence { _, _ ->
+        val response = client.get("/customers/999")
+        response.status shouldBeEqualTo HttpStatusCode.NotFound
+
+        val error = json.decodeFromString<ErrorResponse>(response.bodyAsText())
+        error.code shouldBeEqualTo "NOT_FOUND"
+    }
+
+    @Test
+    fun `invalid id returns bad request`() = testApplicationWithPersistence { _, _ ->
+        val response = client.get("/customers/not-a-number")
+        response.status shouldBeEqualTo HttpStatusCode.BadRequest
+
+        val error = json.decodeFromString<ErrorResponse>(response.bodyAsText())
+        error.code shouldBeEqualTo "VALIDATION_FAILED"
+    }
+
+    @Test
+    fun `validation failures return bad request`() = testApplicationWithPersistence { _, _ ->
+        val blankName = postJson("/customers", CreateCustomerRequest(" ", "alice@example.com"))
+        blankName.status shouldBeEqualTo HttpStatusCode.BadRequest
+        json.decodeFromString<ErrorResponse>(blankName.bodyAsText()).message shouldBeEqualTo "name must not be blank"
+
+        val invalidEmail = postJson("/customers", CreateCustomerRequest("Alice", "alice.example.com"))
+        invalidEmail.status shouldBeEqualTo HttpStatusCode.BadRequest
+        json.decodeFromString<ErrorResponse>(invalidEmail.bodyAsText()).message shouldBeEqualTo "email must contain @"
+    }
+
+    @Test
+    fun `malformed json returns sanitized bad request`() = testApplicationWithPersistence { _, _ ->
+        val response = client.post("/customers") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"name":""")
+        }
+
+        response.status shouldBeEqualTo HttpStatusCode.BadRequest
+        val error = json.decodeFromString<ErrorResponse>(response.bodyAsText())
+        error.code shouldBeEqualTo "BAD_REQUEST"
+        error.message shouldBeEqualTo "Malformed request body"
+    }
+
+    @Test
+    fun `oversized request returns payload too large`() = testApplicationWithPersistence { _, _ ->
+        val largeName = "A".repeat(65 * 1024)
+        val response = client.post("/customers") {
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(CreateCustomerRequest(largeName, "alice@example.com")))
+        }
+
+        response.status shouldBeEqualTo HttpStatusCode.PayloadTooLarge
+        val error = json.decodeFromString<ErrorResponse>(response.bodyAsText())
+        error.code shouldBeEqualTo "PAYLOAD_TOO_LARGE"
+    }
+
+    @Test
+    fun `parallel inserts create distinct rows`() = testApplicationWithPersistence { _, service ->
+        service.count() shouldBeEqualTo 0L
+
+        val created = coroutineScope {
+            (1..16).map { index ->
+                async {
+                    createCustomer("Customer $index", "customer$index@example.com")
+                }
+            }.awaitAll()
+        }
+
+        created.map { it.id }.toSet() shouldHaveSize 16
+        service.count() shouldBeEqualTo 16L
+    }
+
+    private suspend fun ApplicationTestBuilder.createCustomer(
+        name: String,
+        email: String,
+    ): CustomerResponse {
+        val response = postJson("/customers", CreateCustomerRequest(name, email))
+        response.status shouldBeEqualTo HttpStatusCode.Created
+        return json.decodeFromString(response.bodyAsText())
+    }
+
+    private suspend inline fun <reified T> ApplicationTestBuilder.postJson(
+        path: String,
+        body: T,
+    ) = client.post(path) {
+        contentType(ContentType.Application.Json)
+        setBody(json.encodeToString(body))
+    }
+
+    private fun testApplicationWithPersistence(
+        test: suspend ApplicationTestBuilder.(CustomerPersistence, CustomerService) -> Unit,
+    ) = testApplication {
+        val persistence = CustomerPersistence.inMemory("test_${UUID.randomUUID().toString().replace("-", "")}")
+        val service = CustomerService(ExposedCustomerRepository(persistence.database))
+
+        application {
+            ktorArchitectureModule(persistence)
+        }
+
+        test(persistence, service)
+    }
+}

--- a/12-production-integration/01-ktor-application-architecture/src/test/resources/junit-platform.properties
+++ b/12-production-integration/01-ktor-application-architecture/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.testinstance.lifecycle.default = per_class
+junit.jupiter.execution.parallel.enabled = false

--- a/12-production-integration/01-ktor-application-architecture/src/test/resources/logback-test.xml
+++ b/12-production-integration/01-ktor-application-architecture/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] [%X{callId}] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/docs/lessons/2026-05-17-issue-58-ktor-architecture.md
+++ b/docs/lessons/2026-05-17-issue-58-ktor-architecture.md
@@ -1,0 +1,53 @@
+# Issue 58 - Ktor Architecture Baseline
+
+## Context
+
+Chapter 12 starts production integration examples. The first module needed a
+small Ktor baseline before adding auth, outbox, client, or observability
+examples.
+
+## Decision
+
+Use a Ktor + Exposed JDBC module with explicit route/service/repository
+boundaries. Keep blocking Exposed transactions inside a suspend repository API
+that wraps `transaction {}` with `Dispatchers.IO`.
+
+## Outcome
+
+Added `12-production-integration/01-ktor-application-architecture` with Ktor
+JSON, StatusPages, CallId/CallLogging, H2 persistence, route tests, and
+English/Korean README files.
+
+Claude implementation review caught two issues after the first commit: the
+fallback 500 handler did not log root causes, and the body limit only trusted
+`Content-Length`. A first fix checked size after `receiveText()`, but Claude
+correctly rejected it because the body was already buffered. The final version
+logs unexpected failures and enforces the size limit while streaming request
+body chunks before JSON decoding.
+
+## Verification
+
+- `./gradlew -q projects`
+- `./gradlew :01-ktor-application-architecture:compileKotlin`
+- `./gradlew :01-ktor-application-architecture:compileTestKotlin`
+- `./gradlew :01-ktor-application-architecture:test` - 8 passing
+- `./gradlew --offline :01-ktor-application-architecture:compileKotlin :01-ktor-application-architecture:compileTestKotlin :01-ktor-application-architecture:test` - 8 passing after review fixes
+- `./gradlew detekt` - `NO-SOURCE`
+- `git diff --check`
+- Claude Code implementation final re-review - PASS, P0 = 0, P1 = 0
+
+IDE batch diagnostics reported zero problems after opening the project through
+IntelliJ, but the CLI diagnostics were not editor-fresh. Online Gradle
+resolution was blocked by an external snapshot POM for
+`io.github.bluetape4k.aws:bluetape4k-aws-bom:0.1.0`; the same targeted compile
+and test verification passed with `--offline`. CI workflow changes were not
+required: daily CI runs repository-wide Gradle tests, and the new H2-only module
+is included through `settings.gradle.kts`.
+
+## Future Guidance
+
+For future Ktor + JDBC examples, do not call Exposed `transaction {}` directly
+from routes. Put the blocking boundary in the repository and test at least one
+parallel write path when the example demonstrates service architecture.
+Do not rely on `Content-Length` alone for request limits; also enforce the limit
+against the bytes actually read.

--- a/docs/superpowers/plans/2026-05-17-issue-58-ktor-architecture-plan.md
+++ b/docs/superpowers/plans/2026-05-17-issue-58-ktor-architecture-plan.md
@@ -1,0 +1,78 @@
+# Issue 58 - Ktor Application Architecture Plan
+
+## Scope
+
+Implement the first chapter 12 Ktor module in `exposed-workshop`.
+
+## Tasks
+
+1. Add design and advisor artifacts.
+   - Complexity: S
+   - Apply `bluetape4k-design` review gates and Claude Code CLI advisor review.
+
+2. Add Gradle/catalog wiring.
+   - Complexity: S
+   - Add `ktor = "3.4.3"` and aliases:
+     `ktor-server-core`, `ktor-server-cio`,
+     `ktor-server-content-negotiation`, `ktor-server-status-pages`,
+     `ktor-server-call-logging`, `ktor-server-call-id`,
+     `ktor-server-test-host`, and `ktor-serialization-kotlinx-json`.
+   - Register `12-production-integration`.
+   - Add module `build.gradle.kts`.
+
+3. Implement Ktor + Exposed baseline.
+   - Complexity: M
+   - Add table, repository, service, DTOs, routes, application module, and main.
+   - Repository API is `suspend`; repository owns the
+     `withContext(Dispatchers.IO) { transaction {} }` boundary.
+   - Use deterministic Hikari/H2 settings for tests, including
+     `maximumPoolSize = 4`.
+   - Add explicit `StatusPages` mappings for validation, not-found, malformed
+     request, and sanitized fallback errors. Do not echo exception messages or
+     stack traces from unexpected exceptions.
+   - Configure request body limit at `64 KiB`.
+   - Configure CallId logging with MDC-friendly logback test output.
+   - Apply `bluetape4k-patterns`: no `!!`, validate caller input with
+     `require*`/explicit exceptions, keep state immutable.
+   - Do not use `runCatching` around suspend calls.
+
+4. Add focused tests.
+   - Complexity: M
+   - Use Ktor `testApplication`.
+   - Use bluetape4k assertions, not JUnit/kotlin.test assertions.
+   - Do not use `assertThrows`, `invoking { } shouldThrow`, or
+     `kotlin.test.assertFailsWith`.
+   - Use a unique H2 JDBC URL per test and assert empty table state at test
+     start.
+   - Add a parallel insert smoke test with 16 concurrent requests and verify
+     distinct primary keys plus total row count.
+
+5. Add documentation.
+   - Complexity: S
+   - Add `README.md` and `README.ko.md`.
+   - Include a small Mermaid architecture diagram.
+   - Document run/test commands, the suspend repository boundary, and why the
+     R2DBC workshop is the non-blocking persistence counterpart.
+
+6. Verify.
+   - Complexity: S
+   - Run `./gradlew projects`.
+   - Run `./gradlew :01-ktor-application-architecture:compileKotlin`.
+   - Run `./gradlew :01-ktor-application-architecture:test`.
+   - Run `./gradlew :01-ktor-application-architecture:detekt` if the task is
+     available for the module.
+   - Run `git diff --check`.
+
+7. Capture lesson and commit.
+   - Complexity: S
+   - Add `docs/lessons/2026-05-17-issue-58-ktor-architecture.md`.
+   - Commit with Lore trailers after verification.
+
+## Advisor Review Requirement
+
+Claude Code CLI review artifacts:
+
+- `.omx/artifacts/claude-issue-58-spec-plan-2026-05-17.md`
+- `.omx/artifacts/claude-issue-58-spec-plan-rereview-2026-05-17.md`
+
+Summarize accepted/rejected findings in the research note.

--- a/docs/superpowers/research/2026-05-17-issue-58-ktor-architecture-review.md
+++ b/docs/superpowers/research/2026-05-17-issue-58-ktor-architecture-review.md
@@ -1,0 +1,82 @@
+# Issue 58 - Spec/Plan Review
+
+## Codex 6-Tier Review
+
+| Tier | Finding | Priority | Decision |
+|---|---|---:|---|
+| Security | Error responses and malformed JSON handling must be explicit to avoid stack trace or implementation-detail leaks. | P1 | Accept; add StatusPages mapping and JSON/body constraints. |
+| Ops/SRE | Blocking Exposed JDBC must not run on Ktor call/event-loop threads. | P0 | Accept; repository owns suspend API and `Dispatchers.IO` transaction boundary. |
+| Structural | Version catalog aliases affect repo-wide dependency names. | P2 | Accept; use namespaced `ktor-*` aliases copied from existing bluetape4k Ktor examples. |
+| Kotlin Quality | Route layer should stay thin; validation belongs in service; persistence belongs in repository. | P1 | Accept; spec/plan now require route-service-repository boundary. |
+| Tests/Types | H2 database isolation and concurrency smoke coverage were under-specified. | P0 | Accept; use unique H2 URL per test and parallel insert smoke test. |
+| Performance/Stability | Hikari pool and blocking dispatcher behavior need deterministic test sizing. | P2 | Accept; pin test pool size and document JDBC boundary. |
+
+Codex gate result after planned edits: P0 = 0, P1 = 0.
+
+## Claude Code Opus Advisor
+
+Artifact: `.omx/artifacts/claude-issue-58-spec-plan-2026-05-17.md`
+
+| Priority | Finding | Decision | Follow-up |
+|---|---|---|---|
+| P0 | Blocking JDBC on Ktor event loop. | Accepted | Add suspend repository API with `Dispatchers.IO` transaction boundary. |
+| P0 | H2 test isolation under-specified. | Accepted | Require unique H2 URL per test and empty-state assertion. |
+| P0 | Missing concurrency smoke test. | Accepted | Add parallel insert route test. |
+| P1 | StatusPages mapping unspecified. | Accepted | Add explicit exception-to-status mapping. |
+| P1 | Missing JSON/body limits. | Accepted | Add JSON config and request size limit requirement. |
+| P1 | Missing CallLogging/CallId baseline. | Accepted | Add plugins to design. |
+| P1 | Repository should expose suspend API. | Accepted | Move blocking boundary into repository. |
+| P2/P3 | Alias naming, negative paths, pool sizing, KDoc, assertion rules. | Accepted | Add to plan and verification criteria. |
+
+Review gate result after planned edits: P0 = 0, P1 = 0.
+
+### Claude Code Opus Re-Review
+
+Artifact: `.omx/artifacts/claude-issue-58-spec-plan-rereview-2026-05-17.md`
+
+Verdict: PASS. P0 = 0, P1 = 0.
+
+| Priority | Finding | Decision | Follow-up |
+|---|---|---|---|
+| P2 | Pin body limit, pool size, and parallel smoke count. | Accepted | Plan now uses 64 KiB, pool size 4, and 16 concurrent requests. |
+| P2 | Sanitized 500 must not echo exception details. | Accepted | Plan now states this explicitly. |
+| P3 | Include CallId/logback and README diagram details. | Accepted | Plan updated. |
+| P3 | Remind implementation not to use `runCatching` around suspend calls. | Accepted | Plan updated. |
+
+## Claude Code Implementation Review
+
+Artifact: `.omx/artifacts/claude-code-review-issue-58-2026-05-17.md`
+
+Verdict: FAIL. P0 = 0, P1 = 2.
+
+| Priority | Finding | Decision | Follow-up |
+|---|---|---|---|
+| P1 | Catch-all 500 handler sanitized the response but did not log the root cause. | Accepted | Log unexpected exceptions before returning `INTERNAL_ERROR`; rethrow cancellation. |
+| P1 | Request body limit only checked `Content-Length`, so missing/chunked length could bypass the guard. | Accepted | Decode through a helper that checks both declared and actual UTF-8 body size before JSON parsing. |
+| P2 | Duplicate JetBrains Exposed and bluetape4k Exposed dependencies. | Accepted | Keep the direct JetBrains Exposed dependencies for this small workshop module. |
+| P2 | `prettyPrint = true` is not a production-shaped JSON default. | Accepted | Use compact JSON with `ignoreUnknownKeys` and `encodeDefaults`. |
+| P2 | Generic `IllegalArgumentException` messages should not be echoed. | Accepted | Add a local validation exception for authored validation messages and sanitize generic `IllegalArgumentException`. |
+| P3 | Parallel insert test had a redundant weak assertion. | Accepted | Keep the distinct-ID set assertion and row-count assertion. |
+
+### Claude Code Implementation Re-Review
+
+Artifact: `.omx/artifacts/claude-code-review-rereview-issue-58-2026-05-17.md`
+
+Verdict: FAIL. P0 = 0, P1 = 1.
+
+| Priority | Finding | Decision | Follow-up |
+|---|---|---|---|
+| P1 | Checking the actual size after `receiveText()` still lets a chunked or missing-length request buffer unbounded data first. | Accepted | Replace `receiveText()` with `receiveChannel()` and enforce the 64 KiB limit while streaming chunks into a bounded buffer. |
+
+### Claude Code Final Re-Review
+
+Artifact: `.omx/artifacts/claude-code-review-final-issue-58-2026-05-17.md`
+
+Verdict: PASS. P0 = 0, P1 = 0.
+
+| Check | Result |
+|---|---|
+| Streaming body limit | 64 KiB is enforced during chunk reads before buffering excess data. |
+| Fallback 500 | Unexpected exceptions are logged and the response remains sanitized. |
+| Cancellation | `CancellationException` is rethrown before logging/responding. |
+| JDBC boundary | Exposed JDBC remains behind the repository-owned `Dispatchers.IO` transaction boundary. |

--- a/docs/superpowers/specs/2026-05-17-issue-58-ktor-architecture-design.md
+++ b/docs/superpowers/specs/2026-05-17-issue-58-ktor-architecture-design.md
@@ -1,0 +1,62 @@
+# Issue 58 - Ktor Application Architecture Design
+
+## Context
+
+Issue #58 starts chapter 12 production integration work with the smallest Ktor
+example in `exposed-workshop`. The module should become the baseline shape for
+later chapter 12 examples without pulling in auth, outbox, WebSocket, external
+client, or observability scope.
+
+## Goal
+
+Add `12-production-integration/01-ktor-application-architecture`, a minimal
+Ktor + Exposed JDBC example that demonstrates explicit application assembly,
+feature routes, service/repository boundaries, JSON serialization, error
+mapping, and route tests.
+
+## Non-Goals
+
+- No Spring Boot dependency in this module.
+- No Testcontainers; use in-memory H2 for the first baseline example.
+- No authentication, sessions, WebSocket, external HTTP client, or metrics.
+- No shared abstraction for future chapter 12 modules until duplication is real.
+
+## Design
+
+- Register the chapter in `settings.gradle.kts` with the existing
+  `includeModules("12-production-integration", false, false)` helper.
+- Add Ktor aliases to `gradle/libs.versions.toml` using the current official
+  Ktor 3.4.3 coordinates already used in `bluetape4k-projects`.
+- Use `kotlin("plugin.serialization")` for DTOs and Ktor kotlinx JSON support.
+- Use a small `Customer` domain:
+  - `Customers` Exposed table.
+  - `CustomerRepository` interface.
+  - `ExposedCustomerRepository` implementation exposing `suspend` functions
+    and wrapping every blocking JDBC `transaction {}` call in
+    `withContext(Dispatchers.IO)`.
+  - `CustomerService` for validation and route-friendly errors.
+- Use Ktor `ContentNegotiation`, `StatusPages`, `CallLogging`, `CallId`, and
+  feature route functions.
+- Configure JSON with `ignoreUnknownKeys = true` and enforce a small request
+  body limit for the demo API.
+- Map `IllegalArgumentException` to HTTP 400, missing records to HTTP 404, and
+  unexpected exceptions to sanitized HTTP 500 JSON responses.
+- Use `testApplication` for route tests with a unique H2 JDBC URL per test.
+
+## Acceptance Criteria
+
+- `:01-ktor-application-architecture:compileKotlin` passes.
+- `:01-ktor-application-architecture:test` passes.
+- Tests cover create, get, list, not found, malformed JSON, at least two
+  validation failure paths, and a parallel insert smoke path.
+- `README.md` and `README.ko.md` exist for the module.
+- KDoc for public/internal module entrypoints explains the contract in English.
+- `git diff --check` passes.
+
+## Risks
+
+- Blocking Exposed JDBC is acceptable only behind the repository-owned
+  `Dispatchers.IO` boundary. README must state that higher-throughput
+  non-blocking persistence belongs in the R2DBC workshop.
+- Version catalog changes affect the whole repo; keep aliases minimal and reuse
+  the Ktor 3.4.3 version from existing bluetape4k examples.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ kotlinx-coroutines = "1.11.0"
 kotlinx-serialization = "1.11.0"
 kotlinx-atomicfu = "0.32.1"
 kotlinx-benchmark = "0.4.15"
+ktor = "3.4.3"
 
 spring-boot = "4.0.6"
 reactor-bom = "2024.0.14"
@@ -173,6 +174,16 @@ kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "k
 # Kotlinx Serialization
 kotlinx-serialization-bom = { module = "org.jetbrains.kotlinx:kotlinx-serialization-bom", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json" }
+
+# Ktor
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
+ktor-server-call-logging = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor" }
+ktor-server-call-id = { module = "io.ktor:ktor-server-call-id", version.ref = "ktor" }
+ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 
 # Kotlinx Benchmark
 kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ includeModules("08-coroutines", false, false)
 includeModules("09-spring", false, false)
 includeModules("10-multi-tenant", false, false)
 includeModules("11-high-performance", false, false)
+includeModules("12-production-integration", false, false)
 
 fun includeModules(baseDir: String, withProjectName: Boolean = true, withBaseDir: Boolean = true) {
     files("$rootDir/$baseDir").files


### PR DESCRIPTION
## Summary
- Add chapter 12 Ktor + Exposed JDBC architecture baseline module.
- Demonstrate route/service/repository boundaries, StatusPages, CallId/CallLogging, H2 persistence, and streaming request body size enforcement.
- Add English/Korean README, design/plan/review artifacts, and a lessons entry.

## Verification
- ./gradlew -q projects
- ./gradlew --offline :01-ktor-application-architecture:compileKotlin :01-ktor-application-architecture:compileTestKotlin :01-ktor-application-architecture:test
- ./gradlew --offline detekt
- git diff --check
- IntelliJ optimize imports
- Claude Code final implementation review: PASS, P0=0, P1=0

## Known gaps
- Fresh IntelliJ editor highlights were unavailable because the IDE reported dumb mode.
- Online Gradle resolution was blocked by external snapshot POM io.github.bluetape4k.aws:bluetape4k-aws-bom:0.1.0; targeted verification passed offline.
- Module-specific detekt task does not exist; root detekt is NO-SOURCE.

Refs #58