### PR TITLE
docs: wire Ktor high-performance examples

### DIFF
--- a/11-high-performance/README.ko.md
+++ b/11-high-performance/README.ko.md
@@ -25,6 +25,9 @@
 | [`02-cache-strategies-coroutines`](02-cache-strategies-coroutines/README.md) | WebFlux + Coroutines 기반 캐시 전략        |
 | [`03-routing-datasource`](03-routing-datasource/README.md)                   | DataSource 라우팅 설계 가이드                |
 | [`04-benchmark`](04-benchmark/README.md)                                     | `kotlinx-benchmark` 기반 성능 측정         |
+| [`05-cache-strategies-ktor`](05-cache-strategies-ktor/README.md)             | Ktor cache-aside/read-through/write-through 예제 |
+| [`06-cache-strategies-coroutines-ktor`](06-cache-strategies-coroutines-ktor/README.md) | Coroutine-safe Ktor cache 예제 |
+| [`07-routing-datasource-ktor`](07-routing-datasource-ktor/README.md)         | Ktor read/write datasource routing 예제 |
 
 ---
 
@@ -58,6 +61,9 @@
 | `02-cache-strategies-coroutines` | WebFlux    | Coroutines + Netty 이벤트 루프 | Netty   |
 | `03-routing-datasource`          | Spring MVC | 스레드 기반                    | Tomcat  |
 | `04-benchmark`                   | JMH        | JMH 스레드                   | N/A     |
+| `05-cache-strategies-ktor`       | Ktor       | CIO 이벤트 루프 + blocking repository | CIO     |
+| `06-cache-strategies-coroutines-ktor` | Ktor  | Suspend route + `Dispatchers.IO` DB | CIO     |
+| `07-routing-datasource-ktor`     | Ktor       | Request plugin + coroutine context | CIO     |
 
 ---
 
@@ -67,6 +73,9 @@
 2. [`02-cache-strategies-coroutines`](02-cache-strategies-coroutines/README.md) — 코루틴 비동기 캐시
 3. [`03-routing-datasource`](03-routing-datasource/README.md) — 동적 DataSource 라우팅
 4. [`04-benchmark`](04-benchmark/README.md) — 성능 측정 및 비교
+5. [`05-cache-strategies-ktor`](05-cache-strategies-ktor/README.md) — Ktor cache strategy route
+6. [`06-cache-strategies-coroutines-ktor`](06-cache-strategies-coroutines-ktor/README.md) — Coroutine-safe Ktor cache
+7. [`07-routing-datasource-ktor`](07-routing-datasource-ktor/README.md) — Ktor read/write datasource routing
 
 ---
 
@@ -77,6 +86,9 @@
 ./gradlew :11-high-performance:01-cache-strategies:test
 ./gradlew :11-high-performance:02-cache-strategies-coroutines:test
 ./gradlew :11-high-performance:03-routing-datasource:test
+./gradlew :05-cache-strategies-ktor:test
+./gradlew :06-cache-strategies-coroutines-ktor:test
+./gradlew :07-routing-datasource-ktor:test
 
 # 벤치마크 (smoke: 빠른 추세, main: 정밀 측정)
 ./gradlew :11-high-performance:04-benchmark:smokeBenchmark
@@ -90,6 +102,8 @@
 - 캐시 적중률/지연시간/DB 부하 감소 효과를 검증한다.
 - Write-Behind 지연 반영 시 정합성 보장 시나리오를 점검한다.
 - 장애 시 폴백 경로(캐시 실패 → DB)가 정상 동작하는지 확인한다.
+- Ktor 모듈은 route response에서 cache source 또는 selected datasource role이 드러나는지 확인한다.
+- Ktor 예제는 H2-only라 container-backed nightly coverage가 필요하지 않다.
 
 ---
 

--- a/11-high-performance/README.md
+++ b/11-high-performance/README.md
@@ -25,6 +25,9 @@ Covers cache and routing strategies for improving throughput and responsiveness 
 | [`02-cache-strategies-coroutines`](02-cache-strategies-coroutines/README.md) | Cache strategies with WebFlux + Coroutines                |
 | [`03-routing-datasource`](03-routing-datasource/README.md)                   | DataSource routing design guide                           |
 | [`04-benchmark`](04-benchmark/README.md)                                     | Performance measurement with `kotlinx-benchmark`          |
