### PR TITLE
docs: wire chapter 10 tenant onboarding

### DIFF
--- a/10-multi-tenant/README.ko.md
+++ b/10-multi-tenant/README.ko.md
@@ -52,6 +52,7 @@ Single DB Instance
 | `05-database-per-tenant-spring-web`       | tenant별 전용 Hikari pool을 쓰는 database-per-tenant 예제 | `ThreadLocal`     |
 | `06-spring-security-tenant-authorization-spring-web` | database routing 전 Spring Security로 tenant authorization 수행 | `ThreadLocal` |
 | `07-multitenant-ktor`                     | Ktor request plugin 기반 멀티테넌트 예제 | Coroutine `ThreadContextElement` |
+| `08-tenant-onboarding-spring-web`         | Tenant catalog 저장과 schema provisioning 예제 | Service transaction |
 
 ---
 
@@ -89,6 +90,7 @@ Single DB Instance
 4. [`04-schema-per-tenant-spring-web`](04-schema-per-tenant-spring-web/README.ko.md) — 하나의 shared pool에서 명시적 schema switch, reset, connection eviction을 실습
 5. [`05-database-per-tenant-spring-web`](05-database-per-tenant-spring-web/README.ko.md) — tenant마다 전용 datasource를 선택하고 fallback database가 없도록 구성
 6. [`06-spring-security-tenant-authorization-spring-web`](06-spring-security-tenant-authorization-spring-web/README.ko.md) — 인증된 identity와 tenant routing을 연결한 뒤 database를 선택
+7. [`08-tenant-onboarding-spring-web`](08-tenant-onboarding-spring-web/README.ko.md) — Tenant metadata를 저장하고 cleanup 가능한 tenant schema를 provisioning
 
 ---
 
@@ -102,9 +104,10 @@ Single DB Instance
 ./gradlew :04-schema-per-tenant-spring-web:test
 ./gradlew :05-database-per-tenant-spring-web:test
 ./gradlew :06-spring-security-tenant-authorization-spring-web:test
+./gradlew :08-tenant-onboarding-spring-web:test
 
 # 전체 챕터 빌드
