### PR TITLE
[build] Sync MyBatis Dynamic SQL 2.0 catalog version

### DIFF
--- a/docs/lessons/2026-05-20-mybatis-dynamic-sql-2-catalog-sync.md
+++ b/docs/lessons/2026-05-20-mybatis-dynamic-sql-2-catalog-sync.md
@@ -1,0 +1,22 @@
+# MyBatis Dynamic SQL 2 Catalog Sync
+
+## Context
+
+`bluetape4k-dependencies` promoted MyBatis Dynamic SQL to 2.0.0 and Fory Kotlin
+to 0.17.0 as shared catalog versions.
+
+## Decision
+
+Materialize the shared catalog change in the Exposed workshop repository and
+verify the build still compiles.
+
+## Outcome
+
+`gradle/libs.versions.toml` now carries MyBatis Dynamic SQL 2.0.0 and Fory
+Kotlin 0.17.0.
+
+## Verification
+
+- `./gradlew build -x test --no-daemon`
+
+The build completed with existing unrelated warnings.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,7 +65,7 @@ random-beans = "3.9.0"
 
 java-uuid-generator = "5.2.0"
 logcaptor = "2.12.6"
-mybatis-dynamic-sql = "1.5.2"
+mybatis-dynamic-sql = "2.0.0"
 
 snappy-java = "1.1.10.8"
 lz4-java = "1.8.0"
@@ -74,7 +74,7 @@ zstd-jni = "1.5.7-8"
 findbugs = "3.0.2"
 guava = "33.6.0-jre"
 kryo = "5.6.2"
-fory-kotlin = "0.15.0"
+fory-kotlin = "0.17.0"
 
 javassist = "3.30.2-GA"
 javamoney-moneta = "1.4.5"


### PR DESCRIPTION
## Summary

Refs bluetape4k/bluetape4k-dependencies#34
Refs bluetape4k/bluetape4k-dependencies#53

- Materialize MyBatis Dynamic SQL 2.0.0 from the central catalog.
- Materialize Fory Kotlin 0.17.0 from the central catalog.
- Add a catalog-sync lesson.

## Validation

- `./gradlew build -x test --no-daemon` before Fory materialization
- Central symlink workspace sync check: shared versions aligned.