+| [`05-cache-strategies-ktor`](05-cache-strategies-ktor/README.md)             | Ktor cache-aside/read-through/write-through examples      |
+| [`06-cache-strategies-coroutines-ktor`](06-cache-strategies-coroutines-ktor/README.md) | Coroutine-safe Ktor cache examples               |
+| [`07-routing-datasource-ktor`](07-routing-datasource-ktor/README.md)         | Ktor read/write datasource routing examples               |
 
 ---
 
@@ -58,6 +61,9 @@ Covers cache and routing strategies for improving throughput and responsiveness 
 | `02-cache-strategies-coroutines` | WebFlux    | Coroutines + Netty event loop         | Netty       |
 | `03-routing-datasource`          | Spring MVC | Thread-based                         | Tomcat      |
 | `04-benchmark`                   | JMH        | JMH threads                          | N/A         |
+| `05-cache-strategies-ktor`       | Ktor       | CIO event loop + blocking repository | CIO         |
+| `06-cache-strategies-coroutines-ktor` | Ktor  | Suspend routes + `Dispatchers.IO` DB | CIO         |
+| `07-routing-datasource-ktor`     | Ktor       | Request plugin + coroutine context   | CIO         |
 
 ---
 
@@ -67,6 +73,9 @@ Covers cache and routing strategies for improving throughput and responsiveness 
 2. [`02-cache-strategies-coroutines`](02-cache-strategies-coroutines/README.md) — Coroutine async cache
 3. [`03-routing-datasource`](03-routing-datasource/README.md) — Dynamic DataSource routing
 4. [`04-benchmark`](04-benchmark/README.md) — Performance measurement and comparison
+5. [`05-cache-strategies-ktor`](05-cache-strategies-ktor/README.md) — Ktor cache strategy routes
+6. [`06-cache-strategies-coroutines-ktor`](06-cache-strategies-coroutines-ktor/README.md) — Coroutine-safe Ktor cache
+7. [`07-routing-datasource-ktor`](07-routing-datasource-ktor/README.md) — Ktor read/write datasource routing
 
 ---
 
@@ -77,6 +86,9 @@ Covers cache and routing strategies for improving throughput and responsiveness 
 ./gradlew :11-high-performance:01-cache-strategies:test
 ./gradlew :11-high-performance:02-cache-strategies-coroutines:test
 ./gradlew :11-high-performance:03-routing-datasource:test
+./gradlew :05-cache-strategies-ktor:test
+./gradlew :06-cache-strategies-coroutines-ktor:test
+./gradlew :07-routing-datasource-ktor:test
 
 # Benchmark (smoke: fast trend check, main: precise measurement)
 ./gradlew :11-high-performance:04-benchmark:smokeBenchmark
@@ -90,6 +102,8 @@ Covers cache and routing strategies for improving throughput and responsiveness 
 - Verify cache hit rate/latency/DB load reduction effects.
 - Check consistency guarantee scenarios during Write-Behind delayed propagation.
 - Confirm fallback path (cache failure → DB) operates correctly on failure.
+- For Ktor modules, confirm route responses expose cache source or selected datasource role.
+- Ktor examples are H2-only and do not require container-backed nightly coverage.
 
 ---
 

--- a/docs/lessons/2026-05-24-issue-50-wire-ktor-examples.md
+++ b/docs/lessons/2026-05-24-issue-50-wire-ktor-examples.md
@@ -1,0 +1,21 @@
+# Issue 50 Wire Ktor Chapter Examples
+
+## Context
+
+Issue #50 asked to wire the new Ktor chapter examples into documentation and verification guidance.
+
+## Decision
+
+Record the chapter 11 Ktor module links, test tasks, and CI/nightly coverage decision in both English and Korean README files. Treat the Ktor modules as H2-only examples that do not need container-backed nightly coverage.
+
+## Outcome
+
+Updated `11-high-performance/README.md` and `README.ko.md` with Ktor cache, coroutine cache, and routing datasource modules plus verification commands.
+
+## Verification
+
+Passed: `git diff --check`.
+
+## Future Guidance
+
+Docs PRs that depend on feature PRs may reference not-yet-merged module directories, but they should clearly list the prerequisite module PRs in the PR body.


### PR DESCRIPTION
## Summary
- Add chapter 11 links for the Ktor cache, coroutine cache, and routing datasource modules.
- Document the expected Gradle test tasks for the new Ktor modules.
- Record the CI/nightly decision: the new Ktor examples are H2-only and do not need container-backed nightly coverage.

Closes #50

## Depends on
- #101
- #102
- #103

## Verification
- `git diff --check`

## Merge
- Do not merge yet; merge this after the dependent Ktor module PRs are ready or merged.