### PR TITLE
build: align dependencies catalog with 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Changed
 
+- **Dependency governance**: `bluetape4k-dependencies` aligned to the published
+  `1.2.0` BOM.
 - **Bluetape4k**: `1.6.2` → `1.7.0`
 - **Kotlin**: `2.3.20` → `2.3.21`
 - **MariaDB JDBC 드라이버**: `mariadb-java-client` `3.5.7` → `3.5.8`, `r2dbc-mariadb` `1.3.0` → `1.4.0`

--- a/docs/lessons/2026-06-01-dependencies-1-2-0-sync.md
+++ b/docs/lessons/2026-06-01-dependencies-1-2-0-sync.md
@@ -1,0 +1,23 @@
+# Dependencies 1.2.0 Sync
+
+## Context
+
+`bluetape4k-dependencies:1.2.0` was published after the final upstream BOM
+matrix became Maven Central-visible.
+
+## Decision
+
+Move the Exposed workshop shared catalog from `1.1.4` to `1.2.0`.
+
+## Outcome
+
+Workshop examples now consume the published 1.2.0 dependency-governance
+baseline.
+
+## Verification
+
+- `sync-shared-versions.py --workspace .. --write --check --summary` updated
+  the catalog line.
+- Maven Central returned HTTP 200 for
+  `io.github.bluetape4k:bluetape4k-dependencies:1.2.0`.
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k-dependencies = "1.1.4"
+bluetape4k-dependencies = "1.2.0"
 
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.11.0"


### PR DESCRIPTION
## Summary

- align the shared bluetape4k-dependencies catalog line with 1.2.0
- record the downstream sync in CHANGELOG and lessons

## Verification

- ./gradlew help --no-daemon --console=plain
- git diff --check
- Maven Central HTTP 200 for bluetape4k-dependencies 1.2.0
