### PR TITLE
Add HTTP outbox idempotency examples

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: gradle/actions/wrapper-validation@v6
 
   build-examples:
-    name: Build / Chapter 12 Architecture Examples
+    name: Build / Chapter 12 Examples
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: validate-wrapper
@@ -64,6 +64,8 @@ jobs:
           ./gradlew \
             :01-ktor-application-architecture:build \
             :02-spring-application-architecture:build \
+            :03-spring-http-outbox-idempotency:build \
+            :04-ktor-http-outbox-idempotency:build \
             --no-daemon --continue
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"

--- a/12-production-integration/03-spring-http-outbox-idempotency/README.ko.md
+++ b/12-production-integration/03-spring-http-outbox-idempotency/README.ko.md
@@ -1,0 +1,59 @@
+# Spring HTTP 아웃박스와 멱등성
+
+[English](README.md) | [한국어](README.ko.md)
+
+이 모듈은 chapter 12 HTTP 클라이언트 아웃박스/멱등성 주제의 Spring Boot 4
+구현입니다. 외부 HTTP 서비스를 호출하기 전에 발신 결제 의도를 먼저
+저장하고, 멱등성 키를 중복 요청의 경계로 사용합니다.
+
+```mermaid
+flowchart TD
+    Client[HTTP client] --> Controller[Spring MVC controller]
+    Controller --> Service[PaymentService]
+    Service --> Repository[PaymentOutboxRepository]
+    Repository --> Exposed[Exposed transactions]
+    Exposed --> H2[(H2 via HikariCP)]
+    Service --> Gateway[RestClientPaymentGateway]
+    Gateway --> External[External payment API]
+```
+
+## 학습 내용
+
+- 결제 생성, 재시도, 조회를 제공하는 Spring Boot 4 MVC 엔드포인트.
+- 발신 요청 레코드를 저장소 경계 안의 Exposed JDBC 트랜잭션으로 관리.
+- 멱등성 키 유니크 제약으로 중복 생성 대신 기존 레코드 반환.
+- 재시도 가능한 외부 실패와 영구 실패의 분리.
+- 실제 외부 HTTP 서비스 없이 fake gateway로 검증하는 테스트 구조.
+
+## HTTP 계약
+
+| 메서드 | 경로 | 동작 |
+|---|---|---|
+| `POST` | `/payments` | pending 아웃박스 레코드를 저장하고 gateway를 호출한 뒤 `201`을 반환합니다. 중복 멱등성 키는 기존 레코드와 `200`을 반환합니다. |
+| `POST` | `/payments/{id}/retry` | `RETRYABLE_FAILED` 상태의 레코드만 재시도합니다. |
+| `GET` | `/payments/{id}` | 단일 결제/아웃박스 레코드를 반환합니다. |
+| `GET` | `/payments` | 모든 결제/아웃박스 레코드를 반환합니다. |
+
+## 실행
+
+```bash
+./gradlew :03-spring-http-outbox-idempotency:bootRun
+```
+
+```bash
+curl -X POST http://localhost:8080/payments \
+  -H 'Content-Type: application/json' \
+  -d '{"orderId":"order-100","amountCents":2500,"idempotencyKey":"payment-key-100"}'
+```
+
+기본 gateway base URL은 실제 결제가 발생하지 않도록 예제용 비라우팅 호스트를
+가리킵니다. 테스트에서는 인메모리 fake gateway로 대체합니다.
+
+## 테스트
+
+```bash
+./gradlew :03-spring-http-outbox-idempotency:test
+```
+
+테스트는 성공 dispatch, 중복 멱등성 키, 재시도 가능한 실패 후 성공 재시도,
+영구 실패, 저장소 영속성, MVC 오류 매핑을 검증합니다.

--- a/12-production-integration/03-spring-http-outbox-idempotency/README.md
+++ b/12-production-integration/03-spring-http-outbox-idempotency/README.md
@@ -1,0 +1,61 @@
+# Spring HTTP Outbox and Idempotency
+
+[English](README.md) | [한국어](README.ko.md)
+
+This module is the Spring Boot 4 implementation for the chapter 12 HTTP client
+outbox/idempotency topic. It persists an outbound payment intent before calling
+an external HTTP service and uses the idempotency key as the duplicate boundary.
+
+```mermaid
+flowchart TD
+    Client[HTTP client] --> Controller[Spring MVC controller]
+    Controller --> Service[PaymentService]
+    Service --> Repository[PaymentOutboxRepository]
+    Repository --> Exposed[Exposed transactions]
+    Exposed --> H2[(H2 via HikariCP)]
+    Service --> Gateway[RestClientPaymentGateway]
+    Gateway --> External[External payment API]
+```
+
+## What This Shows
+
+- Spring Boot 4 MVC endpoints for creating, retrying, and listing payments.
+- Repository-owned Exposed JDBC transactions for the outbound request record.
+- A unique idempotency key that returns the existing record on duplicate submit.
+- Retryable external failures separated from permanent failures.
+- Tests that use a fake gateway instead of a real external HTTP service.
+
+## HTTP Contract
+
+| Method | Path | Behavior |
+|---|---|---|
+| `POST` | `/payments` | Inserts a pending outbox record, calls the gateway, and returns `201`; duplicate idempotency keys return the existing record with `200`. |
+| `POST` | `/payments/{id}/retry` | Retries only records in `RETRYABLE_FAILED`. |
+| `GET` | `/payments/{id}` | Returns one payment/outbox record. |
+| `GET` | `/payments` | Returns all payment/outbox records. |
+
+## Run
+
+```bash
+./gradlew :03-spring-http-outbox-idempotency:bootRun
+```
+
+```bash
+curl -X POST http://localhost:8080/payments \
+  -H 'Content-Type: application/json' \
+  -d '{"orderId":"order-100","amountCents":2500,"idempotencyKey":"payment-key-100"}'
+```
+
+The default gateway base URL points to a non-routable example host so the sample
+does not accidentally charge a real provider. Tests override the gateway with an
+in-memory fake.
+
+## Test
+
+```bash
+./gradlew :03-spring-http-outbox-idempotency:test
+```
+
+The test suite covers successful dispatch, duplicate idempotency keys,
+retryable failure followed by retry success, permanent failure, repository
+persistence, and MVC error handling.

