### PR TITLE
build: consume bluetape4k dependencies 1.3.1

### DIFF
--- a/06-advanced/12-exposed-tink/src/test/kotlin/exposed/examples/tink/TinkColumnTypeTest.kt
+++ b/06-advanced/12-exposed-tink/src/test/kotlin/exposed/examples/tink/TinkColumnTypeTest.kt
@@ -154,12 +154,12 @@ class TinkColumnTypeTest: AbstractExposedTest() {
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `nullable 암호화 컬럼은 null 값을 저장하고 조회할 수 있다`(testDB: TestDB) {
         val nullableTable = object: IntIdTable("tink_nullable_table") {
-            val aeadSecret = tinkAeadVarChar("aead_secret", 512).nullable()
-            val daeadSecret = tinkDaeadVarChar("daead_secret", 512).nullable()
-            val aeadData = tinkAeadBinary("aead_data", 512).nullable()
-            val daeadData = tinkDaeadBinary("daead_data", 512).nullable()
-            val aeadBlob = tinkAeadBlob("aead_blob").nullable()
-            val daeadBlob = tinkDaeadBlob("daead_blob").nullable()
+            val aeadSecret = tinkAeadVarChar("aead_secret", 512, TinkAeads.AES256_GCM).nullable()
+            val daeadSecret = tinkDaeadVarChar("daead_secret", 512, TinkDaeads.AES256_SIV).nullable()
+            val aeadData = tinkAeadBinary("aead_data", 512, TinkAeads.AES256_GCM).nullable()
+            val daeadData = tinkDaeadBinary("daead_data", 512, TinkDaeads.AES256_SIV).nullable()
+            val aeadBlob = tinkAeadBlob("aead_blob", TinkAeads.AES256_GCM).nullable()
+            val daeadBlob = tinkDaeadBlob("daead_blob", TinkDaeads.AES256_SIV).nullable()
         }
 
         withTables(testDB, nullableTable) {
@@ -187,25 +187,25 @@ class TinkColumnTypeTest: AbstractExposedTest() {
     fun `컬럼 길이는 0보다 커야 한다`(testDB: TestDB) {
         assertFailsWith<IllegalArgumentException> {
             object: IntIdTable("invalid_aead_varchar_$testDB") {
-                val invalid = tinkAeadVarChar("invalid", 0)
+                val invalid = tinkAeadVarChar("invalid", 0, TinkAeads.AES256_GCM)
             }
         }
 
         assertFailsWith<IllegalArgumentException> {
             object: IntIdTable("invalid_aead_binary_$testDB") {
-                val invalid = tinkAeadBinary("invalid", 0)
+                val invalid = tinkAeadBinary("invalid", 0, TinkAeads.AES256_GCM)
             }
         }
 
         assertFailsWith<IllegalArgumentException> {
             object: IntIdTable("invalid_daead_varchar_$testDB") {
-                val invalid = tinkDaeadVarChar("invalid", 0)
+                val invalid = tinkDaeadVarChar("invalid", 0, TinkDaeads.AES256_SIV)
             }
         }
 
         assertFailsWith<IllegalArgumentException> {
             object: IntIdTable("invalid_daead_binary_$testDB") {
-                val invalid = tinkDaeadBinary("invalid", 0)
+                val invalid = tinkDaeadBinary("invalid", 0, TinkDaeads.AES256_SIV)
             }
         }
     }

--- a/11-high-performance/01-cache-strategies/src/main/kotlin/exposed/examples/cache/domain/repository/UserCacheRepository.kt
+++ b/11-high-performance/01-cache-strategies/src/main/kotlin/exposed/examples/cache/domain/repository/UserCacheRepository.kt
@@ -26,7 +26,8 @@ class UserCacheRepository(redissonClient: RedissonClient): AbstractJdbcRedissonR
     redissonClient = redissonClient,
     config = RedissonCacheConfig.READ_WRITE_THROUGH_WITH_NEAR_CACHE.copy(
         name = "exposed:users",
-    )
+    ),
+    trustedBinaryCache = true,
 ) {
     companion object: KLoggingChannel()
 

--- a/11-high-performance/01-cache-strategies/src/main/kotlin/exposed/examples/cache/domain/repository/UserCredentialsCacheRepository.kt
+++ b/11-high-performance/01-cache-strategies/src/main/kotlin/exposed/examples/cache/domain/repository/UserCredentialsCacheRepository.kt
@@ -24,6 +24,7 @@ class UserCredentialsCacheRepository(
 ): AbstractJdbcRedissonRepository<String, UserCredentialsRecord>(
     redissonClient = redissonClient,
     config = RedissonCacheConfig.READ_ONLY_WITH_NEAR_CACHE.copy(name = "exposed:user-credentials"),
+    trustedBinaryCache = true,
 ) {
 
     companion object: KLoggingChannel()

--- a/11-high-performance/01-cache-strategies/src/main/kotlin/exposed/examples/cache/domain/repository/UserEventCacheRepository.kt
+++ b/11-high-performance/01-cache-strategies/src/main/kotlin/exposed/examples/cache/domain/repository/UserEventCacheRepository.kt
@@ -22,6 +22,7 @@ class UserEventCacheRepository(
 ): AbstractJdbcRedissonRepository<Long, UserEventRecord>(
     redissonClient = redissonClient,
     config = RedissonCacheConfig.WRITE_BEHIND_WITH_NEAR_CACHE.copy(name = "exposed:user-events"),
+    trustedBinaryCache = true,
 ) {
 
     companion object: KLoggingChannel()

--- a/11-high-performance/02-cache-strategies-coroutines/src/main/kotlin/exposed/examples/cache/coroutines/domain/repository/UserCacheRepository.kt
+++ b/11-high-performance/02-cache-strategies-coroutines/src/main/kotlin/exposed/examples/cache/coroutines/domain/repository/UserCacheRepository.kt
@@ -25,7 +25,8 @@ class UserCacheRepository(redissonClient: RedissonClient):
         redissonClient = redissonClient,
         config = RedissonCacheConfig.READ_WRITE_THROUGH_WITH_NEAR_CACHE.copy(
             name = "exposed:coroutines:users"
-        )
+        ),
+        trustedBinaryCache = true,
     ) {
     companion object: KLoggingChannel()
 

--- a/11-high-performance/02-cache-strategies-coroutines/src/main/kotlin/exposed/examples/cache/coroutines/domain/repository/UserCredentialsCacheRepository.kt
+++ b/11-high-performance/02-cache-strategies-coroutines/src/main/kotlin/exposed/examples/cache/coroutines/domain/repository/UserCredentialsCacheRepository.kt
@@ -22,6 +22,7 @@ class UserCredentialsCacheRepository(
 ): AbstractSuspendedJdbcRedissonRepository<String, UserCredentialsRecord>(
     redissonClient = redissonClient,
     config = RedissonCacheConfig.READ_ONLY_WITH_NEAR_CACHE.copy(name = "exposed:coroutines:user-credentials"),
+    trustedBinaryCache = true,
 ) {
 
     companion object: KLoggingChannel()

--- a/11-high-performance/02-cache-strategies-coroutines/src/main/kotlin/exposed/examples/cache/coroutines/domain/repository/UserEventCacheRepository.kt
+++ b/11-high-performance/02-cache-strategies-coroutines/src/main/kotlin/exposed/examples/cache/coroutines/domain/repository/UserEventCacheRepository.kt
@@ -23,6 +23,7 @@ class UserEventCacheRepository(
 ): AbstractSuspendedJdbcRedissonRepository<Long, UserEventRecord>(
     redissonClient = redissonClient,
     config = RedissonCacheConfig.WRITE_BEHIND_WITH_NEAR_CACHE.copy(name = "exposed:coroutines:user-events"),
+    trustedBinaryCache = true,
 ) {
 
     companion object: KLoggingChannel()

--- a/11-high-performance/02-cache-strategies-coroutines/src/test/kotlin/exposed/examples/cache/coroutines/controller/UserControllerTest.kt
+++ b/11-high-performance/02-cache-strategies-coroutines/src/test/kotlin/exposed/examples/cache/coroutines/controller/UserControllerTest.kt
@@ -89,7 +89,7 @@ class UserControllerTest(
                     .responseBody
                     .shouldNotBeNull()
 
-            users shouldHaveSize idsInDB.size
+            users shouldHaveSize idSize
         }
 
     @Test

--- a/README.ko.md
+++ b/README.ko.md
@@ -62,7 +62,7 @@ Kotlin Exposed는 JetBrains가 만든 Kotlin 우선 SQL 프레임워크입니다
 | Exposed | 1.3.0 |
 | Spring Boot | 4.0.6 |
 | Kotlinx Coroutines | 1.11.0 |
-| Bluetape4k dependencies BOM | 1.3.0 |
+| Bluetape4k dependencies BOM | 1.3.1 |
 | Gradle Wrapper | 9.5.0 |
 
 ## 학습 가이드

--- a/README.ko.md
+++ b/README.ko.md
@@ -62,7 +62,7 @@ Kotlin Exposed는 JetBrains가 만든 Kotlin 우선 SQL 프레임워크입니다
 | Exposed | 1.3.0 |
 | Spring Boot | 4.0.6 |
 | Kotlinx Coroutines | 1.11.0 |
-| Bluetape4k dependencies BOM | 1.2.0 |
+| Bluetape4k dependencies BOM | 1.3.0 |
 | Gradle Wrapper | 9.5.0 |
 
 ## 학습 가이드

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Kotlin Exposed is JetBrains' Kotlin-first SQL framework. It lets you model table
 | Exposed | 1.3.0 |
 | Spring Boot | 4.0.6 |
 | Kotlinx Coroutines | 1.11.0 |
-| Bluetape4k dependencies BOM | 1.3.0 |
+| Bluetape4k dependencies BOM | 1.3.1 |
 | Gradle Wrapper | 9.5.0 |
 
 ## Learning Guide

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Kotlin Exposed is JetBrains' Kotlin-first SQL framework. It lets you model table
 | Exposed | 1.3.0 |
 | Spring Boot | 4.0.6 |
 | Kotlinx Coroutines | 1.11.0 |
-| Bluetape4k dependencies BOM | 1.2.0 |
+| Bluetape4k dependencies BOM | 1.3.0 |
 | Gradle Wrapper | 9.5.0 |
 
 ## Learning Guide

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,7 +68,7 @@ logcaptor = "2.12.6"
 mybatis-dynamic-sql = "2.0.0"
 
 snappy-java = "1.1.10.8"
-lz4-java = "1.8.0"
+lz4-java = "1.11.0"
 zstd-jni = "1.5.7-11"
 
 findbugs = "3.0.2"
@@ -335,7 +335,7 @@ java-uuid-generator = { module = "com.fasterxml.uuid:java-uuid-generator", versi
 
 # Compression
 snappy-java = { module = "org.xerial.snappy:snappy-java", version.ref = "snappy-java" }
-lz4-java = { module = "org.lz4:lz4-java", version.ref = "lz4-java" }
+lz4-java = { module = "at.yawk.lz4:lz4-java", version.ref = "lz4-java" }
 zstd-jni = { module = "com.github.luben:zstd-jni", version.ref = "zstd-jni" }
 
 # Utils

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k-dependencies = "1.3.0"
+bluetape4k-dependencies = "1.3.1"
 
 kotlin = "2.4.0"
 kotlinx-coroutines = "1.11.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -350,7 +350,7 @@ javax-money-api = { module = "javax.money:money-api", version.ref = "javax-money
 mybatis-dynamic-sql = { module = "org.mybatis.dynamic-sql:mybatis-dynamic-sql", version.ref = "mybatis-dynamic-sql" }
 
 # Jakarta
-jakarta-activation-api = { module = "jakarta.activation:jakarta.activation-api", version = "2.1.3" }
+jakarta-activation-api = { module = "jakarta.activation:jakarta.activation-api", version = "2.1.4" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version = "3.0.0" }
 jakarta-el-api = { module = "jakarta.el:jakarta.el-api", version = "6.0.1" }
 jakarta-inject-api = { module = "jakarta.inject:jakarta.inject-api", version = "2.0.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k-dependencies = "1.2.0"
+bluetape4k-dependencies = "1.3.0"
 
 kotlin = "2.4.0"
 kotlinx-coroutines = "1.11.0"


### PR DESCRIPTION
## Summary
- Upgrade the workshop consumer to `io.bluetape4k:bluetape4k-dependencies:1.3.1`.
- Align duplicated external library usage with the bluetape4k ecosystem catalog/runtime expectations.
- Move the local lz4 pin from `org.lz4:lz4-java:1.8.0` to the ecosystem `at.yawk.lz4:lz4-java:1.11.0` coordinate.
- Update example code for upgraded `bluetape4k-exposed` runtime contracts: explicit Tink encryptors and trusted private Redisson binary cache opt-in.
- Refresh stale cache frontend fixture expectations exposed by the repo-level test run.

## Validation
- Catalog drift check against `bluetape4k-dependencies/gradle/libs.versions.toml`: `actionable_drift_count=0`.
- `./gradlew help --refresh-dependencies --no-daemon --no-configuration-cache`
- `./gradlew :06-spring-cache:processTestAot --no-daemon --no-configuration-cache --no-build-cache`
- `./gradlew :12-exposed-tink:test --no-daemon --no-configuration-cache --no-build-cache`
- `./gradlew :01-cache-strategies:test :02-cache-strategies-coroutines:test --no-daemon --no-configuration-cache --no-build-cache`
- `./gradlew test --no-daemon --no-configuration-cache --no-build-cache`

## DoD Status
- [x] Consumes `bluetape4k-dependencies` 1.3.1.
- [x] External library drift was checked and resolved against the bluetape4k catalog/ecosystem.
- [x] Repository-level tests passed before PR creation.
