### PR TITLE
Add CTE Query Builder workshop example

### DIFF
--- a/05-exposed-dml/01-dml/README.ko.md
+++ b/05-exposed-dml/01-dml/README.ko.md
@@ -184,7 +184,7 @@ erDiagram
 | 기본 DML | `Ex01_Select.kt`, `Ex02_Insert.kt`, `Ex03_Update.kt`, `Ex04_Upsert.kt`, `Ex05_Delete.kt`                                                                                                                                           |
 | 조회 고급  | `Ex06_Exists.kt`, `Ex07_DistinctOn.kt`, `Ex08_Count.kt`, `Ex09_GroupBy.kt`, `Ex10_OrderBy.kt`, `Ex11_Join.kt`                                                                                                                      |
 | 변경 고급  | `Ex12_InsertInto_Select.kt`, `Ex13_Replace.kt`, `Ex14_MergeBase.kt`, `Ex14_MergeTable.kt`, `Ex14_MergeSelect.kt`, `Ex15_Returning.kt`                                                                                              |
-| 성능/확장  | `Ex16_FetchBatchedResults.kt`, `Ex17_Union.kt`, `Ex20_AdjustQuery.kt`, `Ex21_Arithmetic.kt`, `Ex22_ColumnWithTransform.kt`, `Ex23_Conditions.kt`, `Ex30_Explain.kt`, `Ex40_LateralJoin.kt`, `Ex50_RecursiveCTE.kt`, `Ex99_Dual.kt` |
+| 성능/확장  | `Ex16_FetchBatchedResults.kt`, `Ex17_Union.kt`, `Ex20_AdjustQuery.kt`, `Ex21_Arithmetic.kt`, `Ex22_ColumnWithTransform.kt`, `Ex23_Conditions.kt`, `Ex30_Explain.kt`, `Ex40_LateralJoin.kt`, `Ex50_RecursiveCTE.kt`, `Ex51_CteQueryBuilder.kt`, `Ex99_Dual.kt` |
 
 ## DB별 기능 지원 현황
 
@@ -195,7 +195,7 @@ erDiagram
 | `MERGE`        | O  | O          | X        | X       |
 | `REPLACE`      | X  | X          | O        | O       |
 | `LATERAL JOIN` | X  | O          | O        | X       |
-| `CTE (WITH)`   | X  | O          | O        | O       |
+| `CTE (WITH)`   | O  | O          | O        | O       |
 | `UPSERT`       | O  | O          | O        | O       |
 
 ## 실행 방법
@@ -236,7 +236,9 @@ USE_FAST_DB=true ./gradlew :05-exposed-dml:01-dml:test
 재귀 CTE를 Raw SQL로 실행하는 방법을 학습합니다. `WITH RECURSIVE` 구문을 통해 계층형 데이터(트리 구조)를 조회합니다.
 
 - 예제: [`Ex50_RecursiveCTE.kt`](src/test/kotlin/exposed/examples/dml/Ex50_RecursiveCTE.kt)
-- 지원 DB: PostgreSQL, MySQL V8, MariaDB (H2 미지원)
+- Query Builder 예제: [`Ex51_CteQueryBuilder.kt`](src/test/kotlin/exposed/examples/dml/Ex51_CteQueryBuilder.kt)
+- Raw SQL 예제 지원 DB: PostgreSQL, MySQL V8, MariaDB.
+- Query Builder 예제 지원 DB: H2, PostgreSQL, MySQL V8.
 
 ### Window Function
 

--- a/05-exposed-dml/01-dml/README.md
+++ b/05-exposed-dml/01-dml/README.md
@@ -184,7 +184,7 @@ Source location: `src/test/kotlin/exposed/examples/dml`
 | Basic DML       | `Ex01_Select.kt`, `Ex02_Insert.kt`, `Ex03_Update.kt`, `Ex04_Upsert.kt`, `Ex05_Delete.kt`                                                                                                                                            |
 | Advanced SELECT | `Ex06_Exists.kt`, `Ex07_DistinctOn.kt`, `Ex08_Count.kt`, `Ex09_GroupBy.kt`, `Ex10_OrderBy.kt`, `Ex11_Join.kt`                                                                                                                       |
 | Advanced DML    | `Ex12_InsertInto_Select.kt`, `Ex13_Replace.kt`, `Ex14_MergeBase.kt`, `Ex14_MergeTable.kt`, `Ex14_MergeSelect.kt`, `Ex15_Returning.kt`                                                                                               |
-| Performance/Extension | `Ex16_FetchBatchedResults.kt`, `Ex17_Union.kt`, `Ex20_AdjustQuery.kt`, `Ex21_Arithmetic.kt`, `Ex22_ColumnWithTransform.kt`, `Ex23_Conditions.kt`, `Ex30_Explain.kt`, `Ex40_LateralJoin.kt`, `Ex50_RecursiveCTE.kt`, `Ex99_Dual.kt` |
+| Performance/Extension | `Ex16_FetchBatchedResults.kt`, `Ex17_Union.kt`, `Ex20_AdjustQuery.kt`, `Ex21_Arithmetic.kt`, `Ex22_ColumnWithTransform.kt`, `Ex23_Conditions.kt`, `Ex30_Explain.kt`, `Ex40_LateralJoin.kt`, `Ex50_RecursiveCTE.kt`, `Ex51_CteQueryBuilder.kt`, `Ex99_Dual.kt` |
 
 ## Feature Support by DB
 
