### PR TITLE
Close routing datasource tenant pools

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [ develop, main ]
     paths:
+      - '11-high-performance/03-routing-datasource/**'
       - '12-production-integration/**'
       - 'buildSrc/**'
       - 'gradle/**'
@@ -15,6 +16,7 @@ on:
   pull_request:
     branches: [ develop, main ]
     paths:
+      - '11-high-performance/03-routing-datasource/**'
       - '12-production-integration/**'
       - 'buildSrc/**'
       - 'gradle/**'
@@ -42,7 +44,7 @@ jobs:
       - uses: gradle/actions/wrapper-validation@v6
 
   build-examples:
-    name: Build / Chapter 12 Examples
+    name: Build / Examples (selected modules)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: validate-wrapper
@@ -59,14 +61,16 @@ jobs:
           gradle-version: wrapper
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
-      - name: Build and test chapter 12 examples
+      - name: Build and test selected examples
         run: |
+          # Routing DataSource uses GraalVM AOT tasks; disable configuration cache for this mixed example build.
           ./gradlew \
+            :03-routing-datasource:build \
             :01-ktor-application-architecture:build \
             :02-spring-application-architecture:build \
             :03-spring-http-outbox-idempotency:build \
             :04-ktor-http-outbox-idempotency:build \
-            --no-daemon --continue
+            --no-daemon --no-configuration-cache --continue
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
 

--- a/11-high-performance/03-routing-datasource/README.ko.md
+++ b/11-high-performance/03-routing-datasource/README.ko.md
@@ -11,6 +11,7 @@
 - 정적 `targetDataSources` 맵 대신 Registry 기반 라우팅 구조를 구성한다.
 - `TenantContext`와 `@Transactional(readOnly = true)`를 하나의 라우팅 규칙으로 통합한다.
 - 미등록 키, 기본 tenant fallback, 동시 등록 같은 운영성 이슈를 테스트로 검증한다.
+- Spring 종료 시 registry가 소유한 Hikari pool을 결정적으로 닫는다.
 
 ## 선수 지식
 
@@ -72,7 +73,7 @@ routing:
 
 | Bean                             | 타입                               | 역할                |
 |----------------------------------|----------------------------------|-------------------|
-| `dataSourceRegistry`             | `InMemoryDataSourceRegistry`     | 키별 DataSource 등록소 |
+| `dataSourceRegistry`             | `InMemoryDataSourceRegistry`     | 종료 lifecycle을 포함한 키별 DataSource 등록소 |
 | `routingKeyResolver`             | `ContextAwareRoutingKeyResolver` | 라우팅 키 계산기         |
 | `routingDataSource` (`@Primary`) | `DynamicRoutingDataSource`       | 실제 연결 위임자         |
 | `exposedDatabase`                | `Database`                       | Exposed DB 연결     |
@@ -171,6 +172,7 @@ curl -X PATCH \
 | 예외 처리    | 미등록 키 조회                      | `IllegalStateException`     |
 | 동시성      | 등록/조회 병행                      | 레이스 없이 항상 유효한 DataSource 반환 |
 | 헤더 처리    | 공백 헤더                         | `defaultTenant` 적용          |
+| Lifecycle | 애플리케이션 종료                    | 등록된 Hikari pool close       |
 
 ---
 