-./gradlew :01-multitenant-spring-web:build :02-multitenant-spring-web-virtualthread:build :03-multitenant-spring-webflux:build :04-schema-per-tenant-spring-web:build :05-database-per-tenant-spring-web:build :06-spring-security-tenant-authorization-spring-web:build
+./gradlew :01-multitenant-spring-web:build :02-multitenant-spring-web-virtualthread:build :03-multitenant-spring-webflux:build :04-schema-per-tenant-spring-web:build :05-database-per-tenant-spring-web:build :06-spring-security-tenant-authorization-spring-web:build :08-tenant-onboarding-spring-web:build
 ```
 
 ---
@@ -114,6 +117,8 @@ Single DB Instance
 - `X-TENANT-ID` 누락/오입력 시 실패 동작을 검증한다.
 - 테넌트 A 요청에서 테넌트 B 데이터가 노출되지 않는지 확인한다.
 - 동시 요청 환경에서 컨텍스트 누수 여부를 검증한다.
+- Tenant onboarding이 duplicate를 거부하고 실패 후 부분 provisioning schema를 제거하는지 확인한다.
+- H2-only onboarding test는 일반 CI에 두고, container-heavy tenant module은 nightly coverage에 유지한다.
 
 ## 성능·안정성 체크포인트
 

--- a/10-multi-tenant/README.md
+++ b/10-multi-tenant/README.md
@@ -52,6 +52,7 @@ It then compares that baseline with **Database per Tenant**, where each whitelis
 | `05-database-per-tenant-spring-web`       | Database-per-tenant with dedicated Hikari pools    | `ThreadLocal`         |
 | `06-spring-security-tenant-authorization-spring-web` | Tenant authorization with Spring Security before database routing | `ThreadLocal` |
 | `07-multitenant-ktor`                     | Multi-tenant with Ktor request plugins             | Coroutine `ThreadContextElement` |
+| `08-tenant-onboarding-spring-web`         | Tenant catalog persistence and schema provisioning | Service transaction   |
 
 ---
 
@@ -89,6 +90,7 @@ All modules follow the flow below. Only the context propagation mechanism differ
 4. [`04-schema-per-tenant-spring-web`](04-schema-per-tenant-spring-web/README.md) — Practice explicit schema switching, reset, and connection eviction with one shared pool
 5. [`05-database-per-tenant-spring-web`](05-database-per-tenant-spring-web/README.md) — Route each tenant to a dedicated datasource with no fallback database
 6. [`06-spring-security-tenant-authorization-spring-web`](06-spring-security-tenant-authorization-spring-web/README.md) — Bind tenant routing to authenticated identity before database selection
+7. [`08-tenant-onboarding-spring-web`](08-tenant-onboarding-spring-web/README.md) — Persist tenant metadata and provision tenant schemas with cleanup
 
 ---
 
@@ -102,9 +104,10 @@ All modules follow the flow below. Only the context propagation mechanism differ
 ./gradlew :04-schema-per-tenant-spring-web:test
 ./gradlew :05-database-per-tenant-spring-web:test
 ./gradlew :06-spring-security-tenant-authorization-spring-web:test
+./gradlew :08-tenant-onboarding-spring-web:test
 
 # Full chapter build
-./gradlew :01-multitenant-spring-web:build :02-multitenant-spring-web-virtualthread:build :03-multitenant-spring-webflux:build :04-schema-per-tenant-spring-web:build :05-database-per-tenant-spring-web:build :06-spring-security-tenant-authorization-spring-web:build
+./gradlew :01-multitenant-spring-web:build :02-multitenant-spring-web-virtualthread:build :03-multitenant-spring-webflux:build :04-schema-per-tenant-spring-web:build :05-database-per-tenant-spring-web:build :06-spring-security-tenant-authorization-spring-web:build :08-tenant-onboarding-spring-web:build
 ```
 
 ---
@@ -114,6 +117,8 @@ All modules follow the flow below. Only the context propagation mechanism differ
 - Verify failure behavior when `X-TENANT-ID` is missing or invalid.
 - Confirm that tenant B data is not exposed in tenant A requests.
 - Verify no context leakage under concurrent request load.
+- Confirm tenant onboarding rejects duplicates and removes partially provisioned schemas after failure.
+- H2-only onboarding tests stay in normal CI; container-heavy tenant modules should remain in nightly coverage.
 
 ## Performance & Stability Checkpoints
 

--- a/docs/lessons/2026-05-24-issue-56-wire-chapter-10-strategies.md
+++ b/docs/lessons/2026-05-24-issue-56-wire-chapter-10-strategies.md
@@ -1,0 +1,21 @@
+# Issue 56 Wire Chapter 10 Strategies
+
+## Context
+
+Issue #56 asked to wire chapter 10 Spring Boot strategy examples into documentation and verification.
+
+## Decision
+
+Add the tenant onboarding module to chapter 10 English/Korean README files with module links, test/build tasks, and a CI/nightly coverage decision.
+
+## Outcome
+
+Updated `10-multi-tenant/README.md` and `README.ko.md` for `08-tenant-onboarding-spring-web`.
+
+## Verification
+
+Passed: `git diff --check`.
+
+## Future Guidance
+
+Docs PRs for strategy wiring should list dependent feature PRs and record whether new modules require nightly container coverage.


### PR DESCRIPTION
## Summary
- Add `08-tenant-onboarding-spring-web` to chapter 10 English/Korean module lists.
- Document the expected test/build tasks for the onboarding module.
- Record the CI/nightly decision: H2-only onboarding tests stay in normal CI; container-heavy tenant modules stay in nightly coverage.

Closes #56

## Depends on
- #105

## Verification
- `git diff --check`

## Merge
- Do not merge yet; merge this after the tenant onboarding module PR is ready or merged.