### PR TITLE
chore: ignore CodeGraph local indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ local.properties
 Thumbs.db
 /.profileconfig.json
 .worktrees/
+
+.codegraph/


### PR DESCRIPTION
## Summary
- Ignore generated `.codegraph/` local index directories.
- Keep CodeGraph SQLite state out of repository history.

## Validation
- `codegraph init -i` completed for the local checkout.
- `git check-ignore` verifies `.codegraph/` is ignored after the change.

## Notes
- No production, documentation, or build behavior changes.
