### PR TITLE
[build] Delegate bluetape4k versions to central BOM

### DIFF
--- a/01-spring-boot/spring-mvc-exposed/build.gradle.kts
+++ b/01-spring-boot/spring-mvc-exposed/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
 
-    testImplementation(libs.bluetape4k.spring.boot4.core)
+    testImplementation(libs.bluetape4k.spring.boot.core)
     testImplementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation(libs.spring.boot.starter.webmvc.test)
     testImplementation("org.springframework.boot:spring-boot-starter-test") {

--- a/01-spring-boot/spring-webflux-exposed/build.gradle.kts
+++ b/01-spring-boot/spring-webflux-exposed/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.jdbc)
-    testImplementation(libs.bluetape4k.spring.boot4.core)
+    testImplementation(libs.bluetape4k.spring.boot.core)
     implementation(libs.bluetape4k.testcontainers)
 
     // Database Drivers
@@ -64,7 +64,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
 
-    testImplementation(libs.bluetape4k.spring.boot4.core)
+    testImplementation(libs.bluetape4k.spring.boot.core)
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "junit", module = "junit")
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")

--- a/02-alternatives-to-jpa/hibernate-reactive-example/build.gradle.kts
+++ b/02-alternatives-to-jpa/hibernate-reactive-example/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.vertx)
     testImplementation(libs.bluetape4k.junit5)
-    testImplementation(libs.bluetape4k.spring.boot4.core)
+    testImplementation(libs.bluetape4k.spring.boot.core)
 
     api(libs.jakarta.annotation.api)
     api(libs.jakarta.persistence.api)

--- a/02-alternatives-to-jpa/r2dbc-example/build.gradle.kts
+++ b/02-alternatives-to-jpa/r2dbc-example/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     testImplementation(libs.reactor.test)
 
     // R2DBC
-    implementation(libs.bluetape4k.spring.boot4.r2dbc)
+    implementation(libs.bluetape4k.spring.boot.r2dbc)
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
     runtimeOnly(libs.r2dbc.postgresql)
     runtimeOnly(libs.r2dbc.h2)