--- a/12-production-integration/03-spring-http-outbox-idempotency/build.gradle.kts
+++ b/12-production-integration/03-spring-http-outbox-idempotency/build.gradle.kts
@@ -1,0 +1,42 @@
+plugins {
+    kotlin("plugin.spring")
+    alias(libs.plugins.spring.boot)
+}
+
+springBoot {
+    mainClass.set("exposed.examples.spring.httpoutbox.SpringHttpOutboxApplicationKt")
+
+    buildInfo {
+        properties {
+            additional.put("name", "Spring Boot HTTP outbox idempotency with Exposed")
+            additional.put("java.version", JavaVersion.current())
+        }
+    }
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    implementation(platform(libs.jetbrains.exposed.bom))
+
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.jetbrains.exposed.spring.boot.starter)
+    implementation(libs.hikaricp)
+
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.boot.starter.web)
+
+    runtimeOnly(libs.h2.v2)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.spring.boot.starter.webmvc.test)
+    testImplementation(libs.spring.boot.starter.test) {
+        exclude(group = "junit", module = "junit")
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+        exclude(module = "mockito-core")
+    }
+}

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/SpringHttpOutboxApplication.kt
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/SpringHttpOutboxApplication.kt
@@ -1,0 +1,67 @@
+package exposed.examples.spring.httpoutbox
+
+import exposed.examples.spring.httpoutbox.client.PaymentGateway
+import exposed.examples.spring.httpoutbox.client.RestClientPaymentGateway
+import exposed.examples.spring.httpoutbox.model.HealthResponse
+import exposed.examples.spring.httpoutbox.model.IndexResponse
+import exposed.examples.spring.httpoutbox.persistence.PaymentPersistence
+import exposed.examples.spring.httpoutbox.repository.ExposedPaymentOutboxRepository
+import exposed.examples.spring.httpoutbox.repository.PaymentOutboxRepository
+import exposed.examples.spring.httpoutbox.service.PaymentService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.client.RestClient
+
+@SpringBootApplication
+internal class SpringHttpOutboxApplication
+
+fun main(args: Array<String>) {
+    runApplication<SpringHttpOutboxApplication>(*args)
+}
+
+@Configuration(proxyBeanMethods = false)
+internal class SpringHttpOutboxConfiguration {
+
+    @Bean(destroyMethod = "close")
+    fun paymentPersistence(): PaymentPersistence =
+        PaymentPersistence.inMemory()
+
+    @Bean
+    fun paymentOutboxRepository(persistence: PaymentPersistence): PaymentOutboxRepository =
+        ExposedPaymentOutboxRepository(persistence.database)
+
+    @Bean
+    fun restClientBuilder(): RestClient.Builder =
+        RestClient.builder()
+
+    @Bean
+    fun paymentGateway(
+        restClientBuilder: RestClient.Builder,
+        @Value("\${example.external-payments.base-url:https://payments.example.invalid}") baseUrl: String,
+    ): PaymentGateway =
+        RestClientPaymentGateway(restClientBuilder.baseUrl(baseUrl).build())
+
+    @Bean
+    fun paymentService(
+        repository: PaymentOutboxRepository,
+        paymentGateway: PaymentGateway,
+    ): PaymentService =
+        PaymentService(repository, paymentGateway)
+}
+
+@RestController
+internal class IndexController {
+
+    @GetMapping("/")
+    fun index(): IndexResponse =
+        IndexResponse()
+
+    @GetMapping("/health")
+    fun health(): HealthResponse =
+        HealthResponse(status = "UP")
+}

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/client/PaymentGateway.kt
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/client/PaymentGateway.kt
@@ -1,0 +1,8 @@
+package exposed.examples.spring.httpoutbox.client
+
+import exposed.examples.spring.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.spring.httpoutbox.model.ExternalPaymentResult
+
+internal interface PaymentGateway {
+    fun charge(command: CreatePaymentCommand): ExternalPaymentResult
+}

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/client/RestClientPaymentGateway.kt
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/client/RestClientPaymentGateway.kt
@@ -1,0 +1,43 @@
+package exposed.examples.spring.httpoutbox.client
+
+import exposed.examples.spring.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.spring.httpoutbox.model.ExternalPaymentRequest
+import exposed.examples.spring.httpoutbox.model.ExternalPaymentResponse
+import exposed.examples.spring.httpoutbox.model.ExternalPaymentResult
+import exposed.examples.spring.httpoutbox.model.PermanentExternalPaymentException
+import exposed.examples.spring.httpoutbox.model.RetryableExternalPaymentException
+import org.springframework.web.client.ResourceAccessException
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientResponseException
+
+internal class RestClientPaymentGateway(
+    private val restClient: RestClient,
+) : PaymentGateway {
+
+    override fun charge(command: CreatePaymentCommand): ExternalPaymentResult {
+        try {
+            val response = restClient.post()
+                .uri("/payments")
+                .header(IDEMPOTENCY_KEY_HEADER, command.idempotencyKey)
+                .body(ExternalPaymentRequest(command.orderId, command.amountCents))
+                .retrieve()
+                .body(ExternalPaymentResponse::class.java)
+
+            return ExternalPaymentResult(
+                externalId = response?.externalId?.takeIf { it.isNotBlank() }
+                    ?: "spring-${command.idempotencyKey}"
+            )
+        } catch (e: RestClientResponseException) {
+            if (e.statusCode.is4xxClientError) {
+                throw PermanentExternalPaymentException("External payment request was rejected", e)
+            }
+            throw RetryableExternalPaymentException("External payment service is temporarily unavailable", e)
+        } catch (e: ResourceAccessException) {
+            throw RetryableExternalPaymentException("External payment service could not be reached", e)
+        }
+    }
+
+    private companion object {
+        private const val IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
+    }
+}

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/model/PaymentModels.kt
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/model/PaymentModels.kt
@@ -1,0 +1,158 @@
+package exposed.examples.spring.httpoutbox.model
+
+import java.io.Serializable
+
+data class IndexResponse(
+    val service: String = "spring-http-outbox-idempotency",
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+data class HealthResponse(
+    val status: String,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+data class CreatePaymentRequest(
+    val orderId: String = "",
+    val amountCents: Long = 0,
+    val idempotencyKey: String = "",
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class CreatePaymentCommand(
+    val orderId: String,
+    val amountCents: Long,
+    val idempotencyKey: String,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+enum class PaymentStatus {
+    PENDING,
+    SUCCEEDED,
+    RETRYABLE_FAILED,
+    PERMANENT_FAILED,
+}
+
+internal data class PaymentRecord(
+    val id: Long,
+    val orderId: String,
+    val amountCents: Long,
+    val idempotencyKey: String,
+    val status: PaymentStatus,
+    val attempts: Int,
+    val externalId: String?,
+    val lastError: String?,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class CreatePaymentResult(
+    val record: PaymentRecord,
+    val inserted: Boolean,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+data class PaymentResponse(
+    val id: Long,
+    val orderId: String,
+    val amountCents: Long,
+    val idempotencyKey: String,
+    val status: PaymentStatus,
+    val attempts: Int,
+    val externalId: String?,
+    val lastError: String?,
+    val duplicate: Boolean,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+data class PaymentsResponse(
+    val payments: List<PaymentResponse>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+data class ErrorResponse(
+    val code: String,
+    val message: String,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class ExternalPaymentRequest(
+    val orderId: String,
+    val amountCents: Long,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class ExternalPaymentResponse(
+    val externalId: String = "",
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class ExternalPaymentResult(
+    val externalId: String,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal class PaymentValidationException(message: String) : RuntimeException(message)
+
+internal open class ExternalPaymentException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)
+
+internal class RetryableExternalPaymentException(
+    message: String,
+    cause: Throwable? = null,
+) : ExternalPaymentException(message, cause)
+
+internal class PermanentExternalPaymentException(
+    message: String,
+    cause: Throwable? = null,
+) : ExternalPaymentException(message, cause)
+
+internal fun PaymentRecord.toResponse(duplicate: Boolean = false): PaymentResponse =
+    PaymentResponse(
+        id = id,
+        orderId = orderId,
+        amountCents = amountCents,
+        idempotencyKey = idempotencyKey,
+        status = status,
+        attempts = attempts,
+        externalId = externalId,
+        lastError = lastError,
+        duplicate = duplicate
+    )

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/persistence/PaymentPersistence.kt
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/persistence/PaymentPersistence.kt
@@ -1,0 +1,31 @@
+package exposed.examples.spring.httpoutbox.persistence
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.jetbrains.exposed.v1.jdbc.Database
+import java.io.Closeable
+
+internal class PaymentPersistence private constructor(
+    private val dataSource: HikariDataSource,
+) : Closeable {
+
+    val database: Database = Database.connect(dataSource)
+
+    override fun close() {
+        dataSource.close()
+    }
+
+    companion object {
+        fun inMemory(databaseName: String = "spring_http_outbox"): PaymentPersistence {
+            val config = HikariConfig().apply {
+                jdbcUrl = "jdbc:h2:mem:$databaseName;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+                driverClassName = "org.h2.Driver"
+                username = "sa"
+                password = ""
+                maximumPoolSize = 4
+                poolName = "spring-http-outbox-$databaseName"
+            }
+            return PaymentPersistence(HikariDataSource(config))
+        }
+    }
+}

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/repository/ExposedPaymentOutboxRepository.kt
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/repository/ExposedPaymentOutboxRepository.kt
@@ -1,0 +1,165 @@
+package exposed.examples.spring.httpoutbox.repository
+
+import exposed.examples.spring.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.spring.httpoutbox.model.CreatePaymentResult
+import exposed.examples.spring.httpoutbox.model.PaymentRecord
+import exposed.examples.spring.httpoutbox.model.PaymentStatus
+import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+internal class ExposedPaymentOutboxRepository(
+    private val database: Database,
+) : PaymentOutboxRepository {
+
+    private val schemaReady = AtomicBoolean(false)
+
+    override fun createPending(command: CreatePaymentCommand): CreatePaymentResult {
+        ensureSchema()
+        return try {
+            transaction(database) {
+                findByIdempotencyKey(command.idempotencyKey)?.let {
+                    CreatePaymentResult(it, inserted = false)
+                } ?: insertPending(command)
+            }
+        } catch (e: ExposedSQLException) {
+            rereadDuplicate(command.idempotencyKey) ?: throw e
+        }
+    }
+
+    override fun findById(id: Long): PaymentRecord? {
+        ensureSchema()
+        return transaction(database) {
+            findByIdInTransaction(id)
+        }
+    }
+
+    override fun findAll(): List<PaymentRecord> {
+        ensureSchema()
+        return transaction(database) {
+            PaymentOutbox.selectAll().map { it.toRecord() }
+        }
+    }
+
+    override fun markSucceeded(id: Long, externalId: String): PaymentRecord =
+        updateStatus(id, PaymentStatus.SUCCEEDED, externalId, null)
+
+    override fun markRetryableFailure(id: Long, message: String): PaymentRecord =
+        updateStatus(id, PaymentStatus.RETRYABLE_FAILED, null, message)
+
+    override fun markPermanentFailure(id: Long, message: String): PaymentRecord =
+        updateStatus(id, PaymentStatus.PERMANENT_FAILED, null, message)
+
+    override fun deleteAll() {
+        ensureSchema()
+        transaction(database) {
+            PaymentOutbox.deleteAll()
+        }
+    }
+
+    private fun updateStatus(
+        id: Long,
+        nextStatus: PaymentStatus,
+        externalId: String?,
+        lastError: String?,
+    ): PaymentRecord {
+        ensureSchema()
+        return transaction(database) {
+            val current = findByIdInTransaction(id)
+                ?: throw NoSuchElementException("Payment request $id was not found")
+            PaymentOutbox.update({ PaymentOutbox.id eq id }) {
+                it[status] = nextStatus.name
+                it[attempts] = current.attempts + 1
+                it[PaymentOutbox.externalId] = externalId
+                it[PaymentOutbox.lastError] = lastError
+            }
+            checkNotNull(findByIdInTransaction(id)) {
+                "Updated payment request $id was not found"
+            }
+        }
+    }
+
+    private fun ensureSchema() {
+        if (schemaReady.get()) {
+            return
+        }
+        schemaLock.withLock {
+            if (!schemaReady.get()) {
+                transaction(database) {
+                    SchemaUtils.create(PaymentOutbox)
+                }
+                schemaReady.set(true)
+            }
+        }
+    }
+
+    private fun findByIdInTransaction(id: Long): PaymentRecord? =
+        PaymentOutbox.selectAll()
+            .where { PaymentOutbox.id eq id }
+            .singleOrNull()
+            ?.toRecord()
+
+    private fun findByIdempotencyKey(idempotencyKey: String): PaymentRecord? =
+        PaymentOutbox.selectAll()
+            .where { PaymentOutbox.idempotencyKey eq idempotencyKey }
+            .singleOrNull()
+            ?.toRecord()
+
+    private fun insertPending(command: CreatePaymentCommand): CreatePaymentResult {
+        val id = PaymentOutbox.insertAndGetId {
+            it[orderId] = command.orderId
+            it[amountCents] = command.amountCents
+            it[idempotencyKey] = command.idempotencyKey
+            it[status] = PaymentStatus.PENDING.name
+            it[attempts] = 0
+        }.value
+        return CreatePaymentResult(
+            checkNotNull(findByIdInTransaction(id)) {
+                "Inserted payment request $id was not found"
+            },
+            inserted = true
+        )
+    }
+
+    private fun rereadDuplicate(idempotencyKey: String): CreatePaymentResult? =
+        transaction(database) {
+            findByIdempotencyKey(idempotencyKey)?.let {
+                CreatePaymentResult(it, inserted = false)
+            }
+        }
+}
+
+private val schemaLock = ReentrantLock()
+
+private object PaymentOutbox : LongIdTable("spring_payment_outbox") {
+    val orderId = varchar("order_id", 80)
+    val amountCents = long("amount_cents")
+    val idempotencyKey = varchar("idempotency_key", 120).uniqueIndex()
+    val status = varchar("status", 32)
+    val attempts = integer("attempts")
+    val externalId = varchar("external_id", 120).nullable()
+    val lastError = varchar("last_error", 240).nullable()
+}
+
+private fun ResultRow.toRecord(): PaymentRecord =
+    PaymentRecord(
+        id = this[PaymentOutbox.id].value,
+        orderId = this[PaymentOutbox.orderId],
+        amountCents = this[PaymentOutbox.amountCents],
+        idempotencyKey = this[PaymentOutbox.idempotencyKey],
+        status = PaymentStatus.valueOf(this[PaymentOutbox.status]),
+        attempts = this[PaymentOutbox.attempts],
+        externalId = this[PaymentOutbox.externalId],
+        lastError = this[PaymentOutbox.lastError]
+    )

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/repository/PaymentOutboxRepository.kt
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/repository/PaymentOutboxRepository.kt
@@ -1,0 +1,15 @@
+package exposed.examples.spring.httpoutbox.repository
+
+import exposed.examples.spring.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.spring.httpoutbox.model.CreatePaymentResult
+import exposed.examples.spring.httpoutbox.model.PaymentRecord
+
+internal interface PaymentOutboxRepository {
+    fun createPending(command: CreatePaymentCommand): CreatePaymentResult
+    fun findById(id: Long): PaymentRecord?
+    fun findAll(): List<PaymentRecord>
+    fun markSucceeded(id: Long, externalId: String): PaymentRecord
+    fun markRetryableFailure(id: Long, message: String): PaymentRecord
+    fun markPermanentFailure(id: Long, message: String): PaymentRecord
+    fun deleteAll()
+}

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/service/PaymentService.kt
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/service/PaymentService.kt
@@ -1,0 +1,96 @@
+package exposed.examples.spring.httpoutbox.service
+
+import exposed.examples.spring.httpoutbox.client.PaymentGateway
+import exposed.examples.spring.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.spring.httpoutbox.model.CreatePaymentRequest
+import exposed.examples.spring.httpoutbox.model.PaymentResponse
+import exposed.examples.spring.httpoutbox.model.PaymentStatus
+import exposed.examples.spring.httpoutbox.model.PaymentValidationException
+import exposed.examples.spring.httpoutbox.model.PaymentsResponse
+import exposed.examples.spring.httpoutbox.model.PermanentExternalPaymentException
+import exposed.examples.spring.httpoutbox.model.RetryableExternalPaymentException
+import exposed.examples.spring.httpoutbox.model.toResponse
+import exposed.examples.spring.httpoutbox.repository.PaymentOutboxRepository
+
+internal class PaymentService(
+    private val repository: PaymentOutboxRepository,
+    private val paymentGateway: PaymentGateway,
+) {
+
+    fun submit(request: CreatePaymentRequest): PaymentResponse {
+        val command = request.toCommand()
+        val created = repository.createPending(command)
+        if (!created.inserted) {
+            return created.record.toResponse(duplicate = true)
+        }
+        return dispatch(created.record.id, command)
+    }
+
+    fun retry(id: Long): PaymentResponse {
+        val record = repository.findById(id)
+            ?: throw NoSuchElementException("Payment request $id was not found")
+        if (record.status != PaymentStatus.RETRYABLE_FAILED) {
+            throw PaymentValidationException("only retryable failed payments can be retried")
+        }
+        return dispatch(
+            id = record.id,
+            command = CreatePaymentCommand(
+                orderId = record.orderId,
+                amountCents = record.amountCents,
+                idempotencyKey = record.idempotencyKey
+            )
+        )
+    }
+
+    fun find(id: Long): PaymentResponse =
+        repository.findById(id)?.toResponse()
+            ?: throw NoSuchElementException("Payment request $id was not found")
+
+    fun findAll(): PaymentsResponse =
+        PaymentsResponse(repository.findAll().map { it.toResponse() })
+
+    fun deleteAll() {
+        repository.deleteAll()
+    }
+
+    private fun dispatch(
+        id: Long,
+        command: CreatePaymentCommand,
+    ): PaymentResponse =
+        try {
+            val result = paymentGateway.charge(command)
+            repository.markSucceeded(id, result.externalId).toResponse()
+        } catch (e: PermanentExternalPaymentException) {
+            repository.markPermanentFailure(id, e.message ?: "permanent external payment failure").toResponse()
+        } catch (e: RetryableExternalPaymentException) {
+            repository.markRetryableFailure(id, e.message ?: "retryable external payment failure").toResponse()
+        }
+
+    private fun CreatePaymentRequest.toCommand(): CreatePaymentCommand =
+        CreatePaymentCommand(
+            orderId = orderId.normalize("orderId", 80),
+            amountCents = amountCents.requirePositiveAmount(),
+            idempotencyKey = idempotencyKey.normalize("idempotencyKey", 120)
+        )
+
+    private fun String.normalize(
+        fieldName: String,
+        maxLength: Int,
+    ): String {
+        val normalized = trim()
+        if (normalized.isBlank()) {
+            throw PaymentValidationException("$fieldName must not be blank")
+        }
+        if (normalized.length > maxLength) {
+            throw PaymentValidationException("$fieldName must be $maxLength characters or less")
+        }
+        return normalized
+    }
+
+    private fun Long.requirePositiveAmount(): Long {
+        if (this <= 0) {
+            throw PaymentValidationException("amountCents must be positive")
+        }
+        return this
+    }
+}

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/web/ErrorAdvice.kt
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/web/ErrorAdvice.kt
@@ -1,0 +1,51 @@
+package exposed.examples.spring.httpoutbox.web
+
+import exposed.examples.spring.httpoutbox.model.ErrorResponse
+import exposed.examples.spring.httpoutbox.model.PaymentValidationException
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+internal class ErrorAdvice {
+
+    @ExceptionHandler(PaymentValidationException::class)
+    fun validationError(error: PaymentValidationException): ResponseEntity<ErrorResponse> =
+        ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse("VALIDATION_ERROR", error.message ?: "Request validation failed"))
+
+    @ExceptionHandler(NoSuchElementException::class)
+    fun notFound(error: NoSuchElementException): ResponseEntity<ErrorResponse> =
+        ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse("NOT_FOUND", error.message ?: "Resource was not found"))
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun invalidArgument(): ResponseEntity<ErrorResponse> =
+        ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse("VALIDATION_ERROR", "Request validation failed"))
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun malformedJson(): ResponseEntity<ErrorResponse> =
+        ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse("MALFORMED_JSON", "Request body is not valid JSON"))
+
+    @ExceptionHandler(Exception::class)
+    fun unexpected(error: Exception): ResponseEntity<ErrorResponse> {
+        logger.error("Unexpected payment outbox error", error)
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ErrorResponse("INTERNAL_ERROR", "Unexpected server error"))
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(ErrorAdvice::class.java)
+    }
+}

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/web/PaymentController.kt
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/main/kotlin/exposed/examples/spring/httpoutbox/web/PaymentController.kt
@@ -1,0 +1,40 @@
+package exposed.examples.spring.httpoutbox.web
+
+import exposed.examples.spring.httpoutbox.model.CreatePaymentRequest
+import exposed.examples.spring.httpoutbox.model.PaymentResponse
+import exposed.examples.spring.httpoutbox.model.PaymentsResponse
+import exposed.examples.spring.httpoutbox.service.PaymentService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/payments")
+internal class PaymentController(
+    private val service: PaymentService,
+) {
+
+    @PostMapping
+    fun submit(@RequestBody request: CreatePaymentRequest): ResponseEntity<PaymentResponse> {
+        val response = service.submit(request)
+        val status = if (response.duplicate) HttpStatus.OK else HttpStatus.CREATED
+        return ResponseEntity.status(status).body(response)
+    }
+
+    @PostMapping("/{id}/retry")
+    fun retry(@PathVariable id: Long): PaymentResponse =
+        service.retry(id)
+
+    @GetMapping("/{id}")
+    fun find(@PathVariable id: Long): PaymentResponse =
+        service.find(id)
+
+    @GetMapping
+    fun findAll(): PaymentsResponse =
+        service.findAll()
+}

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/test/kotlin/exposed/examples/spring/httpoutbox/SpringHttpOutboxApplicationTest.kt
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/test/kotlin/exposed/examples/spring/httpoutbox/SpringHttpOutboxApplicationTest.kt
@@ -1,0 +1,137 @@
+package exposed.examples.spring.httpoutbox
+
+import exposed.examples.spring.httpoutbox.service.PaymentService
+import exposed.examples.spring.httpoutbox.service.ScenarioPaymentGateway
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+
+@SpringBootTest(
+    classes = [
+        SpringHttpOutboxApplication::class,
+        SpringHttpOutboxApplicationTest.TestPaymentGatewayConfiguration::class,
+    ]
+)
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SpringHttpOutboxApplicationTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var service: PaymentService
+
+    @Autowired
+    private lateinit var gateway: ScenarioPaymentGateway
+
+    @BeforeEach
+    fun resetState() {
+        service.deleteAll()
+        gateway.reset()
+    }
+
+    @Test
+    fun `index and health endpoints respond`() {
+        mockMvc.get("/")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.service", equalTo("spring-http-outbox-idempotency"))
+            }
+
+        mockMvc.get("/health")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.status", equalTo("UP"))
+            }
+    }
+
+    @Test
+    fun `payment routes cover success duplicate permanent and retry paths`() {
+        gateway.succeed("ok-key", "ext-ok")
+        mockMvc.post("/payments") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"orderId":" order-ok ","amountCents":2500,"idempotencyKey":" ok-key "}"""
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.status", equalTo("SUCCEEDED"))
+            jsonPath("$.externalId", equalTo("ext-ok"))
+        }
+
+        mockMvc.post("/payments") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"orderId":"order-ok","amountCents":2500,"idempotencyKey":"ok-key"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.duplicate", equalTo(true))
+        }
+
+        gateway.retryableThenSuccess("retry-key", "ext-retry")
+        val retryId = mockMvc.post("/payments") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"orderId":"order-retry","amountCents":1000,"idempotencyKey":"retry-key"}"""
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.status", equalTo("RETRYABLE_FAILED"))
+        }.andReturn().response.contentAsString.substringAfter("\"id\":").substringBefore(",").toLong()
+
+        mockMvc.post("/payments/$retryId/retry")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.status", equalTo("SUCCEEDED"))
+                jsonPath("$.attempts", equalTo(2))
+            }
+
+        gateway.permanent("bad-key")
+        mockMvc.post("/payments") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"orderId":"order-bad","amountCents":1000,"idempotencyKey":"bad-key"}"""
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.status", equalTo("PERMANENT_FAILED"))
+        }
+
+        mockMvc.get("/payments")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.payments", hasSize<Any>(3))
+            }
+    }
+
+    @Test
+    fun `validation and not found errors are sanitized`() {
+        mockMvc.post("/payments") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"orderId":"","amountCents":1000,"idempotencyKey":"key"}"""
+        }.andExpect {
+            status { isBadRequest() }
+            jsonPath("$.code", equalTo("VALIDATION_ERROR"))
+        }
+
+        mockMvc.get("/payments/999")
+            .andExpect {
+                status { isNotFound() }
+                jsonPath("$.code", equalTo("NOT_FOUND"))
+            }
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    internal class TestPaymentGatewayConfiguration {
+        @Bean
+        @Primary
+        fun scenarioPaymentGateway(): ScenarioPaymentGateway =
+            ScenarioPaymentGateway()
+    }
+}

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/test/kotlin/exposed/examples/spring/httpoutbox/repository/ExposedPaymentOutboxRepositoryTest.kt
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/test/kotlin/exposed/examples/spring/httpoutbox/repository/ExposedPaymentOutboxRepositoryTest.kt
@@ -1,0 +1,82 @@
+package exposed.examples.spring.httpoutbox.repository
+
+import exposed.examples.spring.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.spring.httpoutbox.model.CreatePaymentResult
+import exposed.examples.spring.httpoutbox.model.PaymentStatus
+import exposed.examples.spring.httpoutbox.persistence.PaymentPersistence
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.codec.Base58
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExposedPaymentOutboxRepositoryTest {
+
+    @Test
+    fun `create pending request then mark success`() {
+        PaymentPersistence.inMemory("spring_repo_${Base58.randomString(8)}").use { persistence ->
+            val repository = ExposedPaymentOutboxRepository(persistence.database)
+
+            val created = repository.createPending(command("pay-1"))
+            created.inserted shouldBeEqualTo true
+            created.record.status shouldBeEqualTo PaymentStatus.PENDING
+
+            val succeeded = repository.markSucceeded(created.record.id, "ext-1")
+
+            succeeded.status shouldBeEqualTo PaymentStatus.SUCCEEDED
+            succeeded.attempts shouldBeEqualTo 1
+            succeeded.externalId shouldBeEqualTo "ext-1"
+        }
+    }
+
+    @Test
+    fun `duplicate idempotency key returns stored record`() {
+        PaymentPersistence.inMemory("spring_repo_${Base58.randomString(8)}").use { persistence ->
+            val repository = ExposedPaymentOutboxRepository(persistence.database)
+
+            val first = repository.createPending(command("same-key"))
+            val duplicate = repository.createPending(command("same-key"))
+
+            duplicate.inserted shouldBeEqualTo false
+            duplicate.record.id shouldBeEqualTo first.record.id
+        }
+    }
+
+    @Test
+    fun `concurrent duplicate idempotency key returns one stored record`() {
+        PaymentPersistence.inMemory("spring_repo_${Base58.randomString(8)}").use { persistence ->
+            val repository = ExposedPaymentOutboxRepository(persistence.database)
+            val pool = Executors.newFixedThreadPool(8)
+            val start = CountDownLatch(1)
+
+            try {
+                val futures = (1..8).map {
+                    pool.submit<CreatePaymentResult> {
+                        start.await()
+                        repository.createPending(command("concurrent-key"))
+                    }
+                }
+
+                start.countDown()
+                val results = futures.map { it.get(5, TimeUnit.SECONDS) }
+
+                results.count { it.inserted } shouldBeEqualTo 1
+                results.map { it.record.id }.toSet() shouldHaveSize 1
+                repository.findAll() shouldHaveSize 1
+            } finally {
+                pool.shutdownNow()
+            }
+        }
+    }
+
+    private fun command(idempotencyKey: String): CreatePaymentCommand =
+        CreatePaymentCommand(
+            orderId = "order-$idempotencyKey",
+            amountCents = 1_500,
+            idempotencyKey = idempotencyKey
+        )
+}

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/test/kotlin/exposed/examples/spring/httpoutbox/service/PaymentServiceTest.kt
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/test/kotlin/exposed/examples/spring/httpoutbox/service/PaymentServiceTest.kt
@@ -1,0 +1,130 @@
+package exposed.examples.spring.httpoutbox.service
+
+import exposed.examples.spring.httpoutbox.client.PaymentGateway
+import exposed.examples.spring.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.spring.httpoutbox.model.CreatePaymentRequest
+import exposed.examples.spring.httpoutbox.model.ExternalPaymentResult
+import exposed.examples.spring.httpoutbox.model.PaymentStatus
+import exposed.examples.spring.httpoutbox.model.PaymentValidationException
+import exposed.examples.spring.httpoutbox.model.PermanentExternalPaymentException
+import exposed.examples.spring.httpoutbox.model.RetryableExternalPaymentException
+import exposed.examples.spring.httpoutbox.persistence.PaymentPersistence
+import exposed.examples.spring.httpoutbox.repository.ExposedPaymentOutboxRepository
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.codec.Base58
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.ArrayDeque
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PaymentServiceTest {
+
+    @Test
+    fun `successful payment is persisted before external success is recorded`() {
+        withService { service, gateway ->
+            gateway.succeed("key-1", "ext-1")
+
+            val response = service.submit(CreatePaymentRequest(" order-1 ", 2_500, " key-1 "))
+
+            response.status shouldBeEqualTo PaymentStatus.SUCCEEDED
+            response.attempts shouldBeEqualTo 1
+            response.externalId shouldBeEqualTo "ext-1"
+            gateway.commands.single() shouldBeEqualTo CreatePaymentCommand("order-1", 2_500, "key-1")
+        }
+    }
+
+    @Test
+    fun `duplicate idempotency key returns existing payment without second external call`() {
+        withService { service, gateway ->
+            gateway.succeed("key-2", "ext-2")
+
+            val first = service.submit(CreatePaymentRequest("order-2", 2_500, "key-2"))
+            val duplicate = service.submit(CreatePaymentRequest("order-2", 2_500, "key-2"))
+
+            duplicate.id shouldBeEqualTo first.id
+            duplicate.duplicate shouldBeEqualTo true
+            gateway.commands.size shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `retryable failure can be retried to success`() {
+        withService { service, gateway ->
+            gateway.retryableThenSuccess("retry-key", "ext-retry")
+
+            val failed = service.submit(CreatePaymentRequest("order-retry", 1_000, "retry-key"))
+            failed.status shouldBeEqualTo PaymentStatus.RETRYABLE_FAILED
+
+            val retried = service.retry(failed.id)
+
+            retried.status shouldBeEqualTo PaymentStatus.SUCCEEDED
+            retried.attempts shouldBeEqualTo 2
+            retried.externalId shouldBeEqualTo "ext-retry"
+        }
+    }
+
+    @Test
+    fun `permanent failure is not retryable`() {
+        withService { service, gateway ->
+            gateway.permanent("bad-key")
+            val failed = service.submit(CreatePaymentRequest("order-bad", 1_000, "bad-key"))
+
+            val error = try {
+                service.retry(failed.id)
+                throw AssertionError("PaymentValidationException was expected")
+            } catch (e: PaymentValidationException) {
+                e
+            }
+
+            failed.status shouldBeEqualTo PaymentStatus.PERMANENT_FAILED
+            error.message shouldBeEqualTo "only retryable failed payments can be retried"
+        }
+    }
+
+    private fun withService(test: (PaymentService, ScenarioPaymentGateway) -> Unit) {
+        PaymentPersistence.inMemory("spring_service_${Base58.randomString(8)}").use { persistence ->
+            val gateway = ScenarioPaymentGateway()
+            val repository = ExposedPaymentOutboxRepository(persistence.database)
+            test(PaymentService(repository, gateway), gateway)
+        }
+    }
+}
+
+internal class ScenarioPaymentGateway : PaymentGateway {
+    val commands = mutableListOf<CreatePaymentCommand>()
+    private val outcomes = mutableMapOf<String, ArrayDeque<() -> ExternalPaymentResult>>()
+
+    override fun charge(command: CreatePaymentCommand): ExternalPaymentResult {
+        commands += command
+        val next = outcomes[command.idempotencyKey]?.poll()
+        return next?.invoke() ?: ExternalPaymentResult("ext-${command.idempotencyKey}")
+    }
+
+    fun reset() {
+        commands.clear()
+        outcomes.clear()
+    }
+
+    fun succeed(
+        idempotencyKey: String,
+        externalId: String,
+    ) {
+        outcomes[idempotencyKey] = ArrayDeque(listOf({ ExternalPaymentResult(externalId) }))
+    }
+
+    fun retryableThenSuccess(
+        idempotencyKey: String,
+        externalId: String,
+    ) {
+        outcomes[idempotencyKey] = ArrayDeque(
+            listOf(
+                { throw RetryableExternalPaymentException("temporary failure") },
+                { ExternalPaymentResult(externalId) }
+            )
+        )
+    }
+
+    fun permanent(idempotencyKey: String) {
+        outcomes[idempotencyKey] = ArrayDeque(listOf({ throw PermanentExternalPaymentException("permanent failure") }))
+    }
+}

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/test/resources/junit-platform.properties
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/12-production-integration/03-spring-http-outbox-idempotency/src/test/resources/logback-test.xml
+++ b/12-production-integration/03-spring-http-outbox-idempotency/src/test/resources/logback-test.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/12-production-integration/04-ktor-http-outbox-idempotency/README.ko.md
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/README.ko.md
@@ -1,0 +1,61 @@
+# Ktor HTTP 아웃박스와 멱등성
+
+[English](README.md) | [한국어](README.ko.md)
+
+이 모듈은 chapter 12 HTTP 클라이언트 아웃박스/멱등성 주제의 Ktor 쌍입니다.
+Spring Boot 4 예제와 같은 계약을 유지하되, blocking Exposed JDBC 작업은
+저장소가 소유한 `Dispatchers.IO` 경계 뒤에 둡니다.
+
+```mermaid
+flowchart TD
+    Client[HTTP client] --> Routes[Ktor routes]
+    Routes --> Service[PaymentService]
+    Service --> Repository[PaymentOutboxRepository]
+    Repository --> IO[Dispatchers.IO boundary]
+    IO --> Exposed[Exposed transactions]
+    Exposed --> H2[(H2 via HikariCP)]
+    Service --> Gateway[KtorPaymentGateway]
+    Gateway --> External[External payment API]
+```
+
+## 학습 내용
+
+- 결제 생성, 재시도, 조회를 제공하는 명시적 Ktor route.
+- suspend 저장소 메서드 안에서 격리하는 blocking Exposed JDBC 트랜잭션.
+- 멱등성 키 유니크 제약으로 중복 생성 대신 기존 레코드 반환.
+- validation, not found, 영구 실패, 예기치 않은 실패를 처리하는
+  `StatusPages` 오류 매핑.
+- 실제 외부 HTTP 서비스 없이 fake gateway로 검증하는 Ktor client gateway 구조.
+
+## HTTP 계약
+
+| 메서드 | 경로 | 동작 |
+|---|---|---|
+| `POST` | `/payments` | pending 아웃박스 레코드를 저장하고 gateway를 호출한 뒤 `201`을 반환합니다. 중복 멱등성 키는 기존 레코드와 `200`을 반환합니다. |
+| `POST` | `/payments/{id}/retry` | `RETRYABLE_FAILED` 상태의 레코드만 재시도합니다. |
+| `GET` | `/payments/{id}` | 단일 결제/아웃박스 레코드를 반환합니다. |
+| `GET` | `/payments` | 모든 결제/아웃박스 레코드를 반환합니다. |
+
+## 실행
+
+```bash
+./gradlew :04-ktor-http-outbox-idempotency:run
+```
+
+```bash
+curl -X POST http://localhost:8080/payments \
+  -H 'Content-Type: application/json' \
+  -d '{"orderId":"order-100","amountCents":2500,"idempotencyKey":"payment-key-100"}'
+```
+
+기본 gateway base URL은 실제 결제가 발생하지 않도록 예제용 비라우팅 호스트를
+가리킵니다. 테스트에서는 인메모리 fake gateway로 대체합니다.
+
+## 테스트
+
+```bash
+./gradlew :04-ktor-http-outbox-idempotency:test
+```
+
+테스트는 route 성공, 중복 멱등성 키, 재시도 가능한 실패 후 성공 재시도,
+영구 실패, 저장소 영속성, 정제된 Ktor 오류 응답을 검증합니다.

--- a/12-production-integration/04-ktor-http-outbox-idempotency/README.md
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/README.md
@@ -1,0 +1,64 @@
+# Ktor HTTP Outbox and Idempotency
+
+[English](README.md) | [한국어](README.ko.md)
+
+This module is the Ktor pair for the chapter 12 HTTP client
+outbox/idempotency topic. It mirrors the Spring Boot 4 sample while keeping
+blocking Exposed JDBC work behind a repository-owned `Dispatchers.IO` boundary.
+
+```mermaid
+flowchart TD
+    Client[HTTP client] --> Routes[Ktor routes]
+    Routes --> Service[PaymentService]
+    Service --> Repository[PaymentOutboxRepository]
+    Repository --> IO[Dispatchers.IO boundary]
+    IO --> Exposed[Exposed transactions]
+    Exposed --> H2[(H2 via HikariCP)]
+    Service --> Gateway[KtorPaymentGateway]
+    Gateway --> External[External payment API]
+```
+
+## What This Shows
+
+- Explicit Ktor routes for creating, retrying, and listing payments.
+- Blocking Exposed JDBC transactions isolated inside suspend repository methods.
+- A unique idempotency key that returns the existing record on duplicate submit.
+- `StatusPages` error mapping for validation, not found, permanent failure, and
+  unexpected failures.
+- Ktor client gateway tests that use a fake gateway instead of a real external
+  HTTP service.
+
+## HTTP Contract
+
+| Method | Path | Behavior |
+|---|---|---|
+| `POST` | `/payments` | Inserts a pending outbox record, calls the gateway, and returns `201`; duplicate idempotency keys return the existing record with `200`. |
+| `POST` | `/payments/{id}/retry` | Retries only records in `RETRYABLE_FAILED`. |
+| `GET` | `/payments/{id}` | Returns one payment/outbox record. |
+| `GET` | `/payments` | Returns all payment/outbox records. |
+
+## Run
+
+```bash
+./gradlew :04-ktor-http-outbox-idempotency:run
+```
+
+```bash
+curl -X POST http://localhost:8080/payments \
+  -H 'Content-Type: application/json' \
+  -d '{"orderId":"order-100","amountCents":2500,"idempotencyKey":"payment-key-100"}'
+```
+
+The default gateway base URL points to a non-routable example host so the sample
+does not accidentally charge a real provider. Tests override the gateway with an
+in-memory fake.
+
+## Test
+
+```bash
+./gradlew :04-ktor-http-outbox-idempotency:test
+```
+
+The test suite covers route success, duplicate idempotency keys, retryable
+failure followed by retry success, permanent failure, repository persistence,
+and sanitized Ktor errors.

--- a/12-production-integration/04-ktor-http-outbox-idempotency/build.gradle.kts
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+    application
+    alias(libs.plugins.kotlin.serialization)
+}
+
+application {
+    mainClass.set("exposed.examples.ktor.httpoutbox.KtorHttpOutboxApplicationKt")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    implementation(platform(libs.jetbrains.exposed.bom))
+
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.cio)
+    implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.server.status.pages)
+    implementation(libs.ktor.server.call.logging)
+    implementation(libs.ktor.server.call.id)
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.cio)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.kotlinx.serialization.json)
+
+    implementation(libs.jetbrains.exposed.core)
+    implementation(libs.jetbrains.exposed.jdbc)
+    implementation(libs.hikaricp)
+
+    runtimeOnly(libs.h2.v2)
+
+    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/KtorHttpOutboxApplication.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/KtorHttpOutboxApplication.kt
@@ -1,0 +1,55 @@
+package exposed.examples.ktor.httpoutbox
+
+import exposed.examples.ktor.httpoutbox.client.KtorPaymentGateway
+import exposed.examples.ktor.httpoutbox.client.PaymentGateway
+import exposed.examples.ktor.httpoutbox.config.installKtorPlugins
+import exposed.examples.ktor.httpoutbox.model.HealthResponse
+import exposed.examples.ktor.httpoutbox.model.IndexResponse
+import exposed.examples.ktor.httpoutbox.persistence.PaymentPersistence
+import exposed.examples.ktor.httpoutbox.repository.ExposedPaymentOutboxRepository
+import exposed.examples.ktor.httpoutbox.routes.paymentRoutes
+import exposed.examples.ktor.httpoutbox.service.PaymentService
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStopped
+import io.ktor.server.application.call
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+
+private const val DEFAULT_PORT = 8080
+private const val DEFAULT_EXTERNAL_BASE_URL = "https://payments.example.invalid"
+
+fun main() {
+    embeddedServer(CIO, port = DEFAULT_PORT) {
+        ktorHttpOutboxModule()
+    }.start(wait = true)
+}
+
+internal fun Application.ktorHttpOutboxModule(
+    persistence: PaymentPersistence = PaymentPersistence.inMemory(),
+    paymentGateway: PaymentGateway = KtorPaymentGateway(DEFAULT_EXTERNAL_BASE_URL),
+) {
+    monitor.subscribe(ApplicationStopped) {
+        persistence.close()
+        if (paymentGateway is AutoCloseable) {
+            paymentGateway.close()
+        }
+    }
+
+    installKtorPlugins()
+
+    val repository = ExposedPaymentOutboxRepository(persistence.database)
+    val service = PaymentService(repository, paymentGateway)
+
+    routing {
+        get("/") {
+            call.respond(IndexResponse())
+        }
+        get("/health") {
+            call.respond(HealthResponse(status = "UP"))
+        }
+        paymentRoutes(service)
+    }
+}

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/client/KtorPaymentGateway.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/client/KtorPaymentGateway.kt
@@ -1,0 +1,70 @@
+package exposed.examples.ktor.httpoutbox.client
+
+import exposed.examples.ktor.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.ktor.httpoutbox.model.ExternalPaymentRequest
+import exposed.examples.ktor.httpoutbox.model.ExternalPaymentResponse
+import exposed.examples.ktor.httpoutbox.model.ExternalPaymentResult
+import exposed.examples.ktor.httpoutbox.model.PermanentExternalPaymentException
+import exposed.examples.ktor.httpoutbox.model.RetryableExternalPaymentException
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.ServerResponseException
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.Json
+import java.io.Closeable
+
+internal class KtorPaymentGateway(
+    private val baseUrl: String,
+    private val client: HttpClient = defaultClient(),
+) : PaymentGateway,
+    Closeable {
+
+    override suspend fun charge(command: CreatePaymentCommand): ExternalPaymentResult {
+        try {
+            val response = client.post("$baseUrl/payments") {
+                header(IDEMPOTENCY_KEY_HEADER, command.idempotencyKey)
+                setBody(ExternalPaymentRequest(command.orderId, command.amountCents))
+            }.body<ExternalPaymentResponse>()
+
+            return ExternalPaymentResult(
+                externalId = response.externalId.takeIf { it.isNotBlank() }
+                    ?: "ktor-${command.idempotencyKey}"
+            )
+        } catch (e: ClientRequestException) {
+            throw PermanentExternalPaymentException("External payment request was rejected", e)
+        } catch (e: ServerResponseException) {
+            throw RetryableExternalPaymentException("External payment service is temporarily unavailable", e)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw RetryableExternalPaymentException("External payment service could not be reached", e)
+        }
+    }
+
+    private companion object {
+        private const val IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
+    }
+
+    override fun close() {
+        client.close()
+    }
+}
+
+private fun defaultClient(): HttpClient =
+    HttpClient(CIO) {
+        install(ContentNegotiation) {
+            json(
+                Json {
+                    ignoreUnknownKeys = true
+                    encodeDefaults = true
+                }
+            )
+        }
+    }

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/client/PaymentGateway.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/client/PaymentGateway.kt
@@ -1,0 +1,8 @@
+package exposed.examples.ktor.httpoutbox.client
+
+import exposed.examples.ktor.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.ktor.httpoutbox.model.ExternalPaymentResult
+
+internal interface PaymentGateway {
+    suspend fun charge(command: CreatePaymentCommand): ExternalPaymentResult
+}

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/config/KtorPlugins.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/config/KtorPlugins.kt
@@ -1,0 +1,88 @@
+package exposed.examples.ktor.httpoutbox.config
+
+import exposed.examples.ktor.httpoutbox.model.ErrorResponse
+import exposed.examples.ktor.httpoutbox.model.PaymentValidationException
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.error
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.callid.CallId
+import io.ktor.server.plugins.callid.callIdMdc
+import io.ktor.server.plugins.callid.generate
+import io.ktor.server.plugins.calllogging.CallLogging
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.request.ContentTransformationException
+import io.ktor.server.response.respond
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.Json
+import org.slf4j.event.Level
+
+private const val MAX_REQUEST_BODY_BYTES = 64L * 1024L
+
+internal fun Application.installKtorPlugins() {
+    install(ContentNegotiation) {
+        json(
+            Json {
+                ignoreUnknownKeys = true
+                encodeDefaults = true
+            }
+        )
+    }
+
+    install(CallId) {
+        retrieveFromHeader(HttpHeaders.XRequestId)
+        generate(16, "0123456789abcdef")
+        verify { it.length in 8..64 }
+    }
+
+    install(CallLogging) {
+        level = Level.INFO
+        callIdMdc("call-id")
+    }
+
+    install(StatusPages) {
+        exception<PaymentValidationException> { call, cause ->
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ErrorResponse("VALIDATION_ERROR", cause.message ?: "Request validation failed")
+            )
+        }
+        exception<NoSuchElementException> { call, cause ->
+            call.respond(
+                HttpStatusCode.NotFound,
+                ErrorResponse("NOT_FOUND", cause.message ?: "Resource was not found")
+            )
+        }
+        exception<BadRequestException> { call, _ ->
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("BAD_REQUEST", "Malformed request body"))
+        }
+        exception<ContentTransformationException> { call, _ ->
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("BAD_REQUEST", "Malformed request body"))
+        }
+        exception<PayloadTooLargeException> { call, _ ->
+            call.respond(HttpStatusCode.PayloadTooLarge, ErrorResponse("PAYLOAD_TOO_LARGE", "Request body is too large"))
+        }
+        exception<Throwable> { call, cause ->
+            if (cause is CancellationException) {
+                throw cause
+            }
+            KtorHttpOutboxLogger.log.error(cause) { "Unexpected payment outbox error" }
+            call.respond(HttpStatusCode.InternalServerError, ErrorResponse("INTERNAL_ERROR", "Unexpected server error"))
+        }
+    }
+}
+
+internal fun requirePayloadSize(bytes: Long) {
+    if (bytes > MAX_REQUEST_BODY_BYTES) {
+        throw PayloadTooLargeException()
+    }
+}
+
+internal class PayloadTooLargeException : RuntimeException("Request body is too large")
+
+private object KtorHttpOutboxLogger : KLogging()

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/model/PaymentModels.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/model/PaymentModels.kt
@@ -1,0 +1,168 @@
+package exposed.examples.ktor.httpoutbox.model
+
+import kotlinx.serialization.Serializable
+import java.io.Serializable as JavaSerializable
+
+@Serializable
+data class IndexResponse(
+    val service: String = "ktor-http-outbox-idempotency",
+) : JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+data class HealthResponse(
+    val status: String,
+) : JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+data class CreatePaymentRequest(
+    val orderId: String = "",
+    val amountCents: Long = 0,
+    val idempotencyKey: String = "",
+) : JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class CreatePaymentCommand(
+    val orderId: String,
+    val amountCents: Long,
+    val idempotencyKey: String,
+) : JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+enum class PaymentStatus {
+    PENDING,
+    SUCCEEDED,
+    RETRYABLE_FAILED,
+    PERMANENT_FAILED,
+}
+
+internal data class PaymentRecord(
+    val id: Long,
+    val orderId: String,
+    val amountCents: Long,
+    val idempotencyKey: String,
+    val status: PaymentStatus,
+    val attempts: Int,
+    val externalId: String?,
+    val lastError: String?,
+) : JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class CreatePaymentResult(
+    val record: PaymentRecord,
+    val inserted: Boolean,
+) : JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+data class PaymentResponse(
+    val id: Long,
+    val orderId: String,
+    val amountCents: Long,
+    val idempotencyKey: String,
+    val status: PaymentStatus,
+    val attempts: Int,
+    val externalId: String?,
+    val lastError: String?,
+    val duplicate: Boolean,
+) : JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+data class PaymentsResponse(
+    val payments: List<PaymentResponse>,
+) : JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+data class ErrorResponse(
+    val code: String,
+    val message: String,
+) : JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+internal data class ExternalPaymentRequest(
+    val orderId: String,
+    val amountCents: Long,
+) : JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+@Serializable
+internal data class ExternalPaymentResponse(
+    val externalId: String = "",
+) : JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal data class ExternalPaymentResult(
+    val externalId: String,
+) : JavaSerializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+internal class PaymentValidationException(message: String) : RuntimeException(message)
+
+internal open class ExternalPaymentException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)
+
+internal class RetryableExternalPaymentException(
+    message: String,
+    cause: Throwable? = null,
+) : ExternalPaymentException(message, cause)
+
+internal class PermanentExternalPaymentException(
+    message: String,
+    cause: Throwable? = null,
+) : ExternalPaymentException(message, cause)
+
+internal fun PaymentRecord.toResponse(duplicate: Boolean = false): PaymentResponse =
+    PaymentResponse(
+        id = id,
+        orderId = orderId,
+        amountCents = amountCents,
+        idempotencyKey = idempotencyKey,
+        status = status,
+        attempts = attempts,
+        externalId = externalId,
+        lastError = lastError,
+        duplicate = duplicate
+    )

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/persistence/PaymentPersistence.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/persistence/PaymentPersistence.kt
@@ -1,0 +1,31 @@
+package exposed.examples.ktor.httpoutbox.persistence
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.jetbrains.exposed.v1.jdbc.Database
+import java.io.Closeable
+
+internal class PaymentPersistence private constructor(
+    private val dataSource: HikariDataSource,
+) : Closeable {
+
+    val database: Database = Database.connect(dataSource)
+
+    override fun close() {
+        dataSource.close()
+    }
+
+    companion object {
+        fun inMemory(databaseName: String = "ktor_http_outbox"): PaymentPersistence {
+            val config = HikariConfig().apply {
+                jdbcUrl = "jdbc:h2:mem:$databaseName;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+                driverClassName = "org.h2.Driver"
+                username = "sa"
+                password = ""
+                maximumPoolSize = 4
+                poolName = "ktor-http-outbox-$databaseName"
+            }
+            return PaymentPersistence(HikariDataSource(config))
+        }
+    }
+}

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/repository/ExposedPaymentOutboxRepository.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/repository/ExposedPaymentOutboxRepository.kt
@@ -1,0 +1,173 @@
+package exposed.examples.ktor.httpoutbox.repository
+
+import exposed.examples.ktor.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.ktor.httpoutbox.model.CreatePaymentResult
+import exposed.examples.ktor.httpoutbox.model.PaymentRecord
+import exposed.examples.ktor.httpoutbox.model.PaymentStatus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class ExposedPaymentOutboxRepository(
+    private val database: Database,
+) : PaymentOutboxRepository {
+
+    private val schemaReady = AtomicBoolean(false)
+    private val schemaMutex = Mutex()
+
+    override suspend fun createPending(command: CreatePaymentCommand): CreatePaymentResult {
+        ensureSchema()
+        return try {
+            transactionIO {
+                findByIdempotencyKey(command.idempotencyKey)?.let {
+                    CreatePaymentResult(it, inserted = false)
+                } ?: insertPending(command)
+            }
+        } catch (e: ExposedSQLException) {
+            rereadDuplicate(command.idempotencyKey) ?: throw e
+        }
+    }
+
+    override suspend fun findById(id: Long): PaymentRecord? {
+        ensureSchema()
+        return transactionIO {
+            findByIdInTransaction(id)
+        }
+    }
+
+    override suspend fun findAll(): List<PaymentRecord> {
+        ensureSchema()
+        return transactionIO {
+            PaymentOutbox.selectAll().map { it.toRecord() }
+        }
+    }
+
+    override suspend fun markSucceeded(id: Long, externalId: String): PaymentRecord =
+        updateStatus(id, PaymentStatus.SUCCEEDED, externalId, null)
+
+    override suspend fun markRetryableFailure(id: Long, message: String): PaymentRecord =
+        updateStatus(id, PaymentStatus.RETRYABLE_FAILED, null, message)
+
+    override suspend fun markPermanentFailure(id: Long, message: String): PaymentRecord =
+        updateStatus(id, PaymentStatus.PERMANENT_FAILED, null, message)
+
+    override suspend fun deleteAll() {
+        ensureSchema()
+        transactionIO {
+            PaymentOutbox.deleteAll()
+        }
+    }
+
+    private suspend fun updateStatus(
+        id: Long,
+        nextStatus: PaymentStatus,
+        externalId: String?,
+        lastError: String?,
+    ): PaymentRecord {
+        ensureSchema()
+        return transactionIO {
+            val current = findByIdInTransaction(id)
+                ?: throw NoSuchElementException("Payment request $id was not found")
+            PaymentOutbox.update({ PaymentOutbox.id eq id }) {
+                it[status] = nextStatus.name
+                it[attempts] = current.attempts + 1
+                it[PaymentOutbox.externalId] = externalId
+                it[PaymentOutbox.lastError] = lastError
+            }
+            checkNotNull(findByIdInTransaction(id)) {
+                "Updated payment request $id was not found"
+            }
+        }
+    }
+
+    private suspend fun ensureSchema() {
+        if (schemaReady.get()) {
+            return
+        }
+        schemaMutex.withLock {
+            if (!schemaReady.get()) {
+                transactionIO {
+                    SchemaUtils.create(PaymentOutbox)
+                }
+                schemaReady.set(true)
+            }
+        }
+    }
+
+    private suspend fun <T> transactionIO(block: () -> T): T =
+        withContext(Dispatchers.IO) {
+            transaction(database) {
+                block()
+            }
+        }
+
+    private fun findByIdInTransaction(id: Long): PaymentRecord? =
+        PaymentOutbox.selectAll()
+            .where { PaymentOutbox.id eq id }
+            .singleOrNull()
+            ?.toRecord()
+
+    private fun findByIdempotencyKey(idempotencyKey: String): PaymentRecord? =
+        PaymentOutbox.selectAll()
+            .where { PaymentOutbox.idempotencyKey eq idempotencyKey }
+            .singleOrNull()
+            ?.toRecord()
+
+    private fun insertPending(command: CreatePaymentCommand): CreatePaymentResult {
+        val id = PaymentOutbox.insertAndGetId {
+            it[orderId] = command.orderId
+            it[amountCents] = command.amountCents
+            it[idempotencyKey] = command.idempotencyKey
+            it[status] = PaymentStatus.PENDING.name
+            it[attempts] = 0
+        }.value
+        return CreatePaymentResult(
+            checkNotNull(findByIdInTransaction(id)) {
+                "Inserted payment request $id was not found"
+            },
+            inserted = true
+        )
+    }
+
+    private suspend fun rereadDuplicate(idempotencyKey: String): CreatePaymentResult? =
+        transactionIO {
+            findByIdempotencyKey(idempotencyKey)?.let {
+                CreatePaymentResult(it, inserted = false)
+            }
+        }
+}
+
+private object PaymentOutbox : LongIdTable("ktor_payment_outbox") {
+    val orderId = varchar("order_id", 80)
+    val amountCents = long("amount_cents")
+    val idempotencyKey = varchar("idempotency_key", 120).uniqueIndex()
+    val status = varchar("status", 32)
+    val attempts = integer("attempts")
+    val externalId = varchar("external_id", 120).nullable()
+    val lastError = varchar("last_error", 240).nullable()
+}
+
+private fun ResultRow.toRecord(): PaymentRecord =
+    PaymentRecord(
+        id = this[PaymentOutbox.id].value,
+        orderId = this[PaymentOutbox.orderId],
+        amountCents = this[PaymentOutbox.amountCents],
+        idempotencyKey = this[PaymentOutbox.idempotencyKey],
+        status = PaymentStatus.valueOf(this[PaymentOutbox.status]),
+        attempts = this[PaymentOutbox.attempts],
+        externalId = this[PaymentOutbox.externalId],
+        lastError = this[PaymentOutbox.lastError]
+    )

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/repository/PaymentOutboxRepository.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/repository/PaymentOutboxRepository.kt
@@ -1,0 +1,15 @@
+package exposed.examples.ktor.httpoutbox.repository
+
+import exposed.examples.ktor.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.ktor.httpoutbox.model.CreatePaymentResult
+import exposed.examples.ktor.httpoutbox.model.PaymentRecord
+
+internal interface PaymentOutboxRepository {
+    suspend fun createPending(command: CreatePaymentCommand): CreatePaymentResult
+    suspend fun findById(id: Long): PaymentRecord?
+    suspend fun findAll(): List<PaymentRecord>
+    suspend fun markSucceeded(id: Long, externalId: String): PaymentRecord
+    suspend fun markRetryableFailure(id: Long, message: String): PaymentRecord
+    suspend fun markPermanentFailure(id: Long, message: String): PaymentRecord
+    suspend fun deleteAll()
+}

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/routes/PaymentRoutes.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/routes/PaymentRoutes.kt
@@ -1,0 +1,53 @@
+package exposed.examples.ktor.httpoutbox.routes
+
+import exposed.examples.ktor.httpoutbox.config.requirePayloadSize
+import exposed.examples.ktor.httpoutbox.model.CreatePaymentRequest
+import exposed.examples.ktor.httpoutbox.model.PaymentResponse
+import exposed.examples.ktor.httpoutbox.service.PaymentService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.request.receive
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import kotlinx.serialization.json.Json
+
+internal fun Route.paymentRoutes(
+    service: PaymentService,
+    json: Json = Json { ignoreUnknownKeys = true },
+) {
+    route("/payments") {
+        post {
+            val response = service.submit(call.receiveSized(json))
+            call.respond(if (response.duplicate) HttpStatusCode.OK else HttpStatusCode.Created, response)
+        }
+        post("/{id}/retry") {
+            call.respond(service.retry(call.paymentId()))
+        }
+        get("/{id}") {
+            call.respond(service.find(call.paymentId()))
+        }
+        get {
+            call.respond(service.findAll())
+        }
+    }
+}
+
+private suspend fun io.ktor.server.application.ApplicationCall.receiveSized(json: Json): CreatePaymentRequest {
+    val contentLength = request.headers["Content-Length"]?.toLongOrNull()
+    if (contentLength != null) {
+        requirePayloadSize(contentLength)
+        return receive()
+    }
+
+    val body = receiveText()
+    requirePayloadSize(body.toByteArray().size.toLong())
+    return json.decodeFromString(CreatePaymentRequest.serializer(), body)
+}
+
+private fun io.ktor.server.application.ApplicationCall.paymentId(): Long =
+    parameters["id"]?.toLongOrNull()
+        ?: throw exposed.examples.ktor.httpoutbox.model.PaymentValidationException("id must be a number")

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/service/PaymentService.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/main/kotlin/exposed/examples/ktor/httpoutbox/service/PaymentService.kt
@@ -1,0 +1,96 @@
+package exposed.examples.ktor.httpoutbox.service
+
+import exposed.examples.ktor.httpoutbox.client.PaymentGateway
+import exposed.examples.ktor.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.ktor.httpoutbox.model.CreatePaymentRequest
+import exposed.examples.ktor.httpoutbox.model.PaymentResponse
+import exposed.examples.ktor.httpoutbox.model.PaymentStatus
+import exposed.examples.ktor.httpoutbox.model.PaymentValidationException
+import exposed.examples.ktor.httpoutbox.model.PaymentsResponse
+import exposed.examples.ktor.httpoutbox.model.PermanentExternalPaymentException
+import exposed.examples.ktor.httpoutbox.model.RetryableExternalPaymentException
+import exposed.examples.ktor.httpoutbox.model.toResponse
+import exposed.examples.ktor.httpoutbox.repository.PaymentOutboxRepository
+
+internal class PaymentService(
+    private val repository: PaymentOutboxRepository,
+    private val paymentGateway: PaymentGateway,
+) {
+
+    suspend fun submit(request: CreatePaymentRequest): PaymentResponse {
+        val command = request.toCommand()
+        val created = repository.createPending(command)
+        if (!created.inserted) {
+            return created.record.toResponse(duplicate = true)
+        }
+        return dispatch(created.record.id, command)
+    }
+
+    suspend fun retry(id: Long): PaymentResponse {
+        val record = repository.findById(id)
+            ?: throw NoSuchElementException("Payment request $id was not found")
+        if (record.status != PaymentStatus.RETRYABLE_FAILED) {
+            throw PaymentValidationException("only retryable failed payments can be retried")
+        }
+        return dispatch(
+            id = record.id,
+            command = CreatePaymentCommand(
+                orderId = record.orderId,
+                amountCents = record.amountCents,
+                idempotencyKey = record.idempotencyKey
+            )
+        )
+    }
+
+    suspend fun find(id: Long): PaymentResponse =
+        repository.findById(id)?.toResponse()
+            ?: throw NoSuchElementException("Payment request $id was not found")
+
+    suspend fun findAll(): PaymentsResponse =
+        PaymentsResponse(repository.findAll().map { it.toResponse() })
+
+    suspend fun deleteAll() {
+        repository.deleteAll()
+    }
+
+    private suspend fun dispatch(
+        id: Long,
+        command: CreatePaymentCommand,
+    ): PaymentResponse =
+        try {
+            val result = paymentGateway.charge(command)
+            repository.markSucceeded(id, result.externalId).toResponse()
+        } catch (e: PermanentExternalPaymentException) {
+            repository.markPermanentFailure(id, e.message ?: "permanent external payment failure").toResponse()
+        } catch (e: RetryableExternalPaymentException) {
+            repository.markRetryableFailure(id, e.message ?: "retryable external payment failure").toResponse()
+        }
+
+    private fun CreatePaymentRequest.toCommand(): CreatePaymentCommand =
+        CreatePaymentCommand(
+            orderId = orderId.normalize("orderId", 80),
+            amountCents = amountCents.requirePositiveAmount(),
+            idempotencyKey = idempotencyKey.normalize("idempotencyKey", 120)
+        )
+
+    private fun String.normalize(
+        fieldName: String,
+        maxLength: Int,
+    ): String {
+        val normalized = trim()
+        if (normalized.isBlank()) {
+            throw PaymentValidationException("$fieldName must not be blank")
+        }
+        if (normalized.length > maxLength) {
+            throw PaymentValidationException("$fieldName must be $maxLength characters or less")
+        }
+        return normalized
+    }
+
+    private fun Long.requirePositiveAmount(): Long {
+        if (this <= 0) {
+            throw PaymentValidationException("amountCents must be positive")
+        }
+        return this
+    }
+}

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/test/kotlin/exposed/examples/ktor/httpoutbox/KtorHttpOutboxApplicationTest.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/test/kotlin/exposed/examples/ktor/httpoutbox/KtorHttpOutboxApplicationTest.kt
@@ -1,0 +1,41 @@
+package exposed.examples.ktor.httpoutbox
+
+import exposed.examples.ktor.httpoutbox.model.HealthResponse
+import exposed.examples.ktor.httpoutbox.persistence.PaymentPersistence
+import exposed.examples.ktor.httpoutbox.service.ScenarioPaymentGateway
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.codec.Base58
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KtorHttpOutboxApplicationTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    @Test
+    fun `index and health endpoints respond`() = testApplication {
+        application {
+            ktorHttpOutboxModule(
+                persistence = PaymentPersistence.inMemory("app_${Base58.randomString(8)}"),
+                paymentGateway = ScenarioPaymentGateway()
+            )
+        }
+
+        val index = client.get("/")
+        index.status shouldBeEqualTo HttpStatusCode.OK
+        index.bodyAsText() shouldContain "ktor-http-outbox-idempotency"
+
+        val health = json.decodeFromString<HealthResponse>(client.get("/health").bodyAsText())
+        health.status shouldBeEqualTo "UP"
+    }
+}

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/test/kotlin/exposed/examples/ktor/httpoutbox/repository/ExposedPaymentOutboxRepositoryTest.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/test/kotlin/exposed/examples/ktor/httpoutbox/repository/ExposedPaymentOutboxRepositoryTest.kt
@@ -1,0 +1,79 @@
+package exposed.examples.ktor.httpoutbox.repository
+
+import exposed.examples.ktor.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.ktor.httpoutbox.model.PaymentStatus
+import exposed.examples.ktor.httpoutbox.persistence.PaymentPersistence
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.codec.Base58
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExposedPaymentOutboxRepositoryTest {
+
+    @Test
+    fun `create pending request then mark success`() = runTest {
+        PaymentPersistence.inMemory("ktor_repo_${Base58.randomString(8)}").use { persistence ->
+            val repository = ExposedPaymentOutboxRepository(persistence.database)
+
+            val created = repository.createPending(command("pay-1"))
+            created.inserted shouldBeEqualTo true
+            created.record.status shouldBeEqualTo PaymentStatus.PENDING
+
+            val succeeded = repository.markSucceeded(created.record.id, "ext-1")
+
+            succeeded.status shouldBeEqualTo PaymentStatus.SUCCEEDED
+            succeeded.attempts shouldBeEqualTo 1
+            succeeded.externalId shouldBeEqualTo "ext-1"
+        }
+    }
+
+    @Test
+    fun `duplicate idempotency key returns stored record`() = runTest {
+        PaymentPersistence.inMemory("ktor_repo_${Base58.randomString(8)}").use { persistence ->
+            val repository = ExposedPaymentOutboxRepository(persistence.database)
+
+            val first = repository.createPending(command("same-key"))
+            val duplicate = repository.createPending(command("same-key"))
+
+            duplicate.inserted shouldBeEqualTo false
+            duplicate.record.id shouldBeEqualTo first.record.id
+        }
+    }
+
+    @Test
+    fun `concurrent duplicate idempotency key returns one stored record`() = runTest {
+        PaymentPersistence.inMemory("ktor_repo_${Base58.randomString(8)}").use { persistence ->
+            val repository = ExposedPaymentOutboxRepository(persistence.database)
+            val start = CompletableDeferred<Unit>()
+            val results = coroutineScope {
+                val jobs = (1..8).map {
+                    async(Dispatchers.Default) {
+                        start.await()
+                        repository.createPending(command("concurrent-key"))
+                    }
+                }
+                start.complete(Unit)
+                jobs.awaitAll()
+            }
+
+            results.count { it.inserted } shouldBeEqualTo 1
+            results.map { it.record.id }.toSet() shouldHaveSize 1
+            repository.findAll() shouldHaveSize 1
+        }
+    }
+
+    private fun command(idempotencyKey: String): CreatePaymentCommand =
+        CreatePaymentCommand(
+            orderId = "order-$idempotencyKey",
+            amountCents = 1_500,
+            idempotencyKey = idempotencyKey
+        )
+}

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/test/kotlin/exposed/examples/ktor/httpoutbox/routes/PaymentRoutesTest.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/test/kotlin/exposed/examples/ktor/httpoutbox/routes/PaymentRoutesTest.kt
@@ -1,0 +1,102 @@
+package exposed.examples.ktor.httpoutbox.routes
+
+import exposed.examples.ktor.httpoutbox.ktorHttpOutboxModule
+import exposed.examples.ktor.httpoutbox.model.CreatePaymentRequest
+import exposed.examples.ktor.httpoutbox.model.ErrorResponse
+import exposed.examples.ktor.httpoutbox.model.PaymentResponse
+import exposed.examples.ktor.httpoutbox.model.PaymentsResponse
+import exposed.examples.ktor.httpoutbox.persistence.PaymentPersistence
+import exposed.examples.ktor.httpoutbox.service.ScenarioPaymentGateway
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.codec.Base58
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PaymentRoutesTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    @Test
+    fun `payment routes cover success duplicate permanent and retry paths`() = testApplicationWithPersistence { gateway ->
+        gateway.succeed("ok-key", "ext-ok")
+        val created = createPayment(CreatePaymentRequest(" order-ok ", 2_500, " ok-key "))
+        created.status.name shouldBeEqualTo "SUCCEEDED"
+        created.externalId shouldBeEqualTo "ext-ok"
+
+        val duplicateResponse = postJson("/payments", CreatePaymentRequest("order-ok", 2_500, "ok-key"))
+        duplicateResponse.status shouldBeEqualTo HttpStatusCode.OK
+        json.decodeFromString<PaymentResponse>(duplicateResponse.bodyAsText()).duplicate shouldBeEqualTo true
+
+        gateway.retryableThenSuccess("retry-key", "ext-retry")
+        val retryable = createPayment(CreatePaymentRequest("order-retry", 1_000, "retry-key"))
+        retryable.status.name shouldBeEqualTo "RETRYABLE_FAILED"
+
+        val retried = json.decodeFromString<PaymentResponse>(
+            client.post("/payments/${retryable.id}/retry").bodyAsText()
+        )
+        retried.status.name shouldBeEqualTo "SUCCEEDED"
+        retried.attempts shouldBeEqualTo 2
+
+        gateway.permanent("bad-key")
+        val permanent = createPayment(CreatePaymentRequest("order-bad", 1_000, "bad-key"))
+        permanent.status.name shouldBeEqualTo "PERMANENT_FAILED"
+
+        val list = json.decodeFromString<PaymentsResponse>(client.get("/payments").bodyAsText())
+        list.payments shouldHaveSize 3
+    }
+
+    @Test
+    fun `validation and not found errors are sanitized`() = testApplicationWithPersistence { _ ->
+        val validation = postJson("/payments", CreatePaymentRequest("", 1_000, "key"))
+        validation.status shouldBeEqualTo HttpStatusCode.BadRequest
+        json.decodeFromString<ErrorResponse>(validation.bodyAsText()).code shouldBeEqualTo "VALIDATION_ERROR"
+
+        val notFound = client.get("/payments/999")
+        notFound.status shouldBeEqualTo HttpStatusCode.NotFound
+        json.decodeFromString<ErrorResponse>(notFound.bodyAsText()).code shouldBeEqualTo "NOT_FOUND"
+    }
+
+    private suspend fun ApplicationTestBuilder.createPayment(request: CreatePaymentRequest): PaymentResponse {
+        val response = postJson("/payments", request)
+        response.status shouldBeEqualTo HttpStatusCode.Created
+        return json.decodeFromString(response.bodyAsText())
+    }
+
+    private suspend inline fun <reified T> ApplicationTestBuilder.postJson(
+        path: String,
+        body: T,
+    ) = client.post(path) {
+        contentType(ContentType.Application.Json)
+        setBody(json.encodeToString(body))
+    }
+
+    private fun testApplicationWithPersistence(
+        test: suspend ApplicationTestBuilder.(ScenarioPaymentGateway) -> Unit,
+    ) = testApplication {
+        val persistence = PaymentPersistence.inMemory("route_${Base58.randomString(8)}")
+        val gateway = ScenarioPaymentGateway()
+
+        application {
+            ktorHttpOutboxModule(persistence, gateway)
+        }
+
+        test(gateway)
+    }
+}

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/test/kotlin/exposed/examples/ktor/httpoutbox/service/PaymentServiceTest.kt
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/test/kotlin/exposed/examples/ktor/httpoutbox/service/PaymentServiceTest.kt
@@ -1,0 +1,126 @@
+package exposed.examples.ktor.httpoutbox.service
+
+import exposed.examples.ktor.httpoutbox.client.PaymentGateway
+import exposed.examples.ktor.httpoutbox.model.CreatePaymentCommand
+import exposed.examples.ktor.httpoutbox.model.CreatePaymentRequest
+import exposed.examples.ktor.httpoutbox.model.ExternalPaymentResult
+import exposed.examples.ktor.httpoutbox.model.PaymentStatus
+import exposed.examples.ktor.httpoutbox.model.PaymentValidationException
+import exposed.examples.ktor.httpoutbox.model.PermanentExternalPaymentException
+import exposed.examples.ktor.httpoutbox.model.RetryableExternalPaymentException
+import exposed.examples.ktor.httpoutbox.persistence.PaymentPersistence
+import exposed.examples.ktor.httpoutbox.repository.ExposedPaymentOutboxRepository
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.codec.Base58
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.ArrayDeque
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PaymentServiceTest {
+
+    @Test
+    fun `successful payment is persisted before external success is recorded`() = runTest {
+        withService { service, gateway ->
+            gateway.succeed("key-1", "ext-1")
+
+            val response = service.submit(CreatePaymentRequest(" order-1 ", 2_500, " key-1 "))
+
+            response.status shouldBeEqualTo PaymentStatus.SUCCEEDED
+            response.attempts shouldBeEqualTo 1
+            response.externalId shouldBeEqualTo "ext-1"
+            gateway.commands.single() shouldBeEqualTo CreatePaymentCommand("order-1", 2_500, "key-1")
+        }
+    }
+
+    @Test
+    fun `duplicate idempotency key returns existing payment without second external call`() = runTest {
+        withService { service, gateway ->
+            gateway.succeed("key-2", "ext-2")
+
+            val first = service.submit(CreatePaymentRequest("order-2", 2_500, "key-2"))
+            val duplicate = service.submit(CreatePaymentRequest("order-2", 2_500, "key-2"))
+
+            duplicate.id shouldBeEqualTo first.id
+            duplicate.duplicate shouldBeEqualTo true
+            gateway.commands.size shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `retryable failure can be retried to success`() = runTest {
+        withService { service, gateway ->
+            gateway.retryableThenSuccess("retry-key", "ext-retry")
+
+            val failed = service.submit(CreatePaymentRequest("order-retry", 1_000, "retry-key"))
+            failed.status shouldBeEqualTo PaymentStatus.RETRYABLE_FAILED
+
+            val retried = service.retry(failed.id)
+
+            retried.status shouldBeEqualTo PaymentStatus.SUCCEEDED
+            retried.attempts shouldBeEqualTo 2
+            retried.externalId shouldBeEqualTo "ext-retry"
+        }
+    }
+
+    @Test
+    fun `permanent failure is not retryable`() = runTest {
+        withService { service, gateway ->
+            gateway.permanent("bad-key")
+            val failed = service.submit(CreatePaymentRequest("order-bad", 1_000, "bad-key"))
+
+            val error = try {
+                service.retry(failed.id)
+                throw AssertionError("PaymentValidationException was expected")
+            } catch (e: PaymentValidationException) {
+                e
+            }
+
+            failed.status shouldBeEqualTo PaymentStatus.PERMANENT_FAILED
+            error.message shouldBeEqualTo "only retryable failed payments can be retried"
+        }
+    }
+
+    private suspend fun withService(test: suspend (PaymentService, ScenarioPaymentGateway) -> Unit) {
+        PaymentPersistence.inMemory("ktor_service_${Base58.randomString(8)}").use { persistence ->
+            val gateway = ScenarioPaymentGateway()
+            val repository = ExposedPaymentOutboxRepository(persistence.database)
+            test(PaymentService(repository, gateway), gateway)
+        }
+    }
+}
+
+internal class ScenarioPaymentGateway : PaymentGateway {
+    val commands = mutableListOf<CreatePaymentCommand>()
+    private val outcomes = mutableMapOf<String, ArrayDeque<() -> ExternalPaymentResult>>()
+
+    override suspend fun charge(command: CreatePaymentCommand): ExternalPaymentResult {
+        commands += command
+        val next = outcomes[command.idempotencyKey]?.poll()
+        return next?.invoke() ?: ExternalPaymentResult("ext-${command.idempotencyKey}")
+    }
+
+    fun succeed(
+        idempotencyKey: String,
+        externalId: String,
+    ) {
+        outcomes[idempotencyKey] = ArrayDeque(listOf({ ExternalPaymentResult(externalId) }))
+    }
+
+    fun retryableThenSuccess(
+        idempotencyKey: String,
+        externalId: String,
+    ) {
+        outcomes[idempotencyKey] = ArrayDeque(
+            listOf(
+                { throw RetryableExternalPaymentException("temporary failure") },
+                { ExternalPaymentResult(externalId) }
+            )
+        )
+    }
+
+    fun permanent(idempotencyKey: String) {
+        outcomes[idempotencyKey] = ArrayDeque(listOf({ throw PermanentExternalPaymentException("permanent failure") }))
+    }
+}

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/test/resources/junit-platform.properties
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/12-production-integration/04-ktor-http-outbox-idempotency/src/test/resources/logback-test.xml
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/src/test/resources/logback-test.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/12-production-integration/README.ko.md
+++ b/12-production-integration/README.ko.md
@@ -11,7 +11,7 @@
 | 애플리케이션 아키텍처 | [02-spring-application-architecture](02-spring-application-architecture/README.ko.md) | [01-ktor-application-architecture](01-ktor-application-architecture/README.ko.md) |
 | 인증/세션 | issue #59 예정 | issue #59 예정 |
 | 리얼타임 아웃박스 | issue #60 예정 | issue #60 예정 |
-| HTTP 클라이언트 아웃박스/멱등성 | issue #61 예정 | issue #61 예정 |
+| HTTP 클라이언트 아웃박스/멱등성 | [03-spring-http-outbox-idempotency](03-spring-http-outbox-idempotency/README.ko.md) | [04-ktor-http-outbox-idempotency](04-ktor-http-outbox-idempotency/README.ko.md) |
 | 관측성/준비 상태 | issue #62 예정 | issue #62 예정 |
 
 ## 검증
@@ -19,9 +19,9 @@
 ```bash
 ./gradlew :01-ktor-application-architecture:test
 ./gradlew :02-spring-application-architecture:test
+./gradlew :03-spring-http-outbox-idempotency:test
+./gradlew :04-ktor-http-outbox-idempotency:test
 ```
 
-쌍을 이룬 아키텍처 모듈은 chapter 12 에픽의 첫 완료 주제입니다. 남은 주제도
-Spring/Ktor 쌍, 집중 테스트, README의 트레이드오프 설명을 같은 형태로
-확장합니다.
-
+완료된 주제는 Spring/Ktor 쌍, 집중 테스트, README의 트레이드오프 설명, 실제
+외부 서비스에 의존하지 않는 예제 구조를 같은 형태로 유지합니다.

--- a/12-production-integration/README.md
+++ b/12-production-integration/README.md
@@ -12,7 +12,7 @@ use cases, Exposed persistence, tests, and operational documentation.
 | Application architecture | [02-spring-application-architecture](02-spring-application-architecture/README.md) | [01-ktor-application-architecture](01-ktor-application-architecture/README.md) |
 | Auth/session | Planned by issue #59 | Planned by issue #59 |
 | Realtime outbox | Planned by issue #60 | Planned by issue #60 |
-| HTTP client outbox/idempotency | Planned by issue #61 | Planned by issue #61 |
+| HTTP client outbox/idempotency | [03-spring-http-outbox-idempotency](03-spring-http-outbox-idempotency/README.md) | [04-ktor-http-outbox-idempotency](04-ktor-http-outbox-idempotency/README.md) |
 | Observability/readiness | Planned by issue #62 | Planned by issue #62 |
 
 ## Verification
@@ -20,9 +20,10 @@ use cases, Exposed persistence, tests, and operational documentation.
 ```bash
 ./gradlew :01-ktor-application-architecture:test
 ./gradlew :02-spring-application-architecture:test
+./gradlew :03-spring-http-outbox-idempotency:test
+./gradlew :04-ktor-http-outbox-idempotency:test
 ```
 
-The paired architecture modules are the first completed topic for the chapter
-12 epic. Remaining topics should follow the same shape: paired Spring/Ktor
-coverage, focused tests, and explicit README tradeoffs.
-
+Completed topics should keep the same shape: paired Spring/Ktor coverage,
+focused tests, explicit README tradeoffs, and no real external service
+dependency in examples.

--- a/README.ko.md
+++ b/README.ko.md
@@ -337,6 +337,14 @@ Exposed 기반 운영형 서비스 패턴을 Spring Boot 4와 Ktor로 비교합�
 
 MVC 컨트롤러, 컨트롤러 advice, 서비스 검증, Exposed JDBC 저장소를 갖춘 Spring Boot 4 쌍을 구현합니다.
 
+#### [Spring HTTP 아웃박스와 멱등성](12-production-integration/03-spring-http-outbox-idempotency/README.ko.md)
+
+외부 HTTP 결제 요청을 전송 전에 저장하고, 멱등성 키로 중복을 방지하며, Spring Boot 4에서 재시도 가능한 gateway 실패와 영구 실패를 분리합니다.
+
+#### [Ktor HTTP 아웃박스와 멱등성](12-production-integration/04-ktor-http-outbox-idempotency/README.ko.md)
+
+suspend route handler, `Dispatchers.IO` 뒤의 Exposed JDBC 저장소, 성공/재시도/중복/영구 실패를 검증하는 fake-gateway 테스트를 갖춘 Ktor 쌍을 구현합니다.
+
 ---
 
 ## 시작하기

--- a/README.md
+++ b/README.md
@@ -337,6 +337,14 @@ Build a small Ktor service with explicit routing, service validation, sanitized 
 
 Build the Spring Boot 4 pair with MVC controllers, controller advice, service validation, and an Exposed JDBC repository.
 
+#### [Spring HTTP Outbox and Idempotency](12-production-integration/03-spring-http-outbox-idempotency/README.md)
+
+Persist outbound HTTP payment requests before dispatch, enforce duplicate-safe idempotency keys, and separate retryable from permanent gateway failures in Spring Boot 4.
+
+#### [Ktor HTTP Outbox and Idempotency](12-production-integration/04-ktor-http-outbox-idempotency/README.md)
+
+Implement the Ktor pair with suspend route handlers, an Exposed JDBC repository behind `Dispatchers.IO`, and fake-gateway tests for success, retry, duplicate, and permanent-failure paths.
+
 ---
 
 ## Getting Started

--- a/docs/lessons/2026-05-22-issue-61-http-outbox-idempotency.md
+++ b/docs/lessons/2026-05-22-issue-61-http-outbox-idempotency.md
@@ -1,0 +1,27 @@
+# Issue 61 HTTP Outbox Idempotency Examples
+
+## Context
+
+Issue #61 added the second paired chapter 12 production-integration topic:
+Spring Boot 4 and Ktor HTTP client outbox/idempotency examples.
+
+## Decision
+
+Persist the outbound payment record before gateway dispatch, use a unique
+idempotency key as the duplicate boundary, and keep the gateway replaceable so
+tests do not require a real external HTTP service.
+
+## Outcome
+
+The Spring module uses MVC, `RestClient`, controller advice, and an Exposed JDBC
+repository. The Ktor module mirrors the contract with routes, `StatusPages`, a
+Ktor HTTP client, and blocking Exposed calls isolated behind `Dispatchers.IO`.
+
+## Verification
+
+Run the two module builds and the `Examples.yml` workflow path after changes.
+
+## Future Guidance
+
+For chapter 12 paired examples, update the chapter README, root README files,
+and `.github/workflows/examples.yml` in the same PR as the runnable modules.

--- a/docs/superpowers/plans/2026-05-22-issue-61-http-outbox-idempotency-plan.md
+++ b/docs/superpowers/plans/2026-05-22-issue-61-http-outbox-idempotency-plan.md
@@ -1,0 +1,45 @@
+# Issue 61 HTTP Outbox Idempotency Plan
+
+## Retrieval
+
+- qmd similar work lookup: complete.
+- qmd caution lookup: complete.
+- Current issue body: verified from GitHub issue #61.
+- `$bluetape4k-patterns`: applied to all Kotlin tasks.
+
+## Tasks
+
+1. Create Spring Boot 4 module.
+   - Add Gradle build.
+   - Add Exposed persistence/repository.
+   - Add `RestClient` outbound client.
+   - Add service and MVC controller/advice.
+   - Add repository, service, and MockMvc tests.
+
+2. Create Ktor module.
+   - Add Gradle build.
+   - Add Exposed persistence/repository.
+   - Add Ktor `HttpClient` outbound client.
+   - Add service, plugins, and routes.
+   - Add repository, service, and route tests.
+
+3. Update docs and workflow.
+   - Add module README files in English and Korean.
+   - Update chapter README files.
+   - Update root README files.
+   - Add both modules to `.github/workflows/examples.yml`.
+
+4. Verify.
+   - `./gradlew projects --no-daemon`
+   - `./gradlew :03-spring-http-outbox-idempotency:test --no-daemon`
+   - `./gradlew :04-ktor-http-outbox-idempotency:test --no-daemon`
+   - Examples workflow equivalent build.
+   - `actionlint .github/workflows/examples.yml`
+   - `git diff --check`
+
+5. Delivery.
+   - Record concise lesson.
+   - Commit with Lore trailers.
+   - Open PR assigned to `debop`.
+   - Wait for Examples success.
+   - Merge and sync local `develop`.

--- a/docs/superpowers/specs/2026-05-22-issue-61-http-outbox-idempotency-design.md
+++ b/docs/superpowers/specs/2026-05-22-issue-61-http-outbox-idempotency-design.md
@@ -1,0 +1,65 @@
+# Issue 61 HTTP Outbox Idempotency Design
+
+## Context
+
+Issue #61 adds a chapter 12 pair that demonstrates safe outbound HTTP integration
+for Spring Boot 4 and Ktor services backed by Exposed JDBC.
+
+Prior retrieval:
+
+- `qmd query "HTTP client outbox idempotency external API persisted outbound requests retry duplicate permanent failure examples" -c bluetape4k-docs --no-rerank`
+- `qmd query "Spring Boot Ktor Exposed outbox idempotency retry transaction cancellation testcontainers cautions" -c bluetape4k-docs --no-rerank`
+- `qmd query "outbox idempotency external API retry duplicate key permanent failure Kotlin Exposed" -c wiki --no-rerank`
+
+Relevant cautions:
+
+- Keep blocking Exposed JDBC work inside repositories.
+- Ktor routes must not call `transaction {}` directly.
+- Duplicate writes must be explicit through an idempotency key.
+- Retryable and permanent failures must persist different states.
+
+## Scope
+
+Add two modules:
+
+- `12-production-integration/03-spring-http-outbox-idempotency`
+- `12-production-integration/04-ktor-http-outbox-idempotency`
+
+Both modules expose:
+
+- `POST /payments` to persist an outbound payment request and dispatch it.
+- `POST /payments/{id}/retry` to retry retryable failures.
+- `GET /payments/{id}` and `GET /payments` to inspect stored outbox records.
+- `/` and `/health` discovery endpoints.
+
+## Domain Contract
+
+`PaymentRequest` contains `orderId`, `amountCents`, and `idempotencyKey`.
+
+The service must:
+
+1. Normalize and validate caller input.
+2. Insert a pending outbox row before calling the external client.
+3. Return the existing record for duplicate idempotency keys.
+4. Mark 2xx external responses as `SUCCEEDED`.
+5. Mark retryable failures as `RETRYABLE_FAILED`.
+6. Mark client/permanent failures as `PERMANENT_FAILED`.
+7. Retry only `RETRYABLE_FAILED` records.
+
+## Implementation Notes
+
+- Spring production client uses `RestClient`.
+- Ktor production client uses Ktor `HttpClient`.
+- Tests use fake clients and do not call real external services.
+- Exposed table names are stack-specific to avoid collision:
+  - `spring_payment_outbox`
+  - `ktor_payment_outbox`
+- Public README files explain the Spring vs Ktor tradeoff.
+
+## Acceptance Criteria
+
+- Both modules build and test independently.
+- Success, retryable failure, duplicate idempotency key, and permanent failure
+  paths are covered.
+- `.github/workflows/examples.yml` builds the new modules.
+- Root and chapter README files list the new pair.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -183,6 +183,9 @@ ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", versio
 ktor-server-call-logging = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor" }
 ktor-server-call-id = { module = "io.ktor:ktor-server-call-id", version.ref = "ktor" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 
 # Kotlinx Benchmark


### PR DESCRIPTION
## Summary
- add paired Spring Boot 4 and Ktor HTTP outbox/idempotency examples for chapter 12
- persist outbound payment requests before gateway dispatch and recover duplicate-key races by rereading the winning row
- document the modules and include both new examples in the Examples workflow

## Verification
- actionlint .github/workflows/examples.yml
- ./gradlew :01-ktor-application-architecture:build :02-spring-application-architecture:build :03-spring-http-outbox-idempotency:build :04-ktor-http-outbox-idempotency:build --no-daemon --continue
- Claude advisor gate: P0=0, P1=0

Closes #61