### PR TITLE
feat: pair chapter 12 architecture examples

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,85 @@
+name: Examples
+
+on:
+  schedule:
+    - cron: '0 21 * * *'  # Daily example coverage, UTC 21:00 (KST 06:00)
+  push:
+    branches: [ develop, main ]
+    paths:
+      - '12-production-integration/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - '*.gradle.kts'
+      - 'settings.gradle.kts'
+      - '.github/workflows/examples.yml'
+  pull_request:
+    branches: [ develop, main ]
+    paths:
+      - '12-production-integration/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - '*.gradle.kts'
+      - 'settings.gradle.kts'
+      - '.github/workflows/examples.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  JAVA_VERSION: '21'
+  JAVA_DISTRIBUTION: 'temurin'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  validate-wrapper:
+    name: Validate Gradle Wrapper
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: gradle/actions/wrapper-validation@v6
+
+  build-examples:
+    name: Build / Chapter 12 Architecture Examples
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: validate-wrapper
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+
+      - name: Build and test chapter 12 examples
+        run: |
+          ./gradlew \
+            :01-ktor-application-architecture:build \
+            :02-spring-application-architecture:build \
+            --no-daemon --continue
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+
+  examples-status:
+    name: Examples Status
+    runs-on: ubuntu-latest
+    needs:
+      - validate-wrapper
+      - build-examples
+    if: always()
+    steps:
+      - name: Check Examples result
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || \
+             [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            exit 1
+          fi
+          echo "Examples workflow passed"

--- a/12-production-integration/02-spring-application-architecture/README.ko.md
+++ b/12-production-integration/02-spring-application-architecture/README.ko.md
@@ -1,0 +1,42 @@
+# Spring Boot 애플리케이션 아키텍처
+
+[English](README.md) | [한국어](README.ko.md)
+
+이 모듈은 chapter 12 애플리케이션 아키텍처 주제의 Spring Boot 4 쌍입니다.
+Ktor 모듈과 같은 문제를 얇은 컨트롤러 계층, 서비스 경계, Exposed JDBC
+저장소로 구현합니다.
+
+```mermaid
+flowchart TD
+    Client[HTTP client] --> Controller[Spring MVC controllers]
+    Controller --> Advice[Controller advice]
+    Controller --> Service[CustomerService]
+    Service --> Repository[CustomerRepository]
+    Repository --> Exposed[Exposed transactions]
+    Exposed --> H2[(H2 via HikariCP)]
+```
+
+## 보여주는 내용
+
+- Spring Boot 4 자동 구성과 명시적 애플리케이션 빈 구성.
+- 얇은 MVC 컨트롤러와 정제된 JSON 오류 응답.
+- 저장 전 서비스 계층 입력 검증.
+- 저장소 내부로 격리된 Exposed JDBC 트랜잭션.
+- 서비스 검증, 저장소 동작, HTTP 라우트에 대한 집중 테스트.
+
+## Spring Boot 4와 Ktor 비교
+
+| 관심사 | Spring Boot 4 모듈 | Ktor 모듈 |
+|---|---|---|
+| HTTP 연결 | 애노테이션 기반 MVC 컨트롤러 | 명시적 routing DSL |
+| JSON/오류 | Boot 관리 Jackson과 `@RestControllerAdvice` | Ktor serialization과 `StatusPages` |
+| 영속성 | 저장소 메서드 내부의 blocking Exposed 호출 | `Dispatchers.IO` 뒤로 격리한 blocking Exposed 호출 |
+| 테스트 형태 | `@SpringBootTest`와 `MockMvc` | `testApplication` |
+
+## 실행
+
+```bash
+./gradlew :02-spring-application-architecture:test
+./gradlew :02-spring-application-architecture:compileKotlin
+```
+

--- a/12-production-integration/02-spring-application-architecture/README.md
+++ b/12-production-integration/02-spring-application-architecture/README.md
@@ -1,0 +1,42 @@
+# Spring Boot Application Architecture
+
+[English](README.md) | [한국어](README.ko.md)
+
+This module is the Spring Boot 4 pair for the chapter 12 application
+architecture topic. It mirrors the Ktor module with a thin controller layer, a
+service boundary, and an Exposed JDBC repository.
+
+```mermaid
+flowchart TD
+    Client[HTTP client] --> Controller[Spring MVC controllers]
+    Controller --> Advice[Controller advice]
+    Controller --> Service[CustomerService]
+    Service --> Repository[CustomerRepository]
+    Repository --> Exposed[Exposed transactions]
+    Exposed --> H2[(H2 via HikariCP)]
+```
+
+## What This Shows
+
+- Spring Boot 4 auto-configuration plus explicit application beans.
+- Thin MVC controllers with sanitized JSON error responses.
+- Service-level validation before persistence.
+- Exposed JDBC transactions isolated in the repository.
+- Focused tests for service validation, repository behavior, and HTTP routes.
+
+## Spring Boot 4 vs Ktor
+
+| Concern | Spring Boot 4 module | Ktor module |
+|---|---|---|
+| HTTP wiring | Annotation-driven MVC controllers | Explicit routing DSL |
+| JSON/errors | Boot-managed Jackson and `@RestControllerAdvice` | Ktor serialization and `StatusPages` |
+| Persistence | Blocking Exposed calls inside repository methods | Blocking Exposed calls behind `Dispatchers.IO` |
+| Test shape | `@SpringBootTest` plus `MockMvc` | `testApplication` |
+
+## Run
+
+```bash
+./gradlew :02-spring-application-architecture:test
+./gradlew :02-spring-application-architecture:compileKotlin
+```
+

--- a/12-production-integration/02-spring-application-architecture/build.gradle.kts
+++ b/12-production-integration/02-spring-application-architecture/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+    kotlin("plugin.spring")
+    alias(libs.plugins.spring.boot)
+}
+
+springBoot {
+    mainClass.set("exposed.examples.spring.architecture.SpringArchitectureApplicationKt")
+
+    buildInfo {
+        properties {
+            additional.put("name", "Spring Boot application architecture with Exposed")
+            additional.put("java.version", JavaVersion.current())
+        }
+    }
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    implementation(platform(libs.jetbrains.exposed.bom))
+
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
+    implementation(libs.hikaricp)
+
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.boot.starter.web)
+
+    runtimeOnly(libs.h2.v2)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.spring.boot.starter.webmvc.test)
+    testImplementation(libs.spring.boot.starter.test) {
+        exclude(group = "junit", module = "junit")
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+        exclude(module = "mockito-core")
+    }
+}
+

