### PR TITLE
build: consume catalog 2026-06-02-00

### DIFF
--- a/docs/lessons/2026-06-02-catalog-2026-06-02-00-sync.md
+++ b/docs/lessons/2026-06-02-catalog-2026-06-02-00-sync.md
@@ -1,0 +1,25 @@
+# Catalog 2026-06-02-00 Sync
+
+## Context
+
+`bluetape4k-dependencies` cut `catalog/2026-06-02-00` after the issue #101
+security dependency train.
+
+## Decision
+
+Sync shared version aliases from the central catalog for the workshop catalog.
+
+## Outcome
+
+Netty, Jackson, and Jackson 3 now match the source-of-truth dependency catalog.
+
+## Verification
+
+- `scripts/sync-shared-versions.py --workspace /Users/debop/work/bluetape4k --check --summary`
+- `scripts/sync-dependabot-ignores.py --workspace /Users/debop/work/bluetape4k --check --summary`
+- `git diff --check`
+
+## Future Guidance
+
+Workshop repositories should consume shared dependency changes through the
+central sync scripts instead of carrying local version drift.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,11 +43,11 @@ hibernate-reactive = "4.3.3.Final"
 hibernate-validator = "9.1.0.Final"
 
 micrometer = "1.16.1"
-netty = "4.2.13.Final"
+netty = "4.2.15.Final"
 
-jackson = "2.21.3"
+jackson = "2.21.4"
 jackson-annotations = "2.21"
-jackson3 = "3.1.3"
+jackson3 = "3.1.4"
 
 caffeine = "3.2.3"
 


### PR DESCRIPTION
## Summary

Consume the shared dependency versions from the `catalog/2026-06-02-00` dependency train.

- Updates Netty, Jackson, and Jackson 3 shared aliases.
- Adds a short lesson for future central catalog syncs.

## Verification

- `git diff --check`
- `scripts/sync-shared-versions.py --workspace /Users/debop/work/bluetape4k --check --summary`
- `scripts/sync-dependabot-ignores.py --workspace /Users/debop/work/bluetape4k --check --summary`

## Notes

Full repository CI is expected to validate Gradle resolution after the PR opens.