### PR TITLE
docs: align WIP references with GNO

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -10,7 +10,7 @@ Open count: 1 issue.
   compatibility guards, and Redisson baseline alignment are merged.
 - Test cleanup and Kluent to `bluetape4k-assertions` migration are merged.
 - README hero/architecture refresh is merged.
-- QMD-backed audit registered `#70` for routing datasource pool lifecycle.
+- GNO-backed audit registered `#70` for routing datasource pool lifecycle.
 
 ## Current Direction
 

--- a/docs/lessons/2026-05-18-wip-audit-routing-datasource-lifecycle.md
+++ b/docs/lessons/2026-05-18-wip-audit-routing-datasource-lifecycle.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-The 2026-05-18 qmd-backed exposed-workshop audit compared prior README/WIP
+The 2026-05-18 GNO-backed exposed-workshop audit compared prior README/WIP
 refresh lessons, live GitHub issue state, and current source markers.
 
 ## Decision or Finding
@@ -20,7 +20,7 @@ Registered GitHub issue #70 and refreshed `WIP.md` from 0 assigned issues to
 
 ## Verification
 
-- `qmd query ... --no-rerank -c bluetape4k-docs` surfaced the prior
+- `gno query ... --no-rerank -c bluetape4k-docs` surfaced the prior
   exposed-workshop WIP refresh lesson.
 - `gh issue list --assignee debop` confirmed 20 live assigned open issues after
   registering #70.

--- a/docs/superpowers/plans/2026-05-22-issue-61-http-outbox-idempotency-plan.md
+++ b/docs/superpowers/plans/2026-05-22-issue-61-http-outbox-idempotency-plan.md
@@ -2,8 +2,8 @@
 
 ## Retrieval
 
-- qmd similar work lookup: complete.
-- qmd caution lookup: complete.
+- GNO similar work lookup: complete.
+- GNO caution lookup: complete.
 - Current issue body: verified from GitHub issue #61.
 - `$bluetape4k-patterns`: applied to all Kotlin tasks.
 

--- a/docs/superpowers/specs/2026-05-22-issue-61-http-outbox-idempotency-design.md
+++ b/docs/superpowers/specs/2026-05-22-issue-61-http-outbox-idempotency-design.md
@@ -7,9 +7,9 @@ for Spring Boot 4 and Ktor services backed by Exposed JDBC.
 
 Prior retrieval:
 
-- `qmd query "HTTP client outbox idempotency external API persisted outbound requests retry duplicate permanent failure examples" -c bluetape4k-docs --no-rerank`
-- `qmd query "Spring Boot Ktor Exposed outbox idempotency retry transaction cancellation testcontainers cautions" -c bluetape4k-docs --no-rerank`
-- `qmd query "outbox idempotency external API retry duplicate key permanent failure Kotlin Exposed" -c wiki --no-rerank`
+- `gno query "HTTP client outbox idempotency external API persisted outbound requests retry duplicate permanent failure examples" -c bluetape4k-docs --no-rerank`
+- `gno query "Spring Boot Ktor Exposed outbox idempotency retry transaction cancellation testcontainers cautions" -c bluetape4k-docs --no-rerank`
+- `gno query "outbox idempotency external API retry duplicate key permanent failure Kotlin Exposed" -c wiki --no-rerank`
 
 Relevant cautions:
 


### PR DESCRIPTION
## Summary
- Rename stale qmd retrieval references to GNO in WIP and durable planning notes.
- Keep issue #61 and #70 documentation aligned with the current retrieval workflow.

## Verification
- `git diff --check`
- `rg -n "qmd|QMD" WIP.md docs/lessons/2026-05-18-wip-audit-routing-datasource-lifecycle.md docs/superpowers/plans/2026-05-22-issue-61-http-outbox-idempotency-plan.md docs/superpowers/specs/2026-05-22-issue-61-http-outbox-idempotency-design.md || true`
- `gno query "exposed-workshop qmd gno docs WIP audit" -c bluetape4k-docs --fast --no-rerank`
- `gno query "exposed-workshop qmd gno docs WIP audit PR" -c bluetape4k-github --fast --no-rerank`

## Notes
- Documentation-only change; Gradle build was not run.