@@ -195,7 +195,7 @@ Source location: `src/test/kotlin/exposed/examples/dml`
 | `MERGE`        | O  | O          | X        | X       |
 | `REPLACE`      | X  | X          | O        | O       |
 | `LATERAL JOIN` | X  | O          | O        | X       |
-| `CTE (WITH)`   | X  | O          | O        | O       |
+| `CTE (WITH)`   | O  | O          | O        | O       |
 | `UPSERT`       | O  | O          | O        | O       |
 
 ## Running Tests
@@ -236,7 +236,9 @@ USE_FAST_DB=true ./gradlew :05-exposed-dml:01-dml:test
 Learn how to run recursive CTEs as raw SQL. Use `WITH RECURSIVE` syntax to query hierarchical data (tree structures).
 
 - Example: [`Ex50_RecursiveCTE.kt`](src/test/kotlin/exposed/examples/dml/Ex50_RecursiveCTE.kt)
-- Supported DBs: PostgreSQL, MySQL V8, MariaDB (not H2)
+- Query Builder example: [`Ex51_CteQueryBuilder.kt`](src/test/kotlin/exposed/examples/dml/Ex51_CteQueryBuilder.kt)
+- Raw SQL example support: PostgreSQL, MySQL V8, MariaDB.
+- Query Builder example support: H2, PostgreSQL, MySQL V8.
 
 ### Window Function
 

