### PR TITLE
build: sync dependencies 1.1.4 catalog

### DIFF
--- a/docs/lessons/2026-06-01-dependencies-1-1-4-sync.md
+++ b/docs/lessons/2026-06-01-dependencies-1-1-4-sync.md
@@ -1,0 +1,23 @@
+# Dependencies 1.1.4 Sync
+
+## Context
+
+`bluetape4k-dependencies` 1.2.0 release preparation requires downstream
+workshops to match the central shared-version source of truth before the BOM
+release CI can pass.
+
+## Decision
+
+Align the workshop catalog to the latest published
+`bluetape4k-dependencies:1.1.4` baseline and central shared runtime versions.
+Do not consume `1.2.0` until it is published.
+
+## Outcome
+
+The workshop no longer reports shared-version drift in the central release
+preflight.
+
+## Verification
+
+Validated from `bluetape4k-dependencies` with `sync-shared-versions.py
+--workspace /Users/debop/work/bluetape4k --write --check --summary`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k-dependencies = "1.1.3"
+bluetape4k-dependencies = "1.1.4"
 
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.11.0"
@@ -69,12 +69,12 @@ mybatis-dynamic-sql = "2.0.0"
 
 snappy-java = "1.1.10.8"
 lz4-java = "1.8.0"
-zstd-jni = "1.5.7-8"
+zstd-jni = "1.5.7-9"
 
 findbugs = "3.0.2"
 guava = "33.6.0-jre"
 kryo = "5.6.2"
-fory-kotlin = "0.17.0"
+fory-kotlin = "1.0.0"
 
 javassist = "3.30.2-GA"
 javamoney-moneta = "1.4.5"


### PR DESCRIPTION
## Summary
- align this workshop with `bluetape4k-dependencies:1.1.4`
- sync centrally governed shared versions
- record the release-train sync rationale in `docs/lessons`

## Verification
- `sync-shared-versions.py --workspace /Users/debop/work/bluetape4k --check --summary`
- `git diff --check`
