### PR TITLE
build: sync dependencies 1.1.1 catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k-dependencies = "1.0.1"
+bluetape4k-dependencies = "1.1.0"
 
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.11.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k-dependencies = "1.1.0"
+bluetape4k-dependencies = "1.1.1"
 
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.11.0"


### PR DESCRIPTION
## Summary

- update `bluetape4k-dependencies` from 1.0.1 to the 1.1.1 release catalog
- consume the patched publishable BOM surface that supersedes 1.1.0

## Verification

- CI rerun on this PR branch
