### PR TITLE
build: centralize workshop dependencies on 1.1.3

### DIFF
--- a/00-shared/exposed-shared-tests/build.gradle.kts
+++ b/00-shared/exposed-shared-tests/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     // Bluetape4k Exposed
     api(libs.exposed.core)

--- a/03-exposed-basic/exposed-dao-example/build.gradle.kts
+++ b/03-exposed-basic/exposed-dao-example/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/03-exposed-basic/exposed-sql-example/build.gradle.kts
+++ b/03-exposed-basic/exposed-sql-example/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/04-exposed-ddl/01-connection/build.gradle.kts
+++ b/04-exposed-ddl/01-connection/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/04-exposed-ddl/02-ddl/build.gradle.kts
+++ b/04-exposed-ddl/02-ddl/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/05-exposed-dml/01-dml/build.gradle.kts
+++ b/05-exposed-dml/01-dml/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/05-exposed-dml/02-types/build.gradle.kts
+++ b/05-exposed-dml/02-types/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/05-exposed-dml/03-functions/build.gradle.kts
+++ b/05-exposed-dml/03-functions/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/05-exposed-dml/04-transactions/build.gradle.kts
+++ b/05-exposed-dml/04-transactions/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/05-exposed-dml/05-entities/build.gradle.kts
+++ b/05-exposed-dml/05-entities/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/06-advanced/01-exposed-crypt/build.gradle.kts
+++ b/06-advanced/01-exposed-crypt/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
 
     testImplementation(project(":exposed-shared-tests"))

--- a/06-advanced/02-exposed-javatime/build.gradle.kts
+++ b/06-advanced/02-exposed-javatime/build.gradle.kts
@@ -7,7 +7,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/06-advanced/03-exposed-kotlin-datetime/build.gradle.kts
+++ b/06-advanced/03-exposed-kotlin-datetime/build.gradle.kts
@@ -7,7 +7,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/06-advanced/04-exposed-json/build.gradle.kts
+++ b/06-advanced/04-exposed-json/build.gradle.kts
@@ -7,7 +7,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/06-advanced/05-exposed-money/build.gradle.kts
+++ b/06-advanced/05-exposed-money/build.gradle.kts
@@ -7,7 +7,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/06-advanced/06-custom-columns/build.gradle.kts
+++ b/06-advanced/06-custom-columns/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/06-advanced/07-custom-entities/build.gradle.kts
+++ b/06-advanced/07-custom-entities/build.gradle.kts
@@ -7,7 +7,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/06-advanced/08-exposed-jackson/build.gradle.kts
+++ b/06-advanced/08-exposed-jackson/build.gradle.kts
@@ -3,8 +3,6 @@ configurations {
 }
 
 dependencies {
-    testImplementation(platform(libs.jetbrains.exposed.bom))
-    testImplementation(platform(libs.bluetape4k.dependencies))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/06-advanced/09-exposed-fastjson2/build.gradle.kts
+++ b/06-advanced/09-exposed-fastjson2/build.gradle.kts
@@ -3,8 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
-    implementation(platform(libs.bluetape4k.dependencies))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/06-advanced/11-exposed-jackson3/build.gradle.kts
+++ b/06-advanced/11-exposed-jackson3/build.gradle.kts
@@ -3,8 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
-    implementation(platform(libs.bluetape4k.dependencies))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/06-advanced/12-exposed-tink/build.gradle.kts
+++ b/06-advanced/12-exposed-tink/build.gradle.kts
@@ -3,8 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
-    implementation(platform(libs.bluetape4k.dependencies))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/07-jpa/01-convert-jpa-basic/build.gradle.kts
+++ b/07-jpa/01-convert-jpa-basic/build.gradle.kts
@@ -7,7 +7,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/07-jpa/02-convert-jpa-advanced/build.gradle.kts
+++ b/07-jpa/02-convert-jpa-advanced/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/08-coroutines/01-coroutines-basic/build.gradle.kts
+++ b/08-coroutines/01-coroutines-basic/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/08-coroutines/02-virtualthreads-basic/build.gradle.kts
+++ b/08-coroutines/02-virtualthreads-basic/build.gradle.kts
@@ -3,7 +3,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/09-spring/01-springboot-autoconfigure/build.gradle.kts
+++ b/09-spring/01-springboot-autoconfigure/build.gradle.kts
@@ -9,7 +9,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/09-spring/02-transactiontemplate/build.gradle.kts
+++ b/09-spring/02-transactiontemplate/build.gradle.kts
@@ -10,7 +10,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/09-spring/03-spring-transaction/build.gradle.kts
+++ b/09-spring/03-spring-transaction/build.gradle.kts
@@ -10,7 +10,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     testImplementation(project(":exposed-shared-tests"))
 

--- a/09-spring/06-spring-cache/build.gradle.kts
+++ b/09-spring/06-spring-cache/build.gradle.kts
@@ -22,8 +22,6 @@ configurations {
 }
 
 dependencies {
-
-    implementation(platform(libs.jetbrains.exposed.bom))
     testImplementation(project(":exposed-shared-tests"))
 
 

--- a/11-high-performance/01-cache-strategies/build.gradle.kts
+++ b/11-high-performance/01-cache-strategies/build.gradle.kts
@@ -23,8 +23,6 @@ configurations {
 }
 
 dependencies {
-
-    implementation(platform(libs.jetbrains.exposed.bom))
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed

--- a/11-high-performance/02-cache-strategies-coroutines/build.gradle.kts
+++ b/11-high-performance/02-cache-strategies-coroutines/build.gradle.kts
@@ -22,8 +22,6 @@ configurations {
 }
 
 dependencies {
-
-    implementation(platform(libs.jetbrains.exposed.bom))
     testImplementation(project(":exposed-shared-tests"))
 
     // Exposed

--- a/11-high-performance/03-routing-datasource/build.gradle.kts
+++ b/11-high-performance/03-routing-datasource/build.gradle.kts
@@ -25,8 +25,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
-
-    implementation(platform(libs.jetbrains.exposed.bom))
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)
 

--- a/11-high-performance/04-benchmark/build.gradle.kts
+++ b/11-high-performance/04-benchmark/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
     implementation(libs.jmh.core)
 
     // Exposed
-    implementation(platform(libs.jetbrains.exposed.bom))
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)
     implementation(libs.jetbrains.exposed.dao)

--- a/12-production-integration/01-ktor-application-architecture/build.gradle.kts
+++ b/12-production-integration/01-ktor-application-architecture/build.gradle.kts
@@ -12,7 +12,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.cio)

--- a/12-production-integration/02-spring-application-architecture/build.gradle.kts
+++ b/12-production-integration/02-spring-application-architecture/build.gradle.kts
@@ -19,7 +19,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)