--- a/05-exposed-dml/01-dml/src/test/kotlin/exposed/examples/dml/Ex51_CteQueryBuilder.kt
+++ b/05-exposed-dml/01-dml/src/test/kotlin/exposed/examples/dml/Ex51_CteQueryBuilder.kt
@@ -1,0 +1,134 @@
+package exposed.examples.dml
+
+import exposed.shared.tests.AbstractExposedTest
+import exposed.shared.tests.TestDB
+import exposed.shared.tests.withTables
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.exposed.core.CteTable
+import io.bluetape4k.exposed.jdbc.withCte
+import io.bluetape4k.logging.KLogging
+import org.jetbrains.exposed.v1.core.QueryBuilder
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.crossJoin
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.select
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+/**
+ * `CteTable` 과 `withCte` 로 Exposed Query Builder 기반 CTE를 작성하는 예제.
+ *
+ * Raw SQL 문자열 대신 Exposed DSL 쿼리를 CTE 본문으로 재사용하고, CTE 임시 테이블의 컬럼을
+ * `cte[원본컬럼]` 형태로 참조합니다.
+ */
+class Ex51_CteQueryBuilder: AbstractExposedTest() {
+
+    companion object: KLogging() {
+        private val cteSupportedDb = TestDB.ALL_H2 + TestDB.ALL_POSTGRES_LIKE + TestDB.MYSQL_V8
+    }
+
+    object CteUsers: Table("cte_query_builder_users") {
+        val id = integer("id")
+        val name = varchar("name", 64)
+        val active = bool("active")
+        val managerId = integer("manager_id").nullable()
+
+        override val primaryKey = PrimaryKey(id)
+    }
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `query builder cte filters active users`(testDB: TestDB) {
+        Assumptions.assumeTrue { testDB in cteSupportedDb }
+
+        withTables(testDB, CteUsers) {
+            seedUsers()
+
+            val activeUsers = CteTable(
+                name = "active_users",
+                query = CteUsers
+                    .select(CteUsers.id, CteUsers.name)
+                    .where { CteUsers.active eq true }
+            )
+            val activeName = activeUsers[CteUsers.name]
+            val query = activeUsers
+                .select(activeName)
+                .withCte(activeUsers)
+                .orderBy(activeUsers[CteUsers.id])
+
+            val builder = QueryBuilder(prepared = true)
+            val sql = query.prepareSQL(builder)
+
+            sql shouldContain "WITH"
+            sql.lowercase() shouldContain "active_users"
+            builder.args.map { it.second } shouldBeEqualTo listOf(true)
+
+            query.map { it[activeName] } shouldBeEqualTo listOf("root", "child")
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `recursive query builder cte references temporary table columns`(testDB: TestDB) {
+        Assumptions.assumeTrue { testDB in cteSupportedDb }
+
+        withTables(testDB, CteUsers) {
+            seedUsers()
+
+            val hierarchy = CteTable(
+                name = "user_hierarchy",
+                query = CteUsers
+                    .select(CteUsers.id, CteUsers.name, CteUsers.managerId)
+                    .where { CteUsers.managerId.isNull() and (CteUsers.active eq true) },
+                recursiveQuery = { cte ->
+                    CteUsers
+                        .crossJoin(cte)
+                        .select(CteUsers.id, CteUsers.name, CteUsers.managerId)
+                        .where { CteUsers.managerId eq cte[CteUsers.id] }
+                }
+            )
+            val hierarchyName = hierarchy[CteUsers.name]
+            val query = hierarchy
+                .select(hierarchyName)
+                .withCte(hierarchy)
+                .orderBy(hierarchy[CteUsers.id])
+
+            val sql = query.prepareSQL(QueryBuilder(prepared = true))
+
+            sql shouldContain "WITH RECURSIVE"
+            query.map { it[hierarchyName] } shouldBeEqualTo listOf("root", "child", "inactive-child")
+        }
+    }
+
+    private fun seedUsers() {
+        CteUsers.insert {
+            it[id] = 1
+            it[name] = "root"
+            it[active] = true
+            it[managerId] = null
+        }
+        CteUsers.insert {
+            it[id] = 2
+            it[name] = "child"
+            it[active] = true
+            it[managerId] = 1
+        }
+        CteUsers.insert {
+            it[id] = 3
+            it[name] = "inactive-child"
+            it[active] = false
+            it[managerId] = 2
+        }
+        CteUsers.insert {
+            it[id] = 4
+            it[name] = "other-root"
+            it[active] = false
+            it[managerId] = null
+        }
+    }
+}

--- a/docs/lessons/2026-05-18-cte-query-builder-example.md
+++ b/docs/lessons/2026-05-18-cte-query-builder-example.md
@@ -1,0 +1,22 @@
+# CTE Query Builder Example
+
+## Context
+
+`bluetape4k-exposed` published the `CteTable` and JDBC `withCte` APIs as
+`1.8.1-SNAPSHOT`, so the workshop can demonstrate CTEs without raw SQL.
+
+## Lesson
+
+Keep workshop snapshot adoption narrow. `exposed-workshop` still depends on the
+main `bluetape4k` line for general utilities, while Exposed artifacts can move
+through a dedicated `bluetape4k-exposed` version key.
+
+## Evidence
+
+- Added `Ex51_CteQueryBuilder` beside the existing raw SQL `Ex50_RecursiveCTE`.
+- Verified `CteTable` and `withCte` with H2 through the `:01-dml:test` fast path.
+
+## Future Guard
+
+When adding examples for a freshly published snapshot API, separate library-line
+versions if only one artifact family needs the snapshot.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 
 [versions]
 bluetape4k = "1.8.0-SNAPSHOT"
+bluetape4k-exposed = "1.8.1-SNAPSHOT"
 
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.11.0"
@@ -129,14 +130,14 @@ bluetape4k-jackson2 = { module = "io.github.bluetape4k:bluetape4k-jackson2" , ve
 bluetape4k-jackson3 = { module = "io.github.bluetape4k:bluetape4k-jackson3" , version.ref = "bluetape4k" }
 
 # exposed
-exposed-core = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-core" , version.ref = "bluetape4k" }
-exposed-dao = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-dao" , version.ref = "bluetape4k" }
-exposed-fastjson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-fastjson2" , version.ref = "bluetape4k" }
-exposed-jackson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson2" , version.ref = "bluetape4k" }
-exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" , version.ref = "bluetape4k" }
-exposed-jdbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc" , version.ref = "bluetape4k" }
-exposed-jdbc-redisson = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-redisson" , version.ref = "bluetape4k" }
-exposed-tink = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-tink" , version.ref = "bluetape4k" }
+exposed-core = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-core" , version.ref = "bluetape4k-exposed" }
+exposed-dao = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-dao" , version.ref = "bluetape4k-exposed" }
+exposed-fastjson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-fastjson2" , version.ref = "bluetape4k-exposed" }
+exposed-jackson2 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson2" , version.ref = "bluetape4k-exposed" }
+exposed-jackson3 = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jackson3" , version.ref = "bluetape4k-exposed" }
+exposed-jdbc = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc" , version.ref = "bluetape4k-exposed" }
+exposed-jdbc-redisson = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-jdbc-redisson" , version.ref = "bluetape4k-exposed" }
+exposed-tink = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-tink" , version.ref = "bluetape4k-exposed" }
 
 # bluetape4k hibernate
 bluetape4k-hibernate-reactive = { module = "io.github.bluetape4k:bluetape4k-hibernate-reactive" , version.ref = "bluetape4k" }


### PR DESCRIPTION
## Summary

- add a JDBC DML example for `CteTable` and `withCte`
- keep `bluetape4k-exposed` on `1.8.1-SNAPSHOT` through a dedicated version key
- document the Query Builder CTE example in English and Korean README files
- capture a lesson for narrow snapshot adoption

## Validation

- `./gradlew :01-dml:test --tests 'exposed.examples.dml.Ex51_CteQueryBuilder' -PuseFastDB=true`\n- `git diff --check`\n\n## Notes\n\nPostgreSQL/MySQL matrix execution is left to CI or a broader local DB run.