### PR TITLE
Adopt Exposed Gradle plugin in examples

### DIFF
--- a/01-spring-boot/spring-mvc-exposed/build.gradle.kts
+++ b/01-spring-boot/spring-mvc-exposed/build.gradle.kts
@@ -1,8 +1,18 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
     alias(libs.plugins.gatling)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.workshop.springmvc.domain"
+        databaseUrl = "jdbc:h2:mem:01-spring-boot-spring-mvc-exposed-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 

--- a/01-spring-boot/spring-webflux-exposed/build.gradle.kts
+++ b/01-spring-boot/spring-webflux-exposed/build.gradle.kts
@@ -1,8 +1,18 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
     alias(libs.plugins.gatling)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.workshop.springwebflux"
+        databaseUrl = "jdbc:h2:mem:01-spring-boot-spring-webflux-exposed-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/09-spring/02-transactiontemplate/build.gradle.kts
+++ b/09-spring/02-transactiontemplate/build.gradle.kts
@@ -1,7 +1,17 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.transaction.domain"
+        databaseUrl = "jdbc:h2:mem:09-spring-02-transactiontemplate-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 @Suppress("UnstableApiUsage")

--- a/09-spring/03-spring-transaction/build.gradle.kts
+++ b/09-spring/03-spring-transaction/build.gradle.kts
@@ -1,7 +1,17 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.spring.transaction"
+        databaseUrl = "jdbc:h2:mem:09-spring-03-spring-transaction-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 @Suppress("UnstableApiUsage")

--- a/09-spring/04-exposed-repository/build.gradle.kts
+++ b/09-spring/04-exposed-repository/build.gradle.kts
@@ -1,7 +1,17 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.springmvc"
+        databaseUrl = "jdbc:h2:mem:09-spring-04-exposed-repository-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/09-spring/05-exposed-repository-coroutines/build.gradle.kts
+++ b/09-spring/05-exposed-repository-coroutines/build.gradle.kts
@@ -1,7 +1,17 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.springwebflux"
+        databaseUrl = "jdbc:h2:mem:09-spring-05-exposed-repository-coroutines-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/09-spring/06-spring-cache/build.gradle.kts
+++ b/09-spring/06-spring-cache/build.gradle.kts
@@ -1,7 +1,17 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.springcache.domain"
+        databaseUrl = "jdbc:h2:mem:09-spring-06-spring-cache-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/09-spring/07-spring-suspended-cache/build.gradle.kts
+++ b/09-spring/07-spring-suspended-cache/build.gradle.kts
@@ -1,7 +1,17 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.suspendedcache.domain"
+        databaseUrl = "jdbc:h2:mem:09-spring-07-spring-suspended-cache-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/10-multi-tenant/01-multitenant-spring-web/build.gradle.kts
+++ b/10-multi-tenant/01-multitenant-spring-web/build.gradle.kts
@@ -1,7 +1,17 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.multitenant.springweb"
+        databaseUrl = "jdbc:h2:mem:10-multi-tenant-01-multitenant-spring-web-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/10-multi-tenant/02-multitenant-spring-web-virtualthread/build.gradle.kts
+++ b/10-multi-tenant/02-multitenant-spring-web-virtualthread/build.gradle.kts
@@ -1,7 +1,17 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.multitenant.springweb"
+        databaseUrl = "jdbc:h2:mem:10-multi-tenant-02-multitenant-spring-web-virtualthread-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/10-multi-tenant/03-multitenant-spring-webflux/build.gradle.kts
+++ b/10-multi-tenant/03-multitenant-spring-webflux/build.gradle.kts
@@ -1,7 +1,17 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.multitenant.webflux"
+        databaseUrl = "jdbc:h2:mem:10-multi-tenant-03-multitenant-spring-webflux-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/10-multi-tenant/04-schema-per-tenant-spring-web/build.gradle.kts
+++ b/10-multi-tenant/04-schema-per-tenant-spring-web/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.multitenant.schema.domain"
+        databaseUrl = "jdbc:h2:mem:10-multi-tenant-04-schema-per-tenant-spring-web-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/10-multi-tenant/05-database-per-tenant-spring-web/build.gradle.kts
+++ b/10-multi-tenant/05-database-per-tenant-spring-web/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.multitenant.database.domain"
+        databaseUrl = "jdbc:h2:mem:10-multi-tenant-05-database-per-tenant-spring-web-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/build.gradle.kts
+++ b/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.multitenant.security.domain"
+        databaseUrl = "jdbc:h2:mem:10-multi-tenant-06-spring-security-tenant-authorization-spring-web-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/10-multi-tenant/07-multitenant-ktor/build.gradle.kts
+++ b/10-multi-tenant/07-multitenant-ktor/build.gradle.kts
@@ -1,5 +1,15 @@
 plugins {
+    alias(libs.plugins.exposed)
     alias(libs.plugins.kotlin.serialization)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.multitenant.ktor.persistence"
+        databaseUrl = "jdbc:h2:mem:10-multi-tenant-07-multitenant-ktor-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 dependencies {

--- a/10-multi-tenant/08-tenant-onboarding-spring-web/build.gradle.kts
+++ b/10-multi-tenant/08-tenant-onboarding-spring-web/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.multitenant.onboarding"
+        databaseUrl = "jdbc:h2:mem:10-multi-tenant-08-tenant-onboarding-spring-web-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 dependencies {

--- a/11-high-performance/01-cache-strategies/build.gradle.kts
+++ b/11-high-performance/01-cache-strategies/build.gradle.kts
@@ -1,7 +1,17 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.cache.domain"
+        databaseUrl = "jdbc:h2:mem:11-high-performance-01-cache-strategies-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 

--- a/11-high-performance/02-cache-strategies-coroutines/build.gradle.kts
+++ b/11-high-performance/02-cache-strategies-coroutines/build.gradle.kts
@@ -1,7 +1,17 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.cache.coroutines.domain"
+        databaseUrl = "jdbc:h2:mem:11-high-performance-02-cache-strategies-coroutines-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/11-high-performance/03-routing-datasource/build.gradle.kts
+++ b/11-high-performance/03-routing-datasource/build.gradle.kts
@@ -1,7 +1,17 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.graalvm.native)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.routing.domain"
+        databaseUrl = "jdbc:h2:mem:11-high-performance-03-routing-datasource-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/11-high-performance/04-benchmark/build.gradle.kts
+++ b/11-high-performance/04-benchmark/build.gradle.kts
@@ -2,8 +2,18 @@ import groovy.json.JsonSlurper
 import java.time.Instant
 
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.allopen")
     alias(libs.plugins.kotlinx.benchmark)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.benchmark"
