### PR TITLE
Align Exposed workshop shared versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,14 +9,14 @@ kotlinx-coroutines = "1.11.0"
 kotlinx-serialization = "1.11.0"
 kotlinx-atomicfu = "0.32.1"
 kotlinx-benchmark = "0.4.15"
-ktor = "3.4.3"
+ktor = "3.5.0"
 
 spring-boot = "4.0.6"
-reactor-bom = "2024.0.14"
+reactor-bom = "2025.0.5"
 
-exposed = "1.2.0"
+exposed = "1.3.0"
 
-slf4j = "2.0.17"
+slf4j = "2.0.18"
 logback = "1.5.32"
 
 junit-jupiter = "6.0.3"
@@ -27,16 +27,16 @@ testcontainers = "2.0.5"
 
 hikaricp = "7.0.2"
 h2-v2 = "2.4.240"
-mysql-connector-j = "9.6.0"
+mysql-connector-j = "9.7.0"
 mariadb-java-client = "3.5.8"
-postgresql-driver = "42.7.10"
+postgresql-driver = "42.7.11"
 pgjdbc-ng = "0.8.9"
 r2dbc-h2 = "1.1.0.RELEASE"
 r2dbc-pool = "1.0.2.RELEASE"
 r2dbc-postgresql = "1.1.1.RELEASE"
 
 lettuce = "6.8.2.RELEASE"
-redisson = "4.3.1"
+redisson = "4.4.0"
 
 hibernate = "7.3.3.Final"
 hibernate-reactive = "4.3.3.Final"
@@ -53,26 +53,26 @@ caffeine = "3.2.3"
 
 vertx = "5.0.12"
 
-springdoc-openapi = "2.8.14"
+springdoc-openapi = "3.0.3"
 
-gatling = "3.14.9"
+gatling = "3.15.0"
 
-agroal = "3.0"
+agroal = "3.1.2"
 
 jmh = "1.37"
 datafaker = "2.5.4"
 random-beans = "3.9.0"
 
 java-uuid-generator = "5.2.0"
-logcaptor = "2.12.1"
+logcaptor = "2.12.6"
 mybatis-dynamic-sql = "1.5.2"
 
 snappy-java = "1.1.10.8"
 lz4-java = "1.8.0"
-zstd-jni = "1.5.7-1"
+zstd-jni = "1.5.7-8"
 
 findbugs = "3.0.2"
-guava = "33.5.0-jre"
+guava = "33.6.0-jre"
 kryo = "5.6.2"
 fory-kotlin = "0.15.0"
 
@@ -83,7 +83,7 @@ javax-money-api = "1.1"
 # Plugin versions
 detekt = "1.23.8"
 dependency-management = "1.1.7"
-dokka = "2.1.0"
+dokka = "2.2.0"
 kover = "0.9.8"
 test-logger = "4.0.0"
 graalvm-native = "1.0.0"
@@ -106,7 +106,7 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 test-logger = { id = "com.adarshr.test-logger", version.ref = "test-logger" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 graalvm-native = { id = "org.graalvm.buildtools.native", version.ref = "graalvm-native" }
-gatling = { id = "io.gatling.gradle", version = "3.15.0.1" }
+gatling = { id = "io.gatling.gradle", version = "3.15.0" }
 
 [libraries]
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.1.0" }
@@ -358,20 +358,20 @@ jakarta-servlet-api = { module = "jakarta.servlet:jakarta.servlet-api", version 
 jakarta-transaction-api = { module = "jakarta.transaction:jakarta.transaction-api", version = "2.0.1" }
 jakarta-validation-api = { module = "jakarta.validation:jakarta.validation-api", version = "3.1.1" }
 jakarta-ws-rs-api = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version = "4.0.0" }
-jakarta-xml-bind = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version = "4.0.2" }
+jakarta-xml-bind = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version = "4.0.5" }
 
 # Apache Commons
 commons-beanutils = { module = "commons-beanutils:commons-beanutils", version = "1.11.0" }
-commons-codec = { module = "commons-codec:commons-codec", version = "1.18.0" }
+commons-codec = { module = "commons-codec:commons-codec", version = "1.22.0" }
 commons-collections4 = { module = "org.apache.commons:commons-collections4", version = "4.5.0" }
 commons-compress = { module = "org.apache.commons:commons-compress", version = "1.27.1" }
-commons-csv = { module = "org.apache.commons:commons-csv", version = "1.14.0" }
-commons-exec = { module = "org.apache.commons:commons-exec", version = "1.5.0" }
-commons-io = { module = "commons-io:commons-io", version = "2.19.0" }
+commons-csv = { module = "org.apache.commons:commons-csv", version = "1.14.1" }
+commons-exec = { module = "org.apache.commons:commons-exec", version = "1.6.0" }
+commons-io = { module = "commons-io:commons-io", version = "2.22.0" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.17.0" }
-commons-logging = { module = "commons-logging:commons-logging", version = "1.3.5" }
+commons-logging = { module = "commons-logging:commons-logging", version = "1.3.6" }
 commons-math3 = { module = "org.apache.commons:commons-math3", version = "3.6.1" }
-commons-pool2 = { module = "org.apache.commons:commons-pool2", version = "2.12.1" }
+commons-pool2 = { module = "org.apache.commons:commons-pool2", version = "2.13.1" }
 commons-text = { module = "org.apache.commons:commons-text", version = "1.13.1" }
 
 # Test


### PR DESCRIPTION
## Summary
- align shared dependency and plugin versions with bluetape4k-dependencies
- move Exposed-related shared refs to the governed version train

## Verification
- scripts/sync-shared-versions.py --workspace /tmp/bluetape4k-shared-version-workspace --check --summary

## Notes
- This PR only changes the Gradle version catalog. Full MySQL cache-strategy failure triage remains separate if CI still reproduces it.