### PR TITLE
docs: refresh WIP snapshot

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -1,8 +1,8 @@
 # WIP - exposed-workshop
 
-Snapshot: 2026-05-18 KST
+Snapshot: 2026-06-02 KST
 Scope: open GitHub issues assigned to `debop`, created on or after 2026-01-01.
-Open count: 20 issues.
+Open count: 1 issue.
 
 ## Recently Completed
 


### PR DESCRIPTION
## Summary

Refresh `WIP.md` from the current GitHub assigned-open issue state for the 2026-06-02 KST snapshot.

- Updates the snapshot date.
- Aligns the assigned open issue count with GitHub.
- Keeps the repository work queue usable after recent release-train and catalog-sync merges.

## Verification

- `git diff --check -- WIP.md`
- Live `gh issue list --state open --assignee debop` count check

## Notes

Documentation-only WIP refresh; no production code changed.