--- a/11-high-performance/03-routing-datasource/README.md
+++ b/11-high-performance/03-routing-datasource/README.md
@@ -10,6 +10,7 @@ Combines `tenant + transaction readOnly` information to form a `<tenant>:<rw|ro>
 - Build a Registry-based routing structure instead of a static `targetDataSources` map.
 - Combine `TenantContext` and `@Transactional(readOnly = true)` into a single routing rule.
 - Verify operational concerns such as unregistered keys, default tenant fallback, and concurrent registration through tests.
+- Close registry-owned Hikari pools deterministically during Spring shutdown.
 
 ## Prerequisites
 
@@ -69,7 +70,7 @@ If the `ro` entry is omitted, `RoutingDataSourceConfig` registers the `rw` DataS
 
 | Bean                             | Type                             | Role                          |
 |----------------------------------|----------------------------------|-------------------------------|
-| `dataSourceRegistry`             | `InMemoryDataSourceRegistry`     | Per-key DataSource registry   |
+| `dataSourceRegistry`             | `InMemoryDataSourceRegistry`     | Per-key DataSource registry with shutdown lifecycle |
 | `routingKeyResolver`             | `ContextAwareRoutingKeyResolver` | Routing key calculator        |
 | `routingDataSource` (`@Primary`) | `DynamicRoutingDataSource`       | Actual connection delegator   |
 | `exposedDatabase`                | `Database`                       | Exposed DB connection         |
@@ -166,6 +167,7 @@ curl -X PATCH \
 | Error handling | Lookup of unregistered key        | `IllegalStateException`                  |
 | Concurrency    | Concurrent registration/lookup    | Always returns valid DataSource, no race |
 | Header handling | Blank header                     | Apply `defaultTenant`                    |
+| Lifecycle      | Application shutdown              | Registered Hikari pools are closed       |
 
 ---
 

--- a/11-high-performance/03-routing-datasource/src/main/kotlin/exposed/examples/routing/config/RoutingDataSourceConfig.kt
+++ b/11-high-performance/03-routing-datasource/src/main/kotlin/exposed/examples/routing/config/RoutingDataSourceConfig.kt
@@ -36,9 +36,6 @@ class RoutingDataSourceConfig {
             registry.register("$tenantId:rw", rw)
             registry.register("$tenantId:ro", ro)
         }
-        // TODO: @PreDestroy에서 HikariDataSource들을 close() 호출 필요.
-        // InMemoryDataSourceRegistry가 Closeable을 구현하거나, 별도 @PreDestroy 메서드에서
-        // registry에 등록된 모든 DataSource를 순회하여 close()를 호출해야 커넥션 풀 누수를 방지할 수 있습니다.
         return registry
     }
 

--- a/11-high-performance/03-routing-datasource/src/main/kotlin/exposed/examples/routing/datasource/DataSourceRegistry.kt
+++ b/11-high-performance/03-routing-datasource/src/main/kotlin/exposed/examples/routing/datasource/DataSourceRegistry.kt
@@ -5,10 +5,13 @@ import javax.sql.DataSource
 /**
  * 라우팅 키에 대응하는 [DataSource]를 등록/조회하는 레지스트리입니다.
  */
-interface DataSourceRegistry {
+interface DataSourceRegistry: AutoCloseable {
 
     /**
      * [key]에 [dataSource]를 등록합니다.
+     *
+     * 같은 [key]가 이미 등록되어 있으면 새 값으로 교체하지만, 기존 [DataSource]는 닫지 않습니다.
+     * 교체 전 리소스 해제 책임은 호출자에게 있습니다.
      */
     fun register(key: String, dataSource: DataSource)
 
@@ -26,5 +29,13 @@ interface DataSourceRegistry {
      * 현재 등록된 키 목록을 반환합니다.
      */
     fun keys(): Set<String>
-}
 
+    /**
+     * 레지스트리가 소유한 [DataSource] 리소스를 해제합니다.
+     *
+     * 이미 닫힌 레지스트리에 대해 다시 호출해도 안전해야 합니다. 호출 후 레지스트리는 비워지며 재사용하지 않는 것을
+     * 권장합니다. 하나 이상의 리소스 해제에 실패하면 나머지 리소스 해제를 계속 시도한 뒤 실패 원인을 suppressed
+     * exception으로 담은 [IllegalStateException]을 던집니다.
+     */
+    override fun close()
+}

--- a/11-high-performance/03-routing-datasource/src/main/kotlin/exposed/examples/routing/datasource/InMemoryDataSourceRegistry.kt
+++ b/11-high-performance/03-routing-datasource/src/main/kotlin/exposed/examples/routing/datasource/InMemoryDataSourceRegistry.kt
@@ -1,5 +1,7 @@
 package exposed.examples.routing.datasource
 
+import java.util.Collections
+import java.util.IdentityHashMap
 import java.util.concurrent.ConcurrentHashMap
 import javax.sql.DataSource
 
@@ -18,5 +20,32 @@ class InMemoryDataSourceRegistry: DataSourceRegistry {
     override fun contains(key: String): Boolean = dataSources.containsKey(key)
 
     override fun keys(): Set<String> = dataSources.keys
+
+    override fun close() {
+        val closeableDataSources = dataSources.values
+            .filterIsInstance<AutoCloseable>()
+            .distinctByIdentity()
+        val failures = mutableListOf<Exception>()
+
+        dataSources.clear()
+
+        closeableDataSources.forEach { dataSource ->
+            try {
+                dataSource.close()
+            } catch (e: Exception) {
+                failures.add(e)
+            }
+        }
+
+        if (failures.isNotEmpty()) {
+            throw IllegalStateException("Failed to close registered DataSources.").apply {
+                failures.forEach(::addSuppressed)
+            }
+        }
+    }
 }
 
+private fun <T: Any> Iterable<T>.distinctByIdentity(): List<T> {
+    val seen = Collections.newSetFromMap(IdentityHashMap<T, Boolean>())
+    return filter { seen.add(it) }
+}

--- a/11-high-performance/03-routing-datasource/src/test/kotlin/exposed/examples/routing/config/RoutingDataSourceConfigTest.kt
+++ b/11-high-performance/03-routing-datasource/src/test/kotlin/exposed/examples/routing/config/RoutingDataSourceConfigTest.kt
@@ -1,8 +1,8 @@
 package exposed.examples.routing.config
 
 import com.zaxxer.hikari.HikariDataSource
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 
 class RoutingDataSourceConfigTest {
@@ -24,13 +24,12 @@ class RoutingDataSourceConfigTest {
         val ro = registry.get("default:ro") as HikariDataSource
 
         try {
-            assertTrue(registry.contains("default:rw"))
-            assertTrue(registry.contains("default:ro"))
-            assertEquals("jdbc:h2:mem:routing_default_rw", rw.jdbcUrl)
-            assertEquals("jdbc:h2:mem:routing_default_rw", ro.jdbcUrl)
+            registry.contains("default:rw").shouldBeTrue()
+            registry.contains("default:ro").shouldBeTrue()
+            rw.jdbcUrl shouldBeEqualTo "jdbc:h2:mem:routing_default_rw"
+            ro.jdbcUrl shouldBeEqualTo "jdbc:h2:mem:routing_default_rw"
         } finally {
-            rw.close()
-            ro.close()
+            registry.close()
         }
     }
 
@@ -42,7 +41,28 @@ class RoutingDataSourceConfigTest {
 
         val resolver = config.routingKeyResolver(properties)
 
-        assertEquals("fallback-tenant:rw", resolver.currentLookupKey())
+        resolver.currentLookupKey() shouldBeEqualTo "fallback-tenant:rw"
+    }
+
+    @Test
+    fun `dataSourceRegistry 종료 시 등록된 Hikari pool을 닫는다`() {
+        val properties = RoutingDataSourceProperties().apply {
+            defaultTenant = "default"
+            tenants["default"] = TenantDataSourceProperties().apply {
+                rw = dataSourceNode("jdbc:h2:mem:routing_close_default_rw")
+                ro = dataSourceNode("jdbc:h2:mem:routing_close_default_ro")
+            }
+        }
+
+        val registry = config.dataSourceRegistry(properties)
+        val rw = registry.get("default:rw") as HikariDataSource
+        val ro = registry.get("default:ro") as HikariDataSource
+
+        registry.close()
+
+        rw.isClosed.shouldBeTrue()
+        ro.isClosed.shouldBeTrue()
+        registry.keys().size shouldBeEqualTo 0
     }
 
     private fun dataSourceNode(url: String) =

--- a/11-high-performance/03-routing-datasource/src/test/kotlin/exposed/examples/routing/datasource/InMemoryDataSourceRegistryTest.kt
+++ b/11-high-performance/03-routing-datasource/src/test/kotlin/exposed/examples/routing/datasource/InMemoryDataSourceRegistryTest.kt
@@ -1,13 +1,16 @@
 package exposed.examples.routing.datasource
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
 import org.h2.Driver
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.jdbc.datasource.SimpleDriverDataSource
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.TimeUnit
 
 /** 동시 등록과 조회를 포함한 `InMemoryDataSourceRegistry`의 스레드 안전성과 기본 동작을 검증합니다. */
@@ -28,9 +31,9 @@ class InMemoryDataSourceRegistryTest {
         executor.shutdown()
         executor.awaitTermination(5, TimeUnit.SECONDS)
 
-        assertEquals(count, registry.keys().size)
-        assertTrue(registry.contains("tenant-1:rw"))
-        assertNotNull(registry.get("tenant-1:rw"))
+        registry.keys().size shouldBeEqualTo count
+        registry.contains("tenant-1:rw").shouldBeTrue()
+        registry.get("tenant-1:rw").shouldNotBeNull()
     }
 
     @Test
@@ -42,14 +45,65 @@ class InMemoryDataSourceRegistryTest {
         registry.register("tenant:rw", original)
         registry.register("tenant:rw", replacement)
 
-        assertEquals(1, registry.keys().size)
-        assertEquals(replacement, registry.get("tenant:rw"))
+        registry.keys().size shouldBeEqualTo 1
+        registry.get("tenant:rw") shouldBeSameInstanceAs replacement
     }
 
     @Test
     fun `존재하지 않는 키 조회 시 null을 반환한다`() {
         val registry = InMemoryDataSourceRegistry()
-        assertNull(registry.get("nonexistent:rw"))
+        registry.get("nonexistent:rw").shouldBeNull()
+    }
+
+    @Test
+    fun `close는 등록된 closeable DataSource를 한 번씩 닫고 registry를 비운다`() {
+        val registry = InMemoryDataSourceRegistry()
+        val shared = CloseTrackingDataSource("shared")
+        val dedicated = CloseTrackingDataSource("dedicated")
+
+        registry.register("tenant:rw", shared)
+        registry.register("tenant:ro", shared)
+        registry.register("other:rw", dedicated)
+
+        registry.close()
+
+        shared.closeCount.get() shouldBeEqualTo 1
+        dedicated.closeCount.get() shouldBeEqualTo 1
+        registry.keys().size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `close는 여러 번 호출해도 이미 닫은 DataSource를 다시 닫지 않는다`() {
+        val registry = InMemoryDataSourceRegistry()
+        val dataSource = CloseTrackingDataSource("idempotent")
+
+        registry.register("tenant:rw", dataSource)
+
+        registry.close()
+        registry.close()
+
+        dataSource.closeCount.get() shouldBeEqualTo 1
+        registry.keys().size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `close 실패 시 다른 DataSource 종료를 계속 시도하고 suppressed exception을 전달한다`() {
+        val registry = InMemoryDataSourceRegistry()
+        val failing = FailingCloseDataSource("failing")
+        val dedicated = CloseTrackingDataSource("dedicated-after-failure")
+
+        registry.register("failing:rw", failing)
+        registry.register("dedicated:rw", dedicated)
+
+        val failure = assertFailsWith<IllegalStateException> {
+            registry.close()
+        }
+
+        failure.suppressed.size shouldBeEqualTo 1
+        failure.suppressed.single().message shouldBeEqualTo("close failed: failing")
+        failing.closeCount.get() shouldBeEqualTo 1
+        dedicated.closeCount.get() shouldBeEqualTo 1
+        registry.keys().size shouldBeEqualTo 0
     }
 
     private fun testDataSource(name: String) =
@@ -59,5 +113,26 @@ class InMemoryDataSourceRegistryTest {
             "sa",
             "",
         )
-}
 
+    private open class CloseTrackingDataSource(
+        protected val dataSourceName: String,
+    ): SimpleDriverDataSource(
+        Driver(),
+        "jdbc:h2:mem:$dataSourceName;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "sa",
+        "",
+    ), AutoCloseable {
+        val closeCount = AtomicInteger()
+
+        override fun close() {
+            closeCount.incrementAndGet()
+        }
+    }
+
+    private class FailingCloseDataSource(name: String): CloseTrackingDataSource(name) {
+        override fun close() {
+            super.close()
+            throw IllegalStateException("close failed: $dataSourceName")
+        }
+    }
+}

--- a/docs/lessons/2026-05-22-issue-70-routing-datasource-lifecycle.md
+++ b/docs/lessons/2026-05-22-issue-70-routing-datasource-lifecycle.md
@@ -1,0 +1,35 @@
+# Issue 70 Routing Datasource Lifecycle
+
+## Context
+
+Issue #70 reported that the chapter 11 routing datasource example created
+tenant Hikari pools but did not give Spring a deterministic shutdown hook.
+
+## Decision
+
+Make `DataSourceRegistry` `AutoCloseable` and let `InMemoryDataSourceRegistry`
+own shutdown for currently registered closeable data sources. Deduplicate by
+identity so a shared datasource registered under multiple keys is closed once.
+Document that replacing an existing key does not close the old datasource.
+
+## Outcome
+
+The TODO in `RoutingDataSourceConfig` was removed. The routing datasource example
+now closes registry-owned Hikari pools during Spring shutdown, and `Examples.yml`
+builds the routing module together with selected chapter 12 examples. The
+workflow disables Gradle configuration cache for this mixed example build because
+the routing module's GraalVM AOT tasks triggered a local configuration-cache
+serialization failure.
+
+## Verification
+
+- `actionlint .github/workflows/examples.yml`
+- `./gradlew :03-routing-datasource:test --no-daemon` — 29 passing
+- `./gradlew :03-routing-datasource:build :01-ktor-application-architecture:build :02-spring-application-architecture:build :03-spring-http-outbox-idempotency:build :04-ktor-http-outbox-idempotency:build --no-daemon --no-configuration-cache --continue`
+- Claude advisor artifact: `.omx/artifacts/ask-claude-code-review-issue-70-routing-datasource-final2-20260522103201.md` — P0=0, P1=0
+
+## Future Guard
+
+When adding example-owned pools, make the owner `AutoCloseable` and add tests
+for idempotent close, shared-instance close-once behavior, and suppressed
+exception propagation.


### PR DESCRIPTION
Closes #70

## Summary
- make the routing DataSource registry `AutoCloseable` so Spring shutdown closes registry-owned Hikari pools
- close each registered closeable DataSource once by identity and aggregate close failures with suppressed exceptions
- document lifecycle semantics in README.md / README.ko.md and include `:03-routing-datasource:build` in Examples workflow

## Verification
- `actionlint .github/workflows/examples.yml`
- `./gradlew :03-routing-datasource:test --no-daemon` — 29 passing
- `./gradlew :03-routing-datasource:build :01-ktor-application-architecture:build :02-spring-application-architecture:build :03-spring-http-outbox-idempotency:build :04-ktor-http-outbox-idempotency:build --no-daemon --no-configuration-cache --continue` — BUILD SUCCESSFUL

## Review Gate
- Codex review: P0=0, P1=0
- Claude advisor: `.omx/artifacts/ask-claude-code-review-issue-70-routing-datasource-final2-20260522103201.md`, P0=0, P1=0

## Notes
- `Examples.yml` disables Gradle configuration cache for this mixed selected-example build because adding the routing module triggered a local GraalVM AOT configuration-cache serialization failure.
- IntelliJ diagnostics were not available for this worktree; Gradle compile/test and targeted static scans were used instead.
