### PR TITLE
docs: record workshop parity decisions

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -383,6 +383,27 @@ Spring Boot 4 서비스의 Actuator readiness, request correlation, structured e
 
 ---
 
+## exposed-r2dbc-workshop 예제 parity
+
+이슈 [#99](https://github.com/bluetape4k/exposed-workshop/issues/99)는
+[`exposed-r2dbc-workshop`](https://github.com/bluetape4k/exposed-r2dbc-workshop)과의 개념 수준 parity를 추적합니다.
+정확한 모듈명 일치가 목적은 아니며, JDBC/blocking과 R2DBC의 데이터베이스 API 모델이 다를 때는 서로 다른 아키텍처 선택을 유지합니다.
+R2DBC 쪽 대응 추적 이슈는
+[exposed-r2dbc-workshop#89](https://github.com/bluetape4k/exposed-r2dbc-workshop/issues/89)입니다(닫힘; 이 결정을 반영).
+
+| `exposed-workshop` 주제 | R2DBC 대응 항목 | 결정 |
+|------------------------|----------------|------|
+| Ktor 예제 epic `#45` 및 멀티테넌트 `#46` | 닫힌 R2DBC 이슈 `#32`, `#33`; 모듈 `10-multi-tenant/07-multitenant-ktor` | 대응 항목으로 충족 |
+| Ktor 캐시/라우팅 구현 이슈 `#47`, `#48`, `#49` 및 wiring `#50`; JDBC 모듈 `11-high-performance/05-07-*` | 닫힌 R2DBC 이슈 `#34`, `#35`, `#36`, `#69`; R2DBC 모듈 `11-high-performance/04-06-*` | 대응 항목으로 충족; `#50`은 문서 wiring |
+| Spring Boot 테넌트 전략 epic `#51`, 구현 `#52`-`#55`, wiring `#56`; JDBC 모듈 `10-multi-tenant/04-06-*`, `08-tenant-onboarding-spring-web` | 닫힌 R2DBC 이슈 `#37`-`#42`; R2DBC 모듈 `10-multi-tenant/03-06-*` | 대응 항목으로 충족; `#56`은 문서 wiring |
+| Chapter 12 production integration epic `#57` 및 분리 모듈 `12-production-integration/01-10-*` | 닫힌 R2DBC 이슈 `#43`-`#49`; 통합 모듈 `12-production-integration/01-spring-production-integration`, `02-ktor-production-integration` | 대응 항목으로 충족 |
+| R2DBC connection-factory-per-tenant | 닫힌 R2DBC 이슈 `#39`; JDBC는 database-per-tenant `#53` 및 schema-per-tenant `#52` 사용 | 플랫폼 특화, 중복 이슈 없음 |
+| JDBC DAO/entities, transaction template, Spring cache, benchmark | `03-exposed-basic`, `05-exposed-dml`, `09-spring`, `11-high-performance`의 blocking/JDBC 전용 모듈 | 플랫폼 특화, 중복 이슈 없음 |
+
+2026-05-24 기준 남은 차이는 플랫폼 특화 항목이므로 새 후속 이슈는 만들지 않습니다.
+
+---
+
 ## 시작하기
 
 ### 사전 요구사항

--- a/README.md
+++ b/README.md
@@ -383,6 +383,26 @@ Implement the Ktor pair with explicit `/readyz`, sanitized `X-Request-ID`, struc
 
 ---
 
+## Example parity with exposed-r2dbc-workshop
+
+Issue [#99](https://github.com/bluetape4k/exposed-workshop/issues/99) tracks concept-level parity with
+[`exposed-r2dbc-workshop`](https://github.com/bluetape4k/exposed-r2dbc-workshop), not exact module-name parity. JDBC/blocking
+and R2DBC examples keep distinct architecture choices when the database API model differs. The R2DBC-side counterpart is
+[exposed-r2dbc-workshop#89](https://github.com/bluetape4k/exposed-r2dbc-workshop/issues/89) (closed; mirrors this decision).
+
+| Topic in `exposed-workshop` | R2DBC counterpart | Decision |
+|-----------------------------|-------------------|----------|
+| Ktor examples epic `#45` and multi-tenant `#46` | Closed R2DBC issues `#32`, `#33`; module `10-multi-tenant/07-multitenant-ktor` | Covered by counterpart |
+| Ktor cache/routing implementation issues `#47`, `#48`, `#49` plus wiring `#50`; JDBC modules `11-high-performance/05-07-*` | Closed R2DBC issues `#34`, `#35`, `#36`, `#69`; R2DBC modules `11-high-performance/04-06-*` | Covered by counterpart; `#50` is docs wiring |
+| Spring Boot tenant strategy epic `#51`, implementations `#52`-`#55`, plus wiring `#56`; JDBC modules `10-multi-tenant/04-06-*`, `08-tenant-onboarding-spring-web` | Closed R2DBC issues `#37`-`#42`; R2DBC modules `10-multi-tenant/03-06-*` | Covered by counterpart; `#56` is docs wiring |
+| Chapter 12 production integration epic `#57` and split modules `12-production-integration/01-10-*` | Closed R2DBC issues `#43`-`#49`; consolidated modules `12-production-integration/01-spring-production-integration`, `02-ktor-production-integration` | Covered by counterpart |
+| R2DBC connection-factory-per-tenant | Closed R2DBC issue `#39`; JDBC uses database-per-tenant `#53` and schema-per-tenant `#52` | Platform-specific, no duplicate issue |
+| JDBC DAO/entities, transaction template, Spring cache, benchmark | Blocking/JDBC-only modules in `03-exposed-basic`, `05-exposed-dml`, `09-spring`, and `11-high-performance` | Platform-specific, no duplicate issue |
+
+No new follow-up issues are needed as of 2026-05-24 because the remaining differences are platform-specific.
+
+---
+
 ## Getting Started
 
 ### Prerequisites

--- a/docs/lessons/2026-05-24-issue-99-r2dbc-parity-audit.md
+++ b/docs/lessons/2026-05-24-issue-99-r2dbc-parity-audit.md
@@ -1,0 +1,28 @@
+# Issue 99 R2DBC Parity Audit
+
+## Context
+
+`exposed-workshop` needed a final roadmap parity pass against `exposed-r2dbc-workshop` after the Ktor, chapter 10, and
+chapter 12 example issues were completed.
+
+## Decision
+
+Track parity by concept, not by exact module name. Blocking JDBC modules and R2DBC modules keep separate architecture
+choices when the underlying Exposed API model differs.
+
+## Outcome
+
+The audit found no portable gaps. `README.md`, `README.ko.md`, and the research note now record which issues and modules
+cover each overlapping topic, and mark R2DBC connection-factory routing plus JDBC DAO/transaction-template/cache/benchmark
+topics as platform-specific.
+
+## Verification
+
+- Confirmed `exposed-workshop` has only issue `#99` open.
+- Confirmed `exposed-r2dbc-workshop` has no open issues.
+- Checked closed roadmap issue sets: `exposed-workshop#45`-`#63`, `exposed-r2dbc-workshop#32`-`#49`, `#69`, and `#89`.
+
+## Next time
+
+When adding future example roadmap issues, first check the parity table and create counterpart issues only for portable
+teaching concepts.

--- a/docs/superpowers/research/2026-05-24-issue-99-r2dbc-parity-audit-research.md
+++ b/docs/superpowers/research/2026-05-24-issue-99-r2dbc-parity-audit-research.md
@@ -1,0 +1,38 @@
+# Issue 99 R2DBC Parity Audit
+
+## Context
+
+Issue [#99](https://github.com/bluetape4k/exposed-workshop/issues/99) asks for a concept-level parity audit between
+`exposed-workshop` and `exposed-r2dbc-workshop`. The target is not exact module-name parity. It is to decide whether
+each roadmap topic is covered by the counterpart repo, intentionally platform-specific, or a real gap that needs a
+follow-up issue.
+
+The R2DBC-side counterpart is [exposed-r2dbc-workshop#89](https://github.com/bluetape4k/exposed-r2dbc-workshop/issues/89)
+(closed; mirrors this decision).
+
+## Current issue state on 2026-05-24
+
+| Repository | Open example roadmap issues | Relevant closed roadmap issues |
+|------------|-----------------------------|--------------------------------|
+| `exposed-workshop` | `#99` only | `#45`-`#63` |
+| `exposed-r2dbc-workshop` | None | `#32`-`#49`, `#69`, `#89` |
+
+## Parity decisions
+
+| `exposed-workshop` topic | R2DBC counterpart | Decision |
+|--------------------------|-------------------|----------|
+| Ktor examples epic `#45` and multi-tenant `#46` | R2DBC `#32`, `#33`; `10-multi-tenant/07-multitenant-ktor` | Covered by counterpart |
+| Ktor cache/routing implementation issues `#47`, `#48`, `#49` plus wiring `#50`; JDBC modules `11-high-performance/05-07-*` | R2DBC `#34`, `#35`, `#36`, `#69`; R2DBC modules `11-high-performance/04-06-*` | Covered by counterpart; `#50` is docs wiring |
+| Spring Boot tenant strategy epic `#51`, implementations `#52`-`#55`, plus wiring `#56`; JDBC modules `10-multi-tenant/04-06-*`, `08-tenant-onboarding-spring-web` | R2DBC `#37`-`#42`; R2DBC modules `10-multi-tenant/03-06-*` | Covered by counterpart; `#56` is docs wiring |
+| Chapter 12 production integration epic `#57` and split modules `12-production-integration/01-10-*` | R2DBC `#43`-`#49`; consolidated `12-production-integration/01-spring-production-integration`, `02-ktor-production-integration` | Covered by counterpart |
+| R2DBC connection-factory-per-tenant | R2DBC `#39`; JDBC has database-per-tenant `#53` and schema-per-tenant `#52` instead | Platform-specific, no duplicate |
+| JDBC DAO/entities examples | R2DBC has SQL DSL-only basic examples | Platform-specific; DAO is not a R2DBC teaching target |
+| JDBC transaction template, Spring cache, benchmark | R2DBC uses suspend transactions, suspended cache, and routing examples | Platform-specific, no duplicate |
+
+## Outcome
+
+No new follow-up issues are required. All overlapping roadmap items are closed in both repositories, and the remaining
+differences are caused by the blocking JDBC versus R2DBC API models.
+
+The public parity table is mirrored in `README.md` and `README.ko.md` so future roadmap triage can link to a stable
+document instead of reopening duplicate implementation issues.


### PR DESCRIPTION
## Summary

- Add a public parity table to README.md and README.ko.md for issue #99.
- Record the detailed audit in docs/superpowers/research.
- Add the required lesson entry for future roadmap triage.

## Decisions

- All overlapping roadmap items are already covered by closed issues in both repositories.
- No follow-up issues are needed because the remaining differences are platform-specific JDBC/R2DBC teaching choices.
- R2DBC counterpart tracking issue: bluetape4k/exposed-r2dbc-workshop#89.

Fixes #99

## Verification

- git diff --cached --check
- GitHub issue state reviewed: exposed-workshop has only #99 open; exposed-r2dbc-workshop has no open issues.
- Closed roadmap issue sets reviewed: exposed-workshop #45-#63; exposed-r2dbc-workshop #32-#49, #69, #89.
- Not run: Gradle tests, documentation-only change.