--- a/12-production-integration/03-spring-http-outbox-idempotency/build.gradle.kts
+++ b/12-production-integration/03-spring-http-outbox-idempotency/build.gradle.kts
@@ -19,7 +19,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)

--- a/12-production-integration/04-ktor-http-outbox-idempotency/build.gradle.kts
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/build.gradle.kts
@@ -12,7 +12,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.cio)

--- a/12-production-integration/05-spring-auth-session/build.gradle.kts
+++ b/12-production-integration/05-spring-auth-session/build.gradle.kts
@@ -12,7 +12,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)

--- a/12-production-integration/06-ktor-auth-session/build.gradle.kts
+++ b/12-production-integration/06-ktor-auth-session/build.gradle.kts
@@ -12,7 +12,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.cio)

--- a/12-production-integration/07-spring-outbox-realtime/build.gradle.kts
+++ b/12-production-integration/07-spring-outbox-realtime/build.gradle.kts
@@ -19,7 +19,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)

--- a/12-production-integration/08-ktor-outbox-realtime/build.gradle.kts
+++ b/12-production-integration/08-ktor-outbox-realtime/build.gradle.kts
@@ -12,7 +12,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.cio)

--- a/12-production-integration/09-spring-observability-readiness/build.gradle.kts
+++ b/12-production-integration/09-spring-observability-readiness/build.gradle.kts
@@ -12,7 +12,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)

--- a/12-production-integration/10-ktor-observability-readiness/build.gradle.kts
+++ b/12-production-integration/10-ktor-observability-readiness/build.gradle.kts
@@ -12,7 +12,6 @@ configurations {
 }
 
 dependencies {
-    implementation(platform(libs.jetbrains.exposed.bom))
 
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.cio)

--- a/docs/lessons/2026-05-24-dependencies-1-1-3-sync.md
+++ b/docs/lessons/2026-05-24-dependencies-1-1-3-sync.md
@@ -1,0 +1,31 @@
+# Dependencies 1.1.3 Sync
+
+## Context
+
+`exposed-workshop` was still consuming `bluetape4k-dependencies = "1.1.1"`.
+The published release tag `bluetape4k-dependencies` `1.1.3` is the catalog
+baseline for downstream sync; the local post-release branch may already carry
+the next development version.
+
+## Decision
+
+Keep `bluetape4k-dependencies` as the only bluetape4k BOM source and update the
+catalog version to `1.1.3`. Do not add direct `bluetape4k-bom`,
+`bluetape4k-exposed-bom`, or per-example JetBrains Exposed BOM imports; example
+modules should consume the versions already managed by the root dependency
+management setup.
+
+## Outcome
+
+The local catalog now resolves bluetape4k and bluetape4k-exposed versions
+through `io.github.bluetape4k:bluetape4k-dependencies:1.1.3`, and example
+modules no longer import `libs.jetbrains.exposed.bom` directly.
+
+- `git show 1.1.3:gradle/libs.versions.toml` confirmed the tag catalog declares
+  `bluetape4k-dependencies = "1.1.3"`.
+- `rg` over Gradle files found no direct `libs.jetbrains.exposed.bom`,
+  `libs.bluetape4k.dependencies`, `bluetape4k-bom`, or
+  `bluetape4k-exposed-bom` usage.
+- `./gradlew -q :exposed-shared-tests:dependencyInsight --configuration compileClasspath --dependency org.jetbrains.exposed:exposed-core`
+  resolved `org.jetbrains.exposed:exposed-core:1.3.0`.
+- `./gradlew compileTestKotlin --no-daemon` passed.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k-dependencies = "1.1.1"
+bluetape4k-dependencies = "1.1.3"
 
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.11.0"
@@ -233,7 +233,6 @@ reactor-test = { module = "io.projectreactor:reactor-test" }
 netty-bom = { module = "io.netty:netty-bom", version.ref = "netty" }
 
 # JetBrains Exposed
-jetbrains-exposed-bom = { module = "org.jetbrains.exposed:exposed-bom", version.ref = "exposed" }
 jetbrains-exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
 jetbrains-exposed-crypt = { module = "org.jetbrains.exposed:exposed-crypt", version.ref = "exposed" }
 jetbrains-exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }


### PR DESCRIPTION
## Summary
- update the workshop catalog to `bluetape4k-dependencies` 1.1.3
- remove direct per-module Exposed BOM and redundant bluetape4k dependencies platform imports
- document the dependency governance decision in `docs/lessons`

## Verification
- `./gradlew compileTestKotlin --no-daemon`
- dependencyInsight for managed Exposed coordinates
- forbidden-reference `rg` check for direct BOM imports
- `git diff --check`

## Notes
- Code review is intentionally deferred to a separate step by request.
- Nightly CI will be triggered manually after PR creation.