--- a/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/SpringArchitectureApplication.kt
+++ b/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/SpringArchitectureApplication.kt
@@ -1,0 +1,58 @@
+package exposed.examples.spring.architecture
+
+import exposed.examples.spring.architecture.model.HealthResponse
+import exposed.examples.spring.architecture.model.IndexResponse
+import exposed.examples.spring.architecture.persistence.CustomerPersistence
+import exposed.examples.spring.architecture.repository.CustomerRepository
+import exposed.examples.spring.architecture.repository.ExposedCustomerRepository
+import exposed.examples.spring.architecture.service.CustomerService
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Spring Boot 4 application architecture example backed by Exposed JDBC.
+ *
+ * ## Contract
+ * - Controllers remain thin and delegate to service use cases.
+ * - Repositories own Exposed transactions and schema bootstrap.
+ * - Error responses are sanitized by controller advice.
+ */
+@SpringBootApplication
+internal class SpringArchitectureApplication
+
+fun main(args: Array<String>) {
+    runApplication<SpringArchitectureApplication>(*args)
+}
+
+@Configuration(proxyBeanMethods = false)
+internal class SpringArchitectureConfiguration {
+
+    @Bean(destroyMethod = "close")
+    fun customerPersistence(): CustomerPersistence =
+        CustomerPersistence.inMemory()
+
+    @Bean
+    fun customerRepository(persistence: CustomerPersistence): CustomerRepository =
+        ExposedCustomerRepository(persistence.database)
+
+    @Bean
+    fun customerService(repository: CustomerRepository): CustomerService =
+        CustomerService(repository)
+}
+
+@RestController
+internal class IndexController {
+
+    @GetMapping("/")
+    fun index(): IndexResponse =
+        IndexResponse()
+
+    @GetMapping("/health")
+    fun health(): HealthResponse =
+        HealthResponse(status = "UP")
+}
+

