### PR TITLE
Apply Kotlin 2.4 catalog train

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 [versions]
 bluetape4k-dependencies = "1.2.0"
 
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 kotlinx-coroutines = "1.11.0"
 kotlinx-serialization = "1.11.0"
 kotlinx-atomicfu = "0.32.1"


### PR DESCRIPTION
## Summary
- Apply shared dependencies catalog tag `catalog/2026-06-09-01`.
- Move Kotlin catalog entries to `2.4.0` through the synced version catalog.
- Keep downstream builds pinned to an immutable catalog train.

## Notes
- Kotlin language/API levels remain controlled by each repo build configuration; this change advances catalog dependency/plugin versions only.
- detekt 2.0.0-alpha.3 is validated with Kotlin 2.3.21, so graph keeps the detekt runtime Kotlin classpath isolated from the project Kotlin BOM.

## Validation
- ./gradlew --no-daemon build -x test --parallel --no-configuration-cache: BUILD SUCCESSFUL in 3m 4s

## DoD Status
- [x] Catalog ref points to `catalog/2026-06-09-01` where this repo consumes raw catalog refs.
- [x] Kotlin catalog value is `2.4.0`.
- [x] Local build validation completed as listed above.
- [ ] Merge after GitHub checks are green.