### PR TITLE
chore: align bluetape4k-dependencies 1.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k-dependencies = "1.0.1-SNAPSHOT"
+bluetape4k-dependencies = "1.0.1"
 
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.11.0"


### PR DESCRIPTION
## Summary
- Align shared bluetape4k-dependencies catalog version with the released 1.0.1 train.

## Verification
- ./gradlew help --no-daemon
- scripts/sync-shared-versions.py --workspace .. --check --summary from bluetape4k-dependencies

## Notes
- This is a downstream sync-only change required by the dependencies repo shared-version gate.