--- a/06-advanced/08-exposed-jackson/build.gradle.kts
+++ b/06-advanced/08-exposed-jackson/build.gradle.kts
@@ -4,7 +4,7 @@ configurations {
 
 dependencies {
     testImplementation(platform(libs.jetbrains.exposed.bom))
-    testImplementation(platform(libs.bluetape4k.bom))
+    testImplementation(platform(libs.bluetape4k.dependencies))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/06-advanced/09-exposed-fastjson2/build.gradle.kts
+++ b/06-advanced/09-exposed-fastjson2/build.gradle.kts
@@ -4,7 +4,7 @@ configurations {
 
 dependencies {
     implementation(platform(libs.jetbrains.exposed.bom))
-    implementation(platform(libs.bluetape4k.bom))
+    implementation(platform(libs.bluetape4k.dependencies))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/06-advanced/11-exposed-jackson3/build.gradle.kts
+++ b/06-advanced/11-exposed-jackson3/build.gradle.kts
@@ -4,7 +4,7 @@ configurations {
 
 dependencies {
     implementation(platform(libs.jetbrains.exposed.bom))
-    implementation(platform(libs.bluetape4k.bom))
+    implementation(platform(libs.bluetape4k.dependencies))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/06-advanced/12-exposed-tink/build.gradle.kts
+++ b/06-advanced/12-exposed-tink/build.gradle.kts
@@ -4,7 +4,7 @@ configurations {
 
 dependencies {
     implementation(platform(libs.jetbrains.exposed.bom))
-    implementation(platform(libs.bluetape4k.bom))
+    implementation(platform(libs.bluetape4k.dependencies))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/09-spring/03-spring-transaction/build.gradle.kts
+++ b/09-spring/03-spring-transaction/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     implementation(libs.exposed.core)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jdbc)
-    implementation(libs.bluetape4k.spring.boot4.core)
+    implementation(libs.bluetape4k.spring.boot.core)
 
     // Spring Boot
     implementation("org.springframework.boot:spring-boot-starter-jdbc")

--- a/09-spring/04-exposed-repository/build.gradle.kts
+++ b/09-spring/04-exposed-repository/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.testcontainers)
     testImplementation(libs.bluetape4k.junit5)
-    testImplementation(libs.bluetape4k.spring.boot4.core)
+    testImplementation(libs.bluetape4k.spring.boot.core)
 
     // Database Drivers
     implementation(libs.hikaricp)

--- a/09-spring/05-exposed-repository-coroutines/build.gradle.kts
+++ b/09-spring/05-exposed-repository-coroutines/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.testcontainers)
-    testImplementation(libs.bluetape4k.spring.boot4.core)
+    testImplementation(libs.bluetape4k.spring.boot.core)
 
     // Database Drivers
     implementation(libs.hikaricp)

--- a/09-spring/06-spring-cache/build.gradle.kts
+++ b/09-spring/06-spring-cache/build.gradle.kts
@@ -40,8 +40,8 @@ dependencies {
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.redis)
-    implementation(libs.bluetape4k.spring.boot4.core)
-    implementation(libs.bluetape4k.spring.boot4.redis)
+    implementation(libs.bluetape4k.spring.boot.core)
+    implementation(libs.bluetape4k.spring.boot.redis)
     implementation(libs.bluetape4k.testcontainers)
     testImplementation(libs.bluetape4k.junit5)
 

--- a/10-multi-tenant/01-multitenant-spring-web/build.gradle.kts
+++ b/10-multi-tenant/01-multitenant-spring-web/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.jdbc)
     testImplementation(libs.bluetape4k.junit5)
-    testImplementation(libs.bluetape4k.spring.boot4.core)
+    testImplementation(libs.bluetape4k.spring.boot.core)
 
     // Database Drivers
     implementation(libs.hikaricp)

--- a/10-multi-tenant/02-multitenant-spring-web-virtualthread/build.gradle.kts
+++ b/10-multi-tenant/02-multitenant-spring-web-virtualthread/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.jdbc)
     testImplementation(libs.bluetape4k.junit5)
-    testImplementation(libs.bluetape4k.spring.boot4.core)
+    testImplementation(libs.bluetape4k.spring.boot.core)
 
     // Database Drivers
     implementation(libs.hikaricp)

--- a/10-multi-tenant/03-multitenant-spring-webflux/build.gradle.kts
+++ b/10-multi-tenant/03-multitenant-spring-webflux/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation(libs.bluetape4k.jdbc)
     implementation(libs.bluetape4k.testcontainers)
     testImplementation(libs.bluetape4k.junit5)
-    testImplementation(libs.bluetape4k.spring.boot4.core)
+    testImplementation(libs.bluetape4k.spring.boot.core)
 
     // Database Drivers
     implementation(libs.hikaricp)

--- a/11-high-performance/01-cache-strategies/build.gradle.kts
+++ b/11-high-performance/01-cache-strategies/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     implementation(libs.bluetape4k.redis)
     implementation(libs.bluetape4k.testcontainers)
     testImplementation(libs.bluetape4k.junit5)
-    testImplementation(libs.bluetape4k.spring.boot4.core)
+    testImplementation(libs.bluetape4k.spring.boot.core)
 
     // Codecs
     runtimeOnly(libs.fory.kotlin)

--- a/11-high-performance/02-cache-strategies-coroutines/build.gradle.kts
+++ b/11-high-performance/02-cache-strategies-coroutines/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     implementation(libs.bluetape4k.redis)
     implementation(libs.bluetape4k.testcontainers)
     testImplementation(libs.bluetape4k.junit5)
-    testImplementation(libs.bluetape4k.spring.boot4.core)
+    testImplementation(libs.bluetape4k.spring.boot.core)
 
     // Codecs
     runtimeOnly(libs.fory.kotlin)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -195,7 +195,7 @@ subprojects {
 
         imports {
             mavenBom(rootLibs.spring.boot.dependencies.get().toString())
-            mavenBom(rootLibs.bluetape4k.bom.get().toString())
+            mavenBom(rootLibs.bluetape4k.dependencies.get().toString())
             mavenBom(rootLibs.kotlinx.coroutines.bom.get().toString())
             mavenBom(rootLibs.kotlin.bom.get().toString())
             mavenBom(rootLibs.netty.bom.get().toString())

--- a/docs/lessons/2026-05-18-bluetape4k-dependencies-bom.md
+++ b/docs/lessons/2026-05-18-bluetape4k-dependencies-bom.md
@@ -1,0 +1,29 @@
+# bluetape4k-dependencies BOM 전환
+
+## Context
+
+`exposed-workshop`가 `bluetape4k-bom`과 `bluetape4k-exposed-*` 버전을 `1.8.0-SNAPSHOT` catalog 값으로 직접 고정하고 있었다. `bluetape4k-dependencies:1.0.0`가 release BOM들을 가져오므로, workshop은 central BOM 하나를 기준으로 버전을 받아야 했다.
+
+## Decision
+
+- 루트 `dependencyManagement`는 `bluetape4k-bom` 대신 `io.github.bluetape4k:bluetape4k-dependencies:1.0.0`을 import한다.
+- bluetape4k 및 `io.github.bluetape4k.exposed` alias는 versionless로 둔다.
+- 기존 `spring-boot4-*` alias는 published artifact 이름인 `spring-boot-*`로 바꾼다.
+- 사용하지 않는 `bluetape4k-bom` alias는 제거해서 직접 import로 되돌아갈 여지를 줄인다.
+
+## Outcome
+
+`bluetape4k-dependencies`가 `bluetape4k-bom:1.8.0`과 `bluetape4k-exposed-bom:1.8.0`을 import하고, Gradle이 exposed/spring/bluetape4k 아티팩트 버전을 central BOM에서 해석하도록 정리했다.
+
+## Verification
+
+- `./gradlew -q projects`
+- `./gradlew compileKotlin compileTestKotlin`
+- `./gradlew :01-ktor-application-architecture:test :11-exposed-jackson3:test :06-spring-cache:test`
+- `./gradlew -q :11-exposed-jackson3:dependencyInsight --configuration testRuntimeClasspath --dependency io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3`
+- `./gradlew -q :06-spring-cache:dependencyInsight --configuration compileClasspath --dependency io.github.bluetape4k:bluetape4k-spring-boot-core`
+- `git diff --check`
+
+## Future Guard
+
+External advisor results about BOM coverage can be stale or based on artifact-name assumptions. Verify against the published BOM POM and `dependencyInsight` before changing artifact coordinates.

--- a/docs/lessons/2026-05-18-bluetape4k-dependencies-bom.md
+++ b/docs/lessons/2026-05-18-bluetape4k-dependencies-bom.md
@@ -14,6 +14,7 @@
 ## Outcome
 
 `bluetape4k-dependencies`가 `bluetape4k-bom:1.8.0`과 `bluetape4k-exposed-bom:1.8.0`을 import하고, Gradle이 exposed/spring/bluetape4k 아티팩트 버전을 central BOM에서 해석하도록 정리했다.
+추가로 중앙 shared version 검증에 맞춰 JetBrains Exposed와 Dokka catalog alias도 각각 `1.3.0`, `2.2.0`으로 정렬했다.
 
 ## Verification
 
@@ -23,6 +24,9 @@
 - `./gradlew -q :11-exposed-jackson3:dependencyInsight --configuration testRuntimeClasspath --dependency io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3`
 - `./gradlew -q :06-spring-cache:dependencyInsight --configuration compileClasspath --dependency io.github.bluetape4k:bluetape4k-spring-boot-core`
 - `git diff --check`
+- `bluetape4k-dependencies/scripts/sync-shared-versions.py --workspace <symlink-workspace> --repo exposed-workshop --check --summary`
+- After aligning Exposed/Dokka aliases: `./gradlew compileKotlin compileTestKotlin --no-daemon`
+- `./gradlew build --no-daemon` failed during `:03-functions:test` after MySQL Testcontainers connection refusal; dependency resolution and compilation had already passed.
 
 ## Future Guard
 

--- a/docs/lessons/2026-05-18-central-dependency-governance.md
+++ b/docs/lessons/2026-05-18-central-dependency-governance.md
@@ -1,0 +1,23 @@
+# Central Dependency Governance Sync
+
+## Context
+
+Downstream Dependabot PRs were updating shared dependency versions one repository at a time, creating version drift across the bluetape4k organization.
+
+## Decision
+
+Shared dependency versions should be changed in `bluetape4k-dependencies` first, then materialized into this repository with `sync-shared-versions.py`. This repository also ignores centrally governed dependency names in Dependabot so future PRs route through the central source of truth.
+
+## Outcome
+
+The local version catalog and `.github/dependabot.yml` now follow the central dependency-governance policy.
+
+## Verification
+
+- `sync-shared-versions.py --write --check --summary` for this repository
+- `sync-dependabot-ignores.py --write --check --summary` for this repository
+- `git diff --check`
+
+## Future Guard
+
+Do not merge repo-local Dependabot PRs for centrally governed dependencies. Update `bluetape4k-dependencies`, then sync this repository.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k-dependencies = "1.0.0"
+bluetape4k-dependencies = "1.0.1-SNAPSHOT"
 
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.11.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k = "1.8.0-SNAPSHOT"
-bluetape4k-exposed = "1.8.1-SNAPSHOT"
+bluetape4k-dependencies = "1.0.0"
 
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.11.0"
@@ -113,42 +112,42 @@ gatling = { id = "io.gatling.gradle", version = "3.15.0" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.1.0" }
 
 # bluetape4k
-bluetape4k-bom = { module = "io.github.bluetape4k:bluetape4k-bom", version.ref = "bluetape4k" }
-bluetape4k-core = { module = "io.github.bluetape4k:bluetape4k-core" , version.ref = "bluetape4k" }
-bluetape4k-coroutines = { module = "io.github.bluetape4k:bluetape4k-coroutines" , version.ref = "bluetape4k" }
-bluetape4k-logging = { module = "io.github.bluetape4k:bluetape4k-logging" , version.ref = "bluetape4k" }
-bluetape4k-junit5 = { module = "io.github.bluetape4k:bluetape4k-junit5" , version.ref = "bluetape4k" }
-bluetape4k-testcontainers = { module = "io.github.bluetape4k:bluetape4k-testcontainers" , version.ref = "bluetape4k" }
-bluetape4k-idgenerators = { module = "io.github.bluetape4k:bluetape4k-idgenerators" , version.ref = "bluetape4k" }
-bluetape4k-io = { module = "io.github.bluetape4k:bluetape4k-io" , version.ref = "bluetape4k" }
-bluetape4k-jdbc = { module = "io.github.bluetape4k:bluetape4k-jdbc" , version.ref = "bluetape4k" }
-bluetape4k-money = { module = "io.github.bluetape4k:bluetape4k-money" , version.ref = "bluetape4k" }
-bluetape4k-redis = { module = "io.github.bluetape4k:bluetape4k-redis" , version.ref = "bluetape4k" }
-bluetape4k-vertx = { module = "io.github.bluetape4k:bluetape4k-vertx" , version.ref = "bluetape4k" }
-bluetape4k-grpc = { module = "io.github.bluetape4k:bluetape4k-grpc" , version.ref = "bluetape4k" }
-bluetape4k-jackson2 = { module = "io.github.bluetape4k:bluetape4k-jackson2" , version.ref = "bluetape4k" }
-bluetape4k-jackson3 = { module = "io.github.bluetape4k:bluetape4k-jackson3" , version.ref = "bluetape4k" }
+bluetape4k-dependencies = { module = "io.github.bluetape4k:bluetape4k-dependencies", version.ref = "bluetape4k-dependencies" }
+bluetape4k-core = { module = "io.github.bluetape4k:bluetape4k-core" }
+bluetape4k-coroutines = { module = "io.github.bluetape4k:bluetape4k-coroutines" }
+bluetape4k-logging = { module = "io.github.bluetape4k:bluetape4k-logging" }
+bluetape4k-junit5 = { module = "io.github.bluetape4k:bluetape4k-junit5" }
+bluetape4k-testcontainers = { module = "io.github.bluetape4k:bluetape4k-testcontainers" }
+bluetape4k-idgenerators = { module = "io.github.bluetape4k:bluetape4k-idgenerators" }
+bluetape4k-io = { module = "io.github.bluetape4k:bluetape4k-io" }
+bluetape4k-jdbc = { module = "io.github.bluetape4k:bluetape4k-jdbc" }
+bluetape4k-money = { module = "io.github.bluetape4k:bluetape4k-money" }
+bluetape4k-redis = { module = "io.github.bluetape4k:bluetape4k-redis" }
+bluetape4k-vertx = { module = "io.github.bluetape4k:bluetape4k-vertx" }
+bluetape4k-grpc = { module = "io.github.bluetape4k:bluetape4k-grpc" }
+bluetape4k-jackson2 = { module = "io.github.bluetape4k:bluetape4k-jackson2" }
+bluetape4k-jackson3 = { module = "io.github.bluetape4k:bluetape4k-jackson3" }
 
 # exposed
-exposed-core = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-core" , version.ref = "bluetape4k-exposed" }
-exposed-dao = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-dao" , version.ref = "bluetape4k-exposed" }
-exposed-fastjson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-fastjson2" , version.ref = "bluetape4k-exposed" }
-exposed-jackson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson2" , version.ref = "bluetape4k-exposed" }
-exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" , version.ref = "bluetape4k-exposed" }
-exposed-jdbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc" , version.ref = "bluetape4k-exposed" }
-exposed-jdbc-redisson = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-redisson" , version.ref = "bluetape4k-exposed" }
-exposed-tink = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-tink" , version.ref = "bluetape4k-exposed" }
+exposed-core = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-core" }
+exposed-dao = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-dao" }
+exposed-fastjson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-fastjson2" }
+exposed-jackson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson2" }
+exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" }
+exposed-jdbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc" }
+exposed-jdbc-redisson = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-redisson" }
+exposed-tink = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-tink" }
 
 # bluetape4k hibernate
-bluetape4k-hibernate-reactive = { module = "io.github.bluetape4k:bluetape4k-hibernate-reactive" , version.ref = "bluetape4k" }
+bluetape4k-hibernate-reactive = { module = "io.github.bluetape4k:bluetape4k-hibernate-reactive" }
 
-# bluetape4k spring-boot4
-bluetape4k-spring-boot4-core = { module = "io.github.bluetape4k:bluetape4k-spring-boot4-core" , version.ref = "bluetape4k" }
-bluetape4k-spring-boot4-r2dbc = { module = "io.github.bluetape4k:bluetape4k-spring-boot4-r2dbc" , version.ref = "bluetape4k" }
-bluetape4k-spring-boot4-redis = { module = "io.github.bluetape4k:bluetape4k-spring-boot4-redis" , version.ref = "bluetape4k" }
+# bluetape4k spring-boot
+bluetape4k-spring-boot-core = { module = "io.github.bluetape4k:bluetape4k-spring-boot-core" }
+bluetape4k-spring-boot-r2dbc = { module = "io.github.bluetape4k:bluetape4k-spring-boot-r2dbc" }
+bluetape4k-spring-boot-redis = { module = "io.github.bluetape4k:bluetape4k-spring-boot-redis" }
 
 # bluetape4k virtualthread
-bluetape4k-virtualthread-jdk21 = { module = "io.github.bluetape4k:bluetape4k-virtualthread-jdk21" , version.ref = "bluetape4k" }
+bluetape4k-virtualthread-jdk21 = { module = "io.github.bluetape4k:bluetape4k-virtualthread-jdk21" }
 
 # Kotlin
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- Sync Gradle shared-version aliases with `bluetape4k-dependencies` as the central source.
- Add the generated central Dependabot ignore block so centrally governed dependency lines are not bumped independently in this repository.
- Add a short lesson entry for the cross-repo dependency governance rollout.

## Verification
- Workspace local sync: `all-pull` completed with `ok=16 skipped=0 failed=0`.
- Central sync checks: `sync-shared-versions.py --check` and `sync-dependabot-ignores.py --check`.
- Local compile verification: `./gradlew compileTestKotlin --no-daemon` passed.
- Diff hygiene: `git diff --check` passed.

## 6-Tier Review
1. Correctness: shared versions now resolve through the central BOM/catalog path and Gradle test sources compile locally.
2. Build/Dependency: downstream Dependabot is constrained to avoid independent PRs for centrally governed libraries.
3. Tests: compile-time verification covers affected Gradle dependency resolution and test-source compilation.
4. Compatibility: no production API changes; only build metadata, generated Dependabot ignore config, and lesson docs.
5. Maintainability: generated marker blocks keep repo-local Dependabot rules reproducible from `bluetape4k-dependencies`.
6. Documentation: lesson documents the rollout and future maintenance rule.

## Notes
- MyBatis Dynamic SQL 2.0.0 and Timefold Solver 2.x were intentionally rejected centrally because they require separate migration work.