+        databaseUrl = "jdbc:h2:mem:11-high-performance-04-benchmark-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 dependencies {

--- a/11-high-performance/05-cache-strategies-ktor/build.gradle.kts
+++ b/11-high-performance/05-cache-strategies-ktor/build.gradle.kts
@@ -1,5 +1,15 @@
 plugins {
+    alias(libs.plugins.exposed)
     alias(libs.plugins.kotlin.serialization)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.ktor.cache.persistence"
+        databaseUrl = "jdbc:h2:mem:11-high-performance-05-cache-strategies-ktor-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 dependencies {

--- a/11-high-performance/06-cache-strategies-coroutines-ktor/build.gradle.kts
+++ b/11-high-performance/06-cache-strategies-coroutines-ktor/build.gradle.kts
@@ -1,5 +1,15 @@
 plugins {
+    alias(libs.plugins.exposed)
     alias(libs.plugins.kotlin.serialization)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.ktor.cache.coroutines.persistence"
+        databaseUrl = "jdbc:h2:mem:11-high-performance-06-cache-strategies-coroutines-ktor-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 dependencies {

--- a/11-high-performance/07-routing-datasource-ktor/build.gradle.kts
+++ b/11-high-performance/07-routing-datasource-ktor/build.gradle.kts
@@ -1,5 +1,15 @@
 plugins {
+    alias(libs.plugins.exposed)
     alias(libs.plugins.kotlin.serialization)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.ktor.routingdatasource.persistence"
+        databaseUrl = "jdbc:h2:mem:11-high-performance-07-routing-datasource-ktor-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 dependencies {

--- a/12-production-integration/01-ktor-application-architecture/build.gradle.kts
+++ b/12-production-integration/01-ktor-application-architecture/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     application
     alias(libs.plugins.kotlin.serialization)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.ktor.architecture.repository"
+        databaseUrl = "jdbc:h2:mem:12-production-integration-01-ktor-application-architecture-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 application {

--- a/12-production-integration/02-spring-application-architecture/build.gradle.kts
+++ b/12-production-integration/02-spring-application-architecture/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.spring.architecture.repository"
+        databaseUrl = "jdbc:h2:mem:12-production-integration-02-spring-application-architecture-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/12-production-integration/03-spring-http-outbox-idempotency/build.gradle.kts
+++ b/12-production-integration/03-spring-http-outbox-idempotency/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.spring.httpoutbox.repository"
+        databaseUrl = "jdbc:h2:mem:12-production-integration-03-spring-http-outbox-idempotency-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/12-production-integration/04-ktor-http-outbox-idempotency/build.gradle.kts
+++ b/12-production-integration/04-ktor-http-outbox-idempotency/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     application
     alias(libs.plugins.kotlin.serialization)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.ktor.httpoutbox.repository"
+        databaseUrl = "jdbc:h2:mem:12-production-integration-04-ktor-http-outbox-idempotency-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 application {

--- a/12-production-integration/05-spring-auth-session/build.gradle.kts
+++ b/12-production-integration/05-spring-auth-session/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.spring.auth.repository"
+        databaseUrl = "jdbc:h2:mem:12-production-integration-05-spring-auth-session-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/12-production-integration/06-ktor-auth-session/build.gradle.kts
+++ b/12-production-integration/06-ktor-auth-session/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     application
     alias(libs.plugins.kotlin.serialization)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.ktor.auth.repository"
+        databaseUrl = "jdbc:h2:mem:12-production-integration-06-ktor-auth-session-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 application {

--- a/12-production-integration/07-spring-outbox-realtime/build.gradle.kts
+++ b/12-production-integration/07-spring-outbox-realtime/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.spring.realtime.repository"
+        databaseUrl = "jdbc:h2:mem:12-production-integration-07-spring-outbox-realtime-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/12-production-integration/08-ktor-outbox-realtime/build.gradle.kts
+++ b/12-production-integration/08-ktor-outbox-realtime/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     application
     alias(libs.plugins.kotlin.serialization)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.ktor.realtime.repository"
+        databaseUrl = "jdbc:h2:mem:12-production-integration-08-ktor-outbox-realtime-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 application {

--- a/12-production-integration/09-spring-observability-readiness/build.gradle.kts
+++ b/12-production-integration/09-spring-observability-readiness/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.spring.observability.repository"
+        databaseUrl = "jdbc:h2:mem:12-production-integration-09-spring-observability-readiness-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 springBoot {

--- a/12-production-integration/10-ktor-observability-readiness/build.gradle.kts
+++ b/12-production-integration/10-ktor-observability-readiness/build.gradle.kts
@@ -1,6 +1,16 @@
 plugins {
+    alias(libs.plugins.exposed)
     application
     alias(libs.plugins.kotlin.serialization)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "exposed.examples.ktor.observability.repository"
+        databaseUrl = "jdbc:h2:mem:12-production-integration-10-ktor-observability-readiness-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 application {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
     alias(libs.plugins.test.logger)
     alias(libs.plugins.kotlinx.benchmark) apply false
     alias(libs.plugins.graalvm.native) apply false
+    alias(libs.plugins.exposed) apply false
 }
 
 val rootLibs = libs

--- a/docs/lessons/2026-05-26-exposed-gradle-plugin.md
+++ b/docs/lessons/2026-05-26-exposed-gradle-plugin.md
@@ -1,0 +1,19 @@
+## Context
+
+Adopted the JetBrains Exposed Gradle plugin across Exposed workshop modules that define tables in main sources.
+
+## Decision
+
+The workshop uses a repo-local plugin alias tied to the existing Exposed version alias, not the managed `bt4k` catalog.
+
+## Outcome
+
+Spring, multi-tenant, performance, Ktor, and production-integration examples now expose `generateMigrations` with explicit migration settings.
+
+## Verification
+
+Ran `git diff --check`, `./gradlew -q help`, and `:spring-mvc-exposed:tasks --all`.
+
+## Future Guard
+
+Keep shared test fixtures out of the migration plugin rollout unless a concrete migration output is needed for those fixtures.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -107,6 +107,7 @@ test-logger = { id = "com.adarshr.test-logger", version.ref = "test-logger" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 graalvm-native = { id = "org.graalvm.buildtools.native", version.ref = "graalvm-native" }
 gatling = { id = "io.gatling.gradle", version = "3.15.0" }
+exposed = { id = "org.jetbrains.exposed.plugin", version.ref = "exposed" }
 
 [libraries]
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.1.0" }


### PR DESCRIPTION
## Summary
- Applies the JetBrains Exposed Gradle plugin to modules that define Exposed tables.
- Adds migration task configuration with explicit table package and H2 migration database settings where main table definitions exist.
- Keeps the workshop independent from the managed catalog and uses the repo-local Exposed plugin alias.
- Adds a short lesson under docs/lessons for future catalog/plugin governance.

## Validation
- git diff --check; ./gradlew -q help; :spring-mvc-exposed:tasks --all

Closes #114