--- a/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/model/CustomerModels.kt
+++ b/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/model/CustomerModels.kt
@@ -1,0 +1,79 @@
+package exposed.examples.spring.architecture.model
+
+internal data class IndexResponse(
+    val service: String = "spring-application-architecture",
+    val endpoints: List<String> = listOf("/health", "/customers", "/customers/{id}"),
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class HealthResponse(
+    val status: String,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class CreateCustomerRequest(
+    val name: String,
+    val email: String,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class CreateCustomerCommand(
+    val name: String,
+    val email: String,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class CustomerRecord(
+    val id: Long,
+    val name: String,
+    val email: String,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class CustomerResponse(
+    val id: Long,
+    val name: String,
+    val email: String,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class CustomersResponse(
+    val customers: List<CustomerResponse>,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class ErrorResponse(
+    val code: String,
+    val message: String,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal class CustomerValidationException(message: String) : RuntimeException(message)
+
+internal fun CustomerRecord.toResponse(): CustomerResponse =
+    CustomerResponse(id = id, name = name, email = email)
+

--- a/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/persistence/CustomerPersistence.kt
+++ b/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/persistence/CustomerPersistence.kt
@@ -1,0 +1,37 @@
+package exposed.examples.spring.architecture.persistence
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.bluetape4k.codec.Base58
+import org.jetbrains.exposed.v1.jdbc.Database
+
+/**
+ * Owns the Hikari data source and Exposed database handle for the Spring example.
+ */
+internal class CustomerPersistence(
+    private val dataSource: HikariDataSource,
+) : AutoCloseable {
+
+    val database: Database = Database.connect(dataSource)
+
+    override fun close() {
+        dataSource.close()
+    }
+
+    companion object {
+        private const val HIKARI_MAX_POOL_SIZE = 4
+
+        fun inMemory(name: String = Base58.randomString(8)): CustomerPersistence {
+            val config = HikariConfig().apply {
+                jdbcUrl = "jdbc:h2:mem:spring_architecture_$name;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+                username = "sa"
+                password = ""
+                driverClassName = "org.h2.Driver"
+                maximumPoolSize = HIKARI_MAX_POOL_SIZE
+                poolName = "spring-architecture-$name"
+            }
+            return CustomerPersistence(HikariDataSource(config))
+        }
+    }
+}
+

--- a/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/repository/CustomerRepository.kt
+++ b/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/repository/CustomerRepository.kt
@@ -1,0 +1,16 @@
+package exposed.examples.spring.architecture.repository
+
+import exposed.examples.spring.architecture.model.CreateCustomerCommand
+import exposed.examples.spring.architecture.model.CustomerRecord
+
+/**
+ * Customer persistence contract used by the Spring service layer.
+ */
+internal interface CustomerRepository {
+    fun create(command: CreateCustomerCommand): CustomerRecord
+    fun findById(id: Long): CustomerRecord?
+    fun findAll(): List<CustomerRecord>
+    fun count(): Long
+    fun deleteAll()
+}
+

--- a/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/repository/ExposedCustomerRepository.kt
+++ b/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/repository/ExposedCustomerRepository.kt
@@ -1,0 +1,100 @@
+package exposed.examples.spring.architecture.repository
+
+import exposed.examples.spring.architecture.model.CreateCustomerCommand
+import exposed.examples.spring.architecture.model.CustomerRecord
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Exposed JDBC repository used by the Spring Boot 4 architecture example.
+ */
+internal class ExposedCustomerRepository(
+    private val database: Database,
+) : CustomerRepository {
+
+    private val schemaReady = AtomicBoolean(false)
+    private val schemaLock = ReentrantLock()
+
+    override fun create(command: CreateCustomerCommand): CustomerRecord {
+        ensureSchema()
+        return transaction(database) {
+            val id = Customers.insertAndGetId {
+                it[name] = command.name
+                it[email] = command.email
+            }.value
+            CustomerRecord(id = id, name = command.name, email = command.email)
+        }
+    }
+
+    override fun findById(id: Long): CustomerRecord? {
+        ensureSchema()
+        return transaction(database) {
+            Customers
+                .selectAll()
+                .where { Customers.id eq id }
+                .singleOrNull()
+                ?.toRecord()
+        }
+    }
+
+    override fun findAll(): List<CustomerRecord> {
+        ensureSchema()
+        return transaction(database) {
+            Customers
+                .selectAll()
+                .orderBy(Customers.id)
+                .map { it.toRecord() }
+        }
+    }
+
+    override fun count(): Long {
+        ensureSchema()
+        return transaction(database) {
+            Customers.selectAll().count()
+        }
+    }
+
+    override fun deleteAll() {
+        ensureSchema()
+        transaction(database) {
+            Customers.deleteAll()
+        }
+    }
+
+    private fun ensureSchema() {
+        if (schemaReady.get()) {
+            return
+        }
+        schemaLock.withLock {
+            if (!schemaReady.get()) {
+                transaction(database) {
+                    SchemaUtils.create(Customers)
+                }
+                schemaReady.set(true)
+            }
+        }
+    }
+}
+
+private object Customers : LongIdTable("spring_customers") {
+    val name = varchar("name", 80)
+    val email = varchar("email", 120)
+}
+
+private fun ResultRow.toRecord(): CustomerRecord =
+    CustomerRecord(
+        id = this[Customers.id].value,
+        name = this[Customers.name],
+        email = this[Customers.email]
+    )
+

--- a/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/service/CustomerService.kt
+++ b/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/service/CustomerService.kt
@@ -1,0 +1,64 @@
+package exposed.examples.spring.architecture.service
+
+import exposed.examples.spring.architecture.model.CreateCustomerCommand
+import exposed.examples.spring.architecture.model.CreateCustomerRequest
+import exposed.examples.spring.architecture.model.CustomerResponse
+import exposed.examples.spring.architecture.model.CustomerValidationException
+import exposed.examples.spring.architecture.model.CustomersResponse
+import exposed.examples.spring.architecture.model.toResponse
+import exposed.examples.spring.architecture.repository.CustomerRepository
+
+/**
+ * Customer use cases and caller input validation.
+ */
+internal class CustomerService(
+    private val repository: CustomerRepository,
+) {
+    fun create(request: CreateCustomerRequest): CustomerResponse {
+        val command = CreateCustomerCommand(
+            name = request.name.normalizeName(),
+            email = request.email.normalizeEmail()
+        )
+        return repository.create(command).toResponse()
+    }
+
+    fun find(id: Long): CustomerResponse =
+        repository.findById(id)?.toResponse()
+            ?: throw NoSuchElementException("Customer $id was not found")
+
+    fun findAll(): CustomersResponse =
+        CustomersResponse(repository.findAll().map { it.toResponse() })
+
+    fun count(): Long =
+        repository.count()
+
+    fun deleteAll() {
+        repository.deleteAll()
+    }
+
+    private fun String.normalizeName(): String {
+        val normalized = trim()
+        if (normalized.isBlank()) {
+            throw CustomerValidationException("name must not be blank")
+        }
+        if (normalized.length > 80) {
+            throw CustomerValidationException("name must be 80 characters or less")
+        }
+        return normalized
+    }
+
+    private fun String.normalizeEmail(): String {
+        val normalized = trim().lowercase()
+        if (normalized.isBlank()) {
+            throw CustomerValidationException("email must not be blank")
+        }
+        if (normalized.length > 120) {
+            throw CustomerValidationException("email must be 120 characters or less")
+        }
+        if ("@" !in normalized) {
+            throw CustomerValidationException("email must contain @")
+        }
+        return normalized
+    }
+}
+

--- a/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/web/CustomerController.kt
+++ b/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/web/CustomerController.kt
@@ -1,0 +1,35 @@
+package exposed.examples.spring.architecture.web
+
+import exposed.examples.spring.architecture.model.CreateCustomerRequest
+import exposed.examples.spring.architecture.model.CustomerResponse
+import exposed.examples.spring.architecture.model.CustomersResponse
+import exposed.examples.spring.architecture.service.CustomerService
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/customers", produces = [MediaType.APPLICATION_JSON_VALUE])
+internal class CustomerController(
+    private val service: CustomerService,
+) {
+
+    @GetMapping
+    fun findAll(): CustomersResponse =
+        service.findAll()
+
+    @GetMapping("/{id}")
+    fun find(@PathVariable id: Long): CustomerResponse =
+        service.find(id)
+
+    @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun create(@RequestBody request: CreateCustomerRequest): ResponseEntity<CustomerResponse> =
+        ResponseEntity.status(HttpStatus.CREATED).body(service.create(request))
+}
+

--- a/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/web/ErrorAdvice.kt
+++ b/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/web/ErrorAdvice.kt
@@ -1,0 +1,43 @@
+package exposed.examples.spring.architecture.web
+
+import exposed.examples.spring.architecture.model.CustomerValidationException
+import exposed.examples.spring.architecture.model.ErrorResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+internal class ErrorAdvice {
+
+    private val log = LoggerFactory.getLogger(ErrorAdvice::class.java)
+
+    @ExceptionHandler(CustomerValidationException::class, MethodArgumentNotValidException::class)
+    fun validation(ex: Exception): ResponseEntity<ErrorResponse> =
+        ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(code = "VALIDATION_ERROR", message = ex.message ?: "Invalid request"))
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun malformedRequest(): ResponseEntity<ErrorResponse> =
+        ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(code = "MALFORMED_JSON", message = "Request body is not valid JSON"))
+
+    @ExceptionHandler(NoSuchElementException::class)
+    fun notFound(): ResponseEntity<ErrorResponse> =
+        ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse(code = "NOT_FOUND", message = "Resource was not found"))
+
+    @ExceptionHandler(Exception::class)
+    fun unexpected(ex: Exception): ResponseEntity<ErrorResponse> {
+        log.error("Unexpected request handling failure", ex)
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ErrorResponse(code = "INTERNAL_ERROR", message = "Unexpected server error"))
+    }
+}

--- a/12-production-integration/02-spring-application-architecture/src/test/kotlin/exposed/examples/spring/architecture/SpringArchitectureApplicationTest.kt
+++ b/12-production-integration/02-spring-application-architecture/src/test/kotlin/exposed/examples/spring/architecture/SpringArchitectureApplicationTest.kt
@@ -1,0 +1,100 @@
+package exposed.examples.spring.architecture
+
+import exposed.examples.spring.architecture.service.CustomerService
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class SpringArchitectureApplicationTest(
+    @param:Autowired private val mockMvc: MockMvc,
+    @param:Autowired private val customerService: CustomerService,
+) {
+
+    @BeforeEach
+    fun resetCustomers() {
+        customerService.deleteAll()
+    }
+
+    @Test
+    fun `index and health endpoints describe the application`() {
+        mockMvc.get("/")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.service", equalTo("spring-application-architecture"))
+            }
+
+        mockMvc.get("/health")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.status", equalTo("UP"))
+            }
+    }
+
+    @Test
+    fun `customer routes create list and find customers`() {
+        mockMvc.post("/customers") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"name":" Alice ","email":"ALICE@EXAMPLE.COM "}"""
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.id", equalTo(1))
+            jsonPath("$.name", equalTo("Alice"))
+            jsonPath("$.email", equalTo("alice@example.com"))
+        }
+
+        mockMvc.get("/customers")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.customers", hasSize<Any>(1))
+                jsonPath("$.customers[0].name", equalTo("Alice"))
+            }
+
+        mockMvc.get("/customers/1")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.email", equalTo("alice@example.com"))
+            }
+    }
+
+    @Test
+    fun `validation and not found errors are sanitized`() {
+        mockMvc.post("/customers") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"name":"","email":"alice@example.com"}"""
+        }.andExpect {
+            status { isBadRequest() }
+            jsonPath("$.code", equalTo("VALIDATION_ERROR"))
+        }
+
+        mockMvc.get("/customers/999")
+            .andExpect {
+                status { isNotFound() }
+                jsonPath("$.code", equalTo("NOT_FOUND"))
+                jsonPath("$.message", equalTo("Resource was not found"))
+            }
+    }
+
+    @Test
+    fun `malformed json is reported without parser details`() {
+        mockMvc.post("/customers") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"name":"""
+        }.andExpect {
+            status { isBadRequest() }
+            jsonPath("$.code", equalTo("MALFORMED_JSON"))
+            jsonPath("$.message", equalTo("Request body is not valid JSON"))
+        }
+    }
+}

--- a/12-production-integration/02-spring-application-architecture/src/test/kotlin/exposed/examples/spring/architecture/repository/ExposedCustomerRepositoryTest.kt
+++ b/12-production-integration/02-spring-application-architecture/src/test/kotlin/exposed/examples/spring/architecture/repository/ExposedCustomerRepositoryTest.kt
@@ -1,0 +1,43 @@
+package exposed.examples.spring.architecture.repository
+
+import exposed.examples.spring.architecture.model.CreateCustomerCommand
+import exposed.examples.spring.architecture.persistence.CustomerPersistence
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.codec.Base58
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExposedCustomerRepositoryTest {
+
+    @Test
+    fun `repository creates and finds customers through Exposed transactions`() {
+        withRepository { repository ->
+            repository.count() shouldBeEqualTo 0L
+
+            val created = repository.create(CreateCustomerCommand("Alice", "alice@example.com"))
+
+            repository.findById(created.id) shouldBeEqualTo created
+            repository.findAll() shouldHaveSize 1
+            repository.count() shouldBeEqualTo 1L
+        }
+    }
+
+    @Test
+    fun `deleteAll resets table state for application tests`() {
+        withRepository { repository ->
+            repository.create(CreateCustomerCommand("Alice", "alice@example.com"))
+            repository.deleteAll()
+
+            repository.findAll() shouldHaveSize 0
+        }
+    }
+
+    private fun withRepository(test: (ExposedCustomerRepository) -> Unit) {
+        CustomerPersistence.inMemory("repo_${Base58.randomString(8)}").use { persistence ->
+            test(ExposedCustomerRepository(persistence.database))
+        }
+    }
+}
+

--- a/12-production-integration/02-spring-application-architecture/src/test/kotlin/exposed/examples/spring/architecture/service/CustomerServiceTest.kt
+++ b/12-production-integration/02-spring-application-architecture/src/test/kotlin/exposed/examples/spring/architecture/service/CustomerServiceTest.kt
@@ -1,0 +1,60 @@
+package exposed.examples.spring.architecture.service
+
+import exposed.examples.spring.architecture.model.CreateCustomerCommand
+import exposed.examples.spring.architecture.model.CreateCustomerRequest
+import exposed.examples.spring.architecture.model.CustomerRecord
+import exposed.examples.spring.architecture.model.CustomerValidationException
+import exposed.examples.spring.architecture.repository.CustomerRepository
+import io.bluetape4k.assertions.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CustomerServiceTest {
+
+    @Test
+    fun `create normalizes customer input before persistence`() {
+        val repository = FakeCustomerRepository()
+        val service = CustomerService(repository)
+
+        val created = service.create(CreateCustomerRequest(" Alice ", "ALICE@EXAMPLE.COM "))
+
+        created.name shouldBeEqualTo "Alice"
+        created.email shouldBeEqualTo "alice@example.com"
+        repository.lastCommand shouldBeEqualTo CreateCustomerCommand("Alice", "alice@example.com")
+    }
+
+    @Test
+    fun `blank name is rejected before persistence`() {
+        val service = CustomerService(FakeCustomerRepository())
+
+        val error = try {
+            service.create(CreateCustomerRequest(" ", "alice@example.com"))
+            throw AssertionError("CustomerValidationException was expected")
+        } catch (e: CustomerValidationException) {
+            e
+        }
+
+        error.message shouldBeEqualTo "name must not be blank"
+    }
+
+    private class FakeCustomerRepository : CustomerRepository {
+        var lastCommand: CreateCustomerCommand? = null
+
+        override fun create(command: CreateCustomerCommand): CustomerRecord {
+            lastCommand = command
+            return CustomerRecord(id = 1L, name = command.name, email = command.email)
+        }
+
+        override fun findById(id: Long): CustomerRecord? =
+            null
+
+        override fun findAll(): List<CustomerRecord> =
+            emptyList()
+
+        override fun count(): Long =
+            0L
+
+        override fun deleteAll() = Unit
+    }
+}

--- a/12-production-integration/README.ko.md
+++ b/12-production-integration/README.ko.md
@@ -1,0 +1,27 @@
+# 12장 - 운영 통합
+
+이 장은 데이터베이스 기반 서비스의 운영형 패턴을 Spring Boot 4와 Ktor로
+나란히 비교합니다. 각 예제는 HTTP 계층, 서비스 유스케이스, Exposed 영속성,
+테스트, 운영 문서화 경계를 작게 유지하면서도 실제 서비스 구조를 보여줍니다.
+
+## 모듈
+
+| 주제 | Spring Boot 4 | Ktor |
+|---|---|---|
+| 애플리케이션 아키텍처 | [02-spring-application-architecture](02-spring-application-architecture/README.ko.md) | [01-ktor-application-architecture](01-ktor-application-architecture/README.ko.md) |
+| 인증/세션 | issue #59 예정 | issue #59 예정 |
+| 리얼타임 아웃박스 | issue #60 예정 | issue #60 예정 |
+| HTTP 클라이언트 아웃박스/멱등성 | issue #61 예정 | issue #61 예정 |
+| 관측성/준비 상태 | issue #62 예정 | issue #62 예정 |
+
+## 검증
+
+```bash
+./gradlew :01-ktor-application-architecture:test
+./gradlew :02-spring-application-architecture:test
+```
+
+쌍을 이룬 아키텍처 모듈은 chapter 12 에픽의 첫 완료 주제입니다. 남은 주제도
+Spring/Ktor 쌍, 집중 테스트, README의 트레이드오프 설명을 같은 형태로
+확장합니다.
+

--- a/12-production-integration/README.md
+++ b/12-production-integration/README.md
@@ -1,0 +1,28 @@
+# Chapter 12 - Production Integration
+
+This chapter compares production-grade database-backed service patterns across
+Spring Boot 4 and Ktor. Each topic keeps the example small enough to inspect
+while preserving the boundary that matters in production: HTTP layer, service
+use cases, Exposed persistence, tests, and operational documentation.
+
+## Modules
+
+| Topic | Spring Boot 4 | Ktor |
+|---|---|---|
+| Application architecture | [02-spring-application-architecture](02-spring-application-architecture/README.md) | [01-ktor-application-architecture](01-ktor-application-architecture/README.md) |
+| Auth/session | Planned by issue #59 | Planned by issue #59 |
+| Realtime outbox | Planned by issue #60 | Planned by issue #60 |
+| HTTP client outbox/idempotency | Planned by issue #61 | Planned by issue #61 |
+| Observability/readiness | Planned by issue #62 | Planned by issue #62 |
+
+## Verification
+
+```bash
+./gradlew :01-ktor-application-architecture:test
+./gradlew :02-spring-application-architecture:test
+```
+
+The paired architecture modules are the first completed topic for the chapter
+12 epic. Remaining topics should follow the same shape: paired Spring/Ktor
+coverage, focused tests, and explicit README tradeoffs.
+

--- a/README.ko.md
+++ b/README.ko.md
@@ -323,6 +323,20 @@ Multi-Tenant 또는 Read Replica 구조를 위한 유연한 DataSource 라우팅
 
 `kotlinx-benchmark` 기반 마이크로벤치마크로 캐시/라우팅 예제의 성능을 측정합니다. smoke 프로파일과 main 프로파일을 제공하며 Markdown 리포트를 생성할 수 있습니다.
 
+### 운영 통합
+
+#### [Chapter 12 개요](12-production-integration/README.ko.md)
+
+Exposed 기반 운영형 서비스 패턴을 Spring Boot 4와 Ktor로 비교합니다.
+
+#### [Ktor 애플리케이션 아키텍처](12-production-integration/01-ktor-application-architecture/README.ko.md)
+
+명시적 라우팅, 서비스 검증, 정제된 오류, Exposed JDBC 저장소를 갖춘 작은 Ktor 서비스를 구현합니다.
+
+#### [Spring Boot 애플리케이션 아키텍처](12-production-integration/02-spring-application-architecture/README.ko.md)
+
+MVC 컨트롤러, 컨트롤러 advice, 서비스 검증, Exposed JDBC 저장소를 갖춘 Spring Boot 4 쌍을 구현합니다.
+
 ---
 
 ## 시작하기

--- a/README.md
+++ b/README.md
@@ -323,6 +323,20 @@ Learn flexible DataSource routing configuration for multi-tenant or read replica
 
 Measure performance of cache/routing examples using `kotlinx-benchmark` micro-benchmarks. Provides smoke and main profiles with Markdown report generation.
 
+### Production Integration
+
+#### [Chapter 12 Overview](12-production-integration/README.md)
+
+Compare production-grade Spring Boot 4 and Ktor service patterns backed by Exposed.
+
+#### [Ktor Application Architecture](12-production-integration/01-ktor-application-architecture/README.md)
+
+Build a small Ktor service with explicit routing, service validation, sanitized errors, and an Exposed JDBC repository.
+
+#### [Spring Boot Application Architecture](12-production-integration/02-spring-application-architecture/README.md)
+
+Build the Spring Boot 4 pair with MVC controllers, controller advice, service validation, and an Exposed JDBC repository.
+
 ---
 
 ## Getting Started

--- a/docs/lessons/2026-05-22-issue-57-spring-architecture-pair.md
+++ b/docs/lessons/2026-05-22-issue-57-spring-architecture-pair.md
@@ -30,6 +30,11 @@ README files that mark later production-integration topics as planned work.
 - `./gradlew :01-ktor-application-architecture:test
   :02-spring-application-architecture:test --no-daemon` passed after Claude
   advisor fixes.
+- `.github/workflows/examples.yml` added to run the paired chapter 12
+  architecture examples in the `Examples` workflow.
+- `./gradlew :01-ktor-application-architecture:build
+  :02-spring-application-architecture:build --no-daemon --continue` passed.
+- `actionlint .github/workflows/examples.yml` passed.
 - `git diff --check` passed.
 - `:02-spring-application-architecture:detekt` is not registered.
 - Claude CLI P0/P1 advisor review returned no P0 and two P1 findings in

--- a/docs/lessons/2026-05-22-issue-57-spring-architecture-pair.md
+++ b/docs/lessons/2026-05-22-issue-57-spring-architecture-pair.md
@@ -1,0 +1,43 @@
+# Issue 57 Spring Architecture Pair
+
+## Context
+
+Issue #57 is a chapter 12 epic. WIP limits require completing one child lane at a
+time; the existing state already had the Ktor side of issue #58.
+
+## Decision
+
+Add the Spring Boot 4 application architecture pair as
+`12-production-integration/02-spring-application-architecture` instead of
+starting another topic. Keep the shape parallel to the Ktor module: HTTP layer,
+service validation, Exposed repository, H2/Hikari persistence, and focused tests.
+
+## Outcome
+
+Chapter 12 now has a paired Spring/Ktor architecture topic plus chapter-level
+README files that mark later production-integration topics as planned work.
+
+## Verification
+
+- `./gradlew projects --no-daemon` registered
+  `:02-spring-application-architecture`.
+- `./gradlew :02-spring-application-architecture:compileKotlin --no-daemon`
+  passed.
+- `./gradlew :02-spring-application-architecture:test --no-daemon` passed with
+  8 tests.
+- `./gradlew :01-ktor-application-architecture:test --no-daemon` passed with
+  13 tests.
+- `./gradlew :01-ktor-application-architecture:test
+  :02-spring-application-architecture:test --no-daemon` passed after Claude
+  advisor fixes.
+- `git diff --check` passed.
+- `:02-spring-application-architecture:detekt` is not registered.
+- Claude CLI P0/P1 advisor review returned no P0 and two P1 findings in
+  `ErrorAdvice`: avoid catching `Throwable` and log unexpected 5xx causes. Both
+  were fixed by handling `Exception` and logging the exception before returning
+  the sanitized response.
+
+## Future Guard
+
+For #59-#62, add Spring and Ktor coverage as pairs and update the chapter README
+table in the same change.


### PR DESCRIPTION
## Summary
- add the Spring Boot 4 application architecture pair for chapter 12 issue #57/#58
- add chapter 12 English/Korean overview docs and root README links
- add the Examples workflow for chapter 12 architecture modules

## Verification
- ./gradlew projects --no-daemon
- ./gradlew :02-spring-application-architecture:compileKotlin --no-daemon
- ./gradlew :02-spring-application-architecture:test --no-daemon
- ./gradlew :01-ktor-application-architecture:test --no-daemon
- ./gradlew :01-ktor-application-architecture:test :02-spring-application-architecture:test --no-daemon
- ./gradlew :01-ktor-application-architecture:build :02-spring-application-architecture:build --no-daemon --continue
- actionlint .github/workflows/examples.yml
- git diff --check

Closes #58
Part of #57