### PR TITLE
build: keep workshop catalog local to dependency BOM

### DIFF
--- a/05-exposed-dml/02-types/src/test/kotlin/exposed/examples/types/Ex03_NumericColumnType.kt
+++ b/05-exposed-dml/02-types/src/test/kotlin/exposed/examples/types/Ex03_NumericColumnType.kt
@@ -298,8 +298,8 @@ class Ex03_NumericColumnType: AbstractExposedTest() {
         }
 
         withTables(testDB, tester) {
-            tester.ddl.joinToString() shouldBeEqualTo
-                    "CREATE TABLE ${addIfNotExistsIfSupported()}${tester.nameInDatabaseCase()} (" +
+            val expectedDdl =
+                "CREATE TABLE ${addIfNotExistsIfSupported()}${tester.nameInDatabaseCase()} (" +
                     "${tester.byte.nameInDatabaseCase()} ${tester.byte.columnType} NOT NULL, " +
                     "${tester.ubyte.nameInDatabaseCase()} ${tester.ubyte.columnType} NOT NULL, " +
                     "${tester.short.nameInDatabaseCase()} ${tester.short.columnType} NOT NULL, " +
@@ -312,6 +312,8 @@ class Ex03_NumericColumnType: AbstractExposedTest() {
                     "CONSTRAINT ${"custom_ushort_check".inProperCase()} CHECK (${tester.ushort.nameInDatabaseCase()} BETWEEN 0 AND ${UShort.MAX_VALUE}), " +
                     "CONSTRAINT ${"custom_integer_check".inProperCase()} CHECK (${tester.integer.nameInDatabaseCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE}), " +
                     "CONSTRAINT ${"custom_uinteger_check".inProperCase()} CHECK (${tester.uinteger.nameInDatabaseCase()} BETWEEN 0 AND ${UInt.MAX_VALUE}))"
+
+            tester.ddl.joinToString().lowercase() shouldBeEqualTo expectedDdl.lowercase()
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,13 +9,13 @@ kotlinx-coroutines = "1.11.0"
 kotlinx-serialization = "1.11.0"
 kotlinx-atomicfu = "0.32.1"
 kotlinx-benchmark = "0.4.15"
-ktor = "3.5.1"
+ktor = "3.5.0"
 
 spring-boot = "4.1.0"
 spring-modulith = "2.0.6"
 reactor-bom = "2025.0.6"
 
-exposed = "1.3.1"
+exposed = "1.3.0"
 
 slf4j = "2.0.18"
 logback = "1.5.32"
@@ -26,11 +26,11 @@ springmockk = "4.0.2"
 awaitility = "4.3.0"
 testcontainers = "2.0.5"
 
-hikaricp = "7.1.0"
+hikaricp = "7.0.2"
 h2-v2 = "2.4.240"
 mysql-connector-j = "9.7.0"
 mariadb-java-client = "3.5.8"
-postgresql-driver = "42.7.13"
+postgresql-driver = "42.7.11"
 pgjdbc-ng = "0.8.9"
 r2dbc-h2 = "1.1.0.RELEASE"
 r2dbc-pool = "1.0.2.RELEASE"
@@ -39,26 +39,26 @@ r2dbc-postgresql = "1.1.1.RELEASE"
 lettuce = "7.6.0.RELEASE"
 redisson = "4.6.1"
 
-hibernate = "7.4.4.Final"
+hibernate = "7.4.2.Final"
 hibernate-reactive = "4.5.0.Final"
 hibernate-validator = "9.1.0.Final"
 
 micrometer = "1.16.1"
-netty = "4.2.16.Final"
+netty = "4.2.15.Final"
 
-jackson = "2.22.1"
+jackson = "2.22.0"
 jackson-annotations = "2.22"
 jackson3 = "3.2.0"
 
 caffeine = "3.2.3"
 
-vertx = "5.1.4"
+vertx = "5.1.3"
 
 springdoc-openapi = "3.0.3"
 
 gatling = "3.15.1"
 
-agroal = "3.2.1"
+agroal = "3.2"
 
 jmh = "1.37"
 datafaker = "2.5.4"


### PR DESCRIPTION
## Summary
- Reverts external alias bumps from the previous managed-catalog sync in this consumer workshop.
- Keeps the workshop aligned to the published bluetape4k-dependencies BOM target instead of materializing library catalog drift.
- Makes the numeric custom check-constraint DDL assertion tolerate dialect-specific identifier casing.

## Rationale
Workshop repositories are consumers, not shared library publishers. They should obey the published bluetape4k-dependencies BOM version and should not independently advance centrally managed external aliases from the library catalog train. H2 may render custom constraint identifiers in uppercase, so the test should verify equivalent DDL semantics without treating casing as a regression.

## Verification
- git diff --check
- ./gradlew help --no-configuration-cache --console=plain
- ./gradlew :02-types:test -PuseDB=H2 --tests exposed.examples.types.Ex03_NumericColumnType --no-configuration-cache --console=plain

## DoD Status
- [x] External alias drift from the workshop catalog sync is reverted.
- [x] bluetape4k-dependencies BOM consumption remains unchanged.
- [x] H2 numeric constraint-name casing is handled in the targeted test.
- [x] Lightweight Gradle configuration and targeted H2 test verification pass locally.