### PR TITLE
docs: restore database server icon rim

### DIFF
--- a/docs/images/readme-icons/database-server.svg
+++ b/docs/images/readme-icons/database-server.svg
@@ -4,6 +4,7 @@
   <rect x="10" y="8" width="108" height="112" rx="18" fill="#fffaf2" stroke="#28485a" stroke-width="6"/>
   <ellipse cx="64" cy="36" rx="34" ry="13" fill="#fff0d8" stroke="#8c6f33" stroke-width="6"/>
   <path d="M30 36v44c0 8 15 14 34 14s34-6 34-14V36" fill="#fff0d8" stroke="#8c6f33" stroke-width="6" stroke-linejoin="round"/>
+  <ellipse cx="64" cy="36" rx="34" ry="13" fill="none" stroke="#8c6f33" stroke-width="5"/>
   <path d="M30 58c0 8 15 14 34 14s34-6 34-14" fill="none" stroke="#8c6f33" stroke-width="5" stroke-linecap="round"/>
   <path d="M30 80c0 8 15 14 34 14s34-6 34-14" fill="none" stroke="#8c6f33" stroke-width="5" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
## Summary

- Restores the visible top rim outline on the README database-server SVG icon.
- Keeps the change isolated to the single README icon asset.

## Validation

- `git diff --check -- docs/images/readme-icons/database-server.svg`
- `xmllint --noout docs/images/readme-icons/database-server.svg`
- `rsvg-convert -w 256 -h 256 docs/images/readme-icons/database-server.svg -o /tmp/exposed-workshop-icon-check/database-server-postcommit.png`
- GitHub PR checks: `Analyze (actions)` pass, `CodeQL` pass.

## DoD Status

- [x] Scope verified as `docs/images/readme-icons/database-server.svg` only.
- [x] SVG parses as valid XML.
- [x] SVG renders to a non-empty 256x256 PNG.
- [x] GitHub checks completed after PR creation.
