### PR TITLE
build: sync managed catalog versions

### DIFF
--- a/05-exposed-dml/02-types/src/test/kotlin/exposed/examples/types/Ex03_NumericColumnType.kt
+++ b/05-exposed-dml/02-types/src/test/kotlin/exposed/examples/types/Ex03_NumericColumnType.kt
@@ -4,6 +4,7 @@ import exposed.shared.tests.AbstractExposedTest
 import exposed.shared.tests.TestDB
 import exposed.shared.tests.assertFailAndRollback
 import exposed.shared.tests.currentDialectTest
+import exposed.shared.tests.inProperCase
 import exposed.shared.tests.withTables
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
@@ -305,12 +306,12 @@ class Ex03_NumericColumnType: AbstractExposedTest() {
                     "${tester.ushort.nameInDatabaseCase()} ${tester.ushort.columnType} NOT NULL, " +
                     "${tester.integer.nameInDatabaseCase()} ${tester.integer.columnType} NOT NULL, " +
                     "${tester.uinteger.nameInDatabaseCase()} ${tester.uinteger.columnType} NOT NULL, " +
-                    "CONSTRAINT custom_byte_check CHECK (${tester.byte.nameInDatabaseCase()} BETWEEN ${Byte.MIN_VALUE} AND ${Byte.MAX_VALUE}), " +
-                    "CONSTRAINT custom_ubyte_check CHECK (${tester.ubyte.nameInDatabaseCase()} BETWEEN 0 AND ${UByte.MAX_VALUE}), " +
-                    "CONSTRAINT custom_short_check CHECK (${tester.short.nameInDatabaseCase()} BETWEEN ${Short.MIN_VALUE} AND ${Short.MAX_VALUE}), " +
-                    "CONSTRAINT custom_ushort_check CHECK (${tester.ushort.nameInDatabaseCase()} BETWEEN 0 AND ${UShort.MAX_VALUE}), " +
-                    "CONSTRAINT custom_integer_check CHECK (${tester.integer.nameInDatabaseCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE}), " +
-                    "CONSTRAINT custom_uinteger_check CHECK (${tester.uinteger.nameInDatabaseCase()} BETWEEN 0 AND ${UInt.MAX_VALUE}))"
+                    "CONSTRAINT ${"custom_byte_check".inProperCase()} CHECK (${tester.byte.nameInDatabaseCase()} BETWEEN ${Byte.MIN_VALUE} AND ${Byte.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_ubyte_check".inProperCase()} CHECK (${tester.ubyte.nameInDatabaseCase()} BETWEEN 0 AND ${UByte.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_short_check".inProperCase()} CHECK (${tester.short.nameInDatabaseCase()} BETWEEN ${Short.MIN_VALUE} AND ${Short.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_ushort_check".inProperCase()} CHECK (${tester.ushort.nameInDatabaseCase()} BETWEEN 0 AND ${UShort.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_integer_check".inProperCase()} CHECK (${tester.integer.nameInDatabaseCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_uinteger_check".inProperCase()} CHECK (${tester.uinteger.nameInDatabaseCase()} BETWEEN 0 AND ${UInt.MAX_VALUE}))"
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,13 +9,13 @@ kotlinx-coroutines = "1.11.0"
 kotlinx-serialization = "1.11.0"
 kotlinx-atomicfu = "0.32.1"
 kotlinx-benchmark = "0.4.15"
-ktor = "3.5.0"
+ktor = "3.5.1"
 
 spring-boot = "4.1.0"
 spring-modulith = "2.0.6"
 reactor-bom = "2025.0.6"
 
-exposed = "1.3.0"
+exposed = "1.3.1"
 
 slf4j = "2.0.18"
 logback = "1.5.32"
@@ -26,11 +26,11 @@ springmockk = "4.0.2"
 awaitility = "4.3.0"
 testcontainers = "2.0.5"
 
-hikaricp = "7.0.2"
+hikaricp = "7.1.0"
 h2-v2 = "2.4.240"
 mysql-connector-j = "9.7.0"
 mariadb-java-client = "3.5.8"
-postgresql-driver = "42.7.11"
+postgresql-driver = "42.7.13"
 pgjdbc-ng = "0.8.9"
 r2dbc-h2 = "1.1.0.RELEASE"
 r2dbc-pool = "1.0.2.RELEASE"
@@ -39,26 +39,26 @@ r2dbc-postgresql = "1.1.1.RELEASE"
 lettuce = "7.6.0.RELEASE"
 redisson = "4.6.1"
 
-hibernate = "7.4.2.Final"
+hibernate = "7.4.4.Final"
 hibernate-reactive = "4.5.0.Final"
 hibernate-validator = "9.1.0.Final"
 
 micrometer = "1.16.1"
-netty = "4.2.15.Final"
+netty = "4.2.16.Final"
 
-jackson = "2.22.0"
+jackson = "2.22.1"
 jackson-annotations = "2.22"
 jackson3 = "3.2.0"
 
 caffeine = "3.2.3"
 
-vertx = "5.1.3"
+vertx = "5.1.4"
 
 springdoc-openapi = "3.0.3"
 
 gatling = "3.15.1"
 
-agroal = "3.2"
+agroal = "3.2.1"
 
 jmh = "1.37"
 datafaker = "2.5.4"


### PR DESCRIPTION
## Summary
- Materializes the refreshed `bluetape4k-dependencies` shared version catalog into this repository.
- Keeps the change scoped to `gradle/libs.versions.toml`.
- `bluetape4k-experimental` is intentionally excluded from this propagation wave.

## Validation
- `git diff --check`
- `./gradlew help --no-configuration-cache --console=plain`

## DoD Status

- [x] Synced catalog-managed versions from `bluetape4k-dependencies`.
- [x] Kept `bluetape4k-dependencies` BOM target unchanged; aligned only duplicated external library aliases.
- [x] Applied Exposed 1.3.1 compatibility fix for dialect-normalized custom check constraint names.
- [x] Verified locally with `git diff --check`.
- [x] Verified locally with `./gradlew :02-types:test --no-configuration-cache --console=plain` (`BUILD SUCCESSFUL in 24s`).
- [ ] GitHub Actions rerun is pending after commit `aa4f7bad`.
