### PR TITLE
Localize top-level workshop docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,38 @@
-# Changelog
+# 변경 이력
 
 모든 주요 변경 사항은 이 파일에 기록됩니다. 형식은 [Keep a Changelog](https://keepachangelog.com/ko/1.0.0/)를 따르며, 이 프로젝트는 [Semantic Versioning](https://semver.org/lang/ko/)을 따릅니다.
 
 ---
 
-## [Unreleased]
+## [미배포]
 
-### Added
+### 추가
 
 - `.omc/` 디렉터리 추가 (OMC 상태 관리용)
 - `.claude/worktrees` gitignore 규칙 추가
 - `Libs.bluetape4k_lingua`, `Libs.bluetape4k_mock_web_server`, `Libs.bluetape4k_mock_webflux_server` 모듈 참조 추가 (BOM 1.7.0 신규 모듈)
 - GitHub Actions CI 워크플로 개선: DB 매트릭스 (`H2/PostgreSQL/MySQL 8/MariaDB`) 병렬 실행, Kover 커버리지 집계, detekt/테스트 아티팩트 업로드
 
-### Changed
+### 변경
 
-- **Dependency governance**: `bluetape4k-dependencies` aligned to the published
-  `1.2.0` BOM.
+- **의존성 거버넌스**: `bluetape4k-dependencies`를 배포된 `1.2.0` BOM에 맞춤
 - **Bluetape4k**: `1.6.2` → `1.7.0`
 - **Kotlin**: `2.3.20` → `2.3.21`
 - **MariaDB JDBC 드라이버**: `mariadb-java-client` `3.5.7` → `3.5.8`, `r2dbc-mariadb` `1.3.0` → `1.4.0`
 - CI 테스트 잡에서 Testcontainers 기반 DB는 `--max-workers=1` 적용 (Docker 리소스 경합 방지)
 
-### Removed
+### 제거
 
 - `Libs.bluetape4k_crypto`, `Libs.bluetape4k_exposed_jasypt` 참조 제거 (BOM 1.7.0에서 제외됨)
 - `06-advanced/10-exposed-jasypt` 예제 모듈 전체 삭제 (대체 모듈은 `12-exposed-tink`)
 - `06-advanced/06-custom-columns`의 encrypt 테스트 디렉터리 삭제 (`bluetape4k-crypto` 의존)
 - `00-shared/exposed-shared-tests`, `02-alternatives-to-jpa/hibernate-reactive-example`에서 crypto/jasypt 참조 정리
 
-### Fixed
+### 수정
 
 - MariaDB에서 JSON/JSONB 컬럼 default 메타데이터 round-trip 불일치로 실패하던 테스트 8개 스킵 처리 (`04-exposed-json`, `08-exposed-jackson`, `09-exposed-fastjson2`, `11-exposed-jackson3`)
 
-### Test
+### 테스트
 
 - **`10-multi-tenant/01-multitenant-spring-web`**: `ActorExposedRepository` / `MovieExposedRepository`에 `@Transactional` 추가, `ActorRepositoryTest` / `MovieRepositoryTest` 신규 추가 (테넌트별 스키마 격리 검증, 28개)
 - **`10-multi-tenant/02-multitenant-spring-web-virtualthread`**: 동일한 리포지토리 테스트 추가 (가상 스레드 환경, 28개)
@@ -46,7 +45,7 @@
 
 ## [1.1.1] - 2026-03-14
 
-### Added
+### 추가
 
 - **`11-high-performance/04-benchmark`**: `kotlinx-benchmark` 기반 마이크로벤치마크 모듈 추가
     - `RoutingKeyResolverBenchmark`: 라우팅 키 계산 오버헤드 측정
@@ -54,7 +53,7 @@
     - smoke 프로파일(`smokeBenchmark`) 및 Markdown 리포트 생성(`benchmarkMarkdown`) 지원
 - `.editorconfig` 파일 추가
 
-### Changed
+### 변경
 
 - **Kotlin**: `2.3.20-RC3` → `2.3.20` (정식 릴리스)
 - **Bluetape4k**: `1.4.0` → `1.5.0-Beta1`
@@ -63,7 +62,7 @@
 - Kotlin 2.3 기준으로 빌드 설정 전면 전환 (`languageVersion = 2.3`, `apiVersion = 2.3`)
 - Redisson Client 설정 개선 (netty 설정 변경, Virtual Threads 적용)
 
-### Fixed
+### 수정
 
 - `RedissonClient` 설정에서 netty 관련 설정 오류 수정 (`5982dcd7`, `c9870321`, `b1908633`, `d4b7dd01`)
 
@@ -71,19 +70,19 @@
 
 ## [1.0.5] - 2026-03-12
 
-### Added
+### 추가
 
 - **`bin/repo-status`**, **`bin/repo-diff`**, **`bin/repo-test-summary`**: 토큰 절약형 저장소 요약 헬퍼 스크립트 추가
 - **Redisson 설정 최적화**: Virtual Threads 기반 Redisson Client 설정 적용 (`dd8f3042`)
 
-### Changed
+### 변경
 
 - **Bluetape4k**: `1.3.1` → `1.4.0`
 - **Kotlin**: `2.2.21` → `2.3.20-RC3`
     - `vertx-sqlclient-example` compileTestKotlin hang 문제 우회 처리
 - 빌드 속도 개선 (configuration cache 활용 강화)
 
-### Fixed
+### 수정
 
 - `vertx-sqlclient-example` 컴파일 시 hang 걸리는 문제 해결
 
@@ -91,7 +90,7 @@
 
 ## [1.0.0] - 2025-12-01 (초기 릴리스)
 
-### Added
+### 추가
 
 - **워크샵 전체 구조** 구성 (모듈 `00` ~ `11`)
 - **`00-shared/exposed-shared-tests`**: 공통 테스트 인프라 (`AbstractExposedTest`, `TestDB`, `WithTables`)
@@ -100,12 +99,10 @@
 - **`03-exposed-basic`**: DSL / DAO 패턴 기초 예제
 - **`04-exposed-ddl`**: 연결 관리, 스키마 정의
 - **`05-exposed-dml`**: SELECT/INSERT/UPDATE/DELETE, 컬럼 타입, SQL 함수, 트랜잭션, Entity API
-- **`06-advanced`
-  **: Crypt, JavaTime, kotlinx-datetime, JSON, Money, 커스텀 컬럼, 커스텀 Entity, Jackson, Fastjson2, Jasypt, Jackson3, Tink
+- **`06-advanced`**: Crypt, JavaTime, kotlinx-datetime, JSON, Money, 커스텀 컬럼, 커스텀 Entity, Jackson, Fastjson2, Jasypt, Jackson3, Tink
 - **`07-jpa`**: JPA → Exposed 마이그레이션 (기본/고급)
 - **`08-coroutines`**: Coroutines 기반 비동기 트랜잭션, Virtual Threads
-- **`09-spring`
-  **: Spring Boot AutoConfiguration, TransactionTemplate, @Transactional, Repository 패턴, Spring Cache, Suspended Cache
+- **`09-spring`**: Spring Boot AutoConfiguration, TransactionTemplate, @Transactional, Repository 패턴, Spring Cache, Suspended Cache
 - **`10-multi-tenant`**: Schema-based 멀티테넌시 (MVC, Virtual Threads, WebFlux)
 - **`11-high-performance`**: Read/Write Through/Behind 캐시 전략, RoutingDataSource
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,28 +1,28 @@
 # TODO
 
-## 1. Exposed Quick starts examples
+## 1. Exposed 빠른 시작 예제
 
-- [X] Spring Boot MVC Rest API with Exposed
-- [X] Spring Boot Webflux REST API with Exposed Suspended
+- [X] Exposed 기반 Spring Boot MVC REST API
+- [X] Exposed Suspended 기반 Spring Boot WebFlux REST API
 
-## 2. Alternatives to JPA - Asynchronous Database Access
+## 2. JPA 대안 - 비동기 데이터베이스 접근
 
 - [X] Hibernate Reactive
 - [X] R2DBC
-- [X] Vertx SQL Client (with MyBatis SQL Builder)
-- [X] Exposed with Coroutines
-- [X] Virtual Threads with JPA
+- [X] Vert.x SQL Client (MyBatis SQL Builder 사용)
+- [X] Coroutines 기반 Exposed
+- [X] JPA와 Virtual Threads
 
-## 3. Test enviroment for Exposed
+## 3. Exposed 테스트 환경
 
 - [X] JUnit 5
-- [X] TestContainers
-- [X] Databases
+- [X] Testcontainers
+- [X] 데이터베이스
     - [X] H2
-    - [X] Postgres
+    - [X] PostgreSQL
     - [X] MySQL V8
 
-## 3. Basic Features in Exposed
+## 4. Exposed 기본 기능
 
 - [X] SQL DSL
 - [X] Table 정의 및 생성
@@ -54,7 +54,7 @@
 - [X] INSERT INTO SELECT
 - [X] MergeFrom
 
-## 4. Advanced Features in Exposed
+## 5. Exposed 고급 기능
 
 - [X] Expressions
 - [X] Functions
@@ -62,15 +62,15 @@
 - [X] Composite Primary Key
 - [X] CTE (Common Table Expression)
 
-## 5. Define Custom ID Table & Entity
+## 6. 커스텀 ID Table 및 Entity 정의
 
 - [X] Entity
     - [X] Auto Increment ID
     - [X] Client Generated ID
 
-## 6. Advanded Data types
+## 7. 고급 데이터 타입
 
-- [X] Array Column for Postgres
+- [X] PostgreSQL Array Column
 - [X] JSON
     - [X] JSON Column
     - [X] JSONB Column
@@ -78,12 +78,12 @@
 - [X] Kotlin DateTime Column
 - [X] Money Column
 
-## 7. Define Other Data Types
+## 8. 기타 데이터 타입 정의
 
 - Custom EntityID
-    - [X] Snowflake ID for EntityID
-    - [X] Timebased UUID for EntityID
-    - [X] Base62 encoded UUID for EntityID
+    - [X] EntityID용 Snowflake ID
+    - [X] EntityID용 time-based UUID
+    - [X] Base62 encoded UUID 기반 EntityID
 - Object Column
     - [X] Binary Serialized Column
         - [X] JDK Built-in Serializer
@@ -97,13 +97,13 @@
         - [X] Snappy Column
         - [X] ZSTD Column
     - [X] Encrypted Column
-- JSON Column using Jackson
-    - [X] jackson function for JSON Column
+- Jackson 기반 JSON Column
+    - [X] JSON Column용 Jackson 함수
 
-## 7. Migration JPA Entity to Exposed Entity
+## 9. JPA Entity를 Exposed Entity로 마이그레이션
 
-- [X] Simple Entity
-- [X] Relationships
+- [X] 단순 Entity
+- [X] 관계
     - [X] One To One
     - [X] One To Many
         - [X] List
@@ -111,49 +111,49 @@
         - [X] Map
     - [X] Many To One
     - [X] Many To Many
-- [X] Hierarchy
+- [X] 계층 구조
     - [X] Self Referencing
     - [X] Relation Table
-- [X] Inheritance
+- [X] 상속
     - [X] Single Table
     - [X] Table Per Class
     - [X] Joined Table
 
-## 8. Exposed with Coroutines
+## 10. Coroutines와 Exposed
 
-- [X] Transactional Coroutines
+- [X] 트랜잭션 Coroutines
     - [X] newSuspendedTransaction
 
 - [X] Dispatchers
     - [X] Dispatchers.IO
     - [X] Dispatchers.VT
 
-## 9. Integration with Spring Boot
+## 11. Spring Boot 통합
 
-- [X] Using Spring Transaction
+- [X] Spring Transaction 사용
 - [X] Spring Boot MVC
     - [X] Platform Threads
     - [X] Virtual Threads
-- [X] Spring Boot Webflux + Coroutines
-- [X] Implement ExposedRepository
+- [X] Spring Boot WebFlux + Coroutines
+- [X] ExposedRepository 구현
 
-## 10. Multi-tenant Application
+## 12. 멀티테넌트 애플리케이션
 
-- [X] Multitenant with Spring MVC
-- [X] Multitenant with Spring MVC and Virtual Threads
-- [X] Multitenant with Spring Webflux and Coroutines
+- [X] Spring MVC 기반 멀티테넌시
+- [X] Spring MVC와 Virtual Threads 기반 멀티테넌시
+- [X] Spring WebFlux와 Coroutines 기반 멀티테넌시
 
-## 11. Exposed with Redisson (Cache Strategy)
+## 13. Redisson과 Exposed (Cache Strategy)
 
 - [X] Read Through
 - [X] Write Through
 - [X] Write Behind
 
-## 12. Migration Existing Database (Flyway)
+## 14. 기존 데이터베이스 마이그레이션 (Flyway)
 
-- [ ] MigrationUtils in Exposed
-- [ ] Using Flyway for Migration
+- [ ] Exposed의 MigrationUtils
+- [ ] Flyway 기반 Migration
 
-## 13. Exposed with Spring Modulith
+## 15. Spring Modulith와 Exposed
 
-- [ ] Spring Modulith & Application Events
+- [ ] Spring Modulith 및 Application Events

--- a/WIP.md
+++ b/WIP.md
@@ -1,49 +1,49 @@
 # WIP - exposed-workshop
 
-Snapshot: 2026-06-02 KST
-Scope: open GitHub issues assigned to `debop`, created on or after 2026-01-01.
-Open count: 1 issue.
+스냅샷: 2026-06-02 KST
+범위: 2026-01-01 이후 생성되고 `debop`에게 할당된 열린 GitHub 이슈.
+열린 이슈 수: 1개.
 
-## Recently Completed
+## 최근 완료
 
-- Spring Boot 4 alignment, version catalog migration, dependency governance,
-  compatibility guards, and Redisson baseline alignment are merged.
-- Test cleanup and Kluent to `bluetape4k-assertions` migration are merged.
-- README hero/architecture refresh is merged.
-- GNO-backed audit registered `#70` for routing datasource pool lifecycle.
+- Spring Boot 4 정렬, version catalog 마이그레이션, 의존성 거버넌스,
+  호환성 가드, Redisson 기준선 정렬이 병합되었습니다.
+- 테스트 정리와 Kluent에서 `bluetape4k-assertions`로의 마이그레이션이 병합되었습니다.
+- README hero/architecture 갱신이 병합되었습니다.
+- GNO 기반 감사에서 routing datasource pool lifecycle 문제를 `#70`으로 등록했습니다.
 
-## Current Direction
+## 현재 방향
 
-Restore lifecycle correctness in existing examples before adding more chapter
-content. Chapter 10-12 backlog is valuable, but it should not expand on top of
-examples that leak tenant-owned datasource pools.
+새 chapter 콘텐츠를 늘리기 전에 기존 예제의 lifecycle 정확성을 먼저 회복합니다.
+Chapter 10-12 backlog는 가치가 있지만, tenant 소유 datasource pool을 누수하는
+예제 위에 더 확장해서는 안 됩니다.
 
-## Priority Queue
+## 우선순위 큐
 
-| Priority | Issue | Difficulty | Notes |
+| 우선순위 | 이슈 | 난이도 | 메모 |
 |---|---|---:|---|
-| P2 | [#70](https://github.com/bluetape4k/exposed-workshop/issues/70) routing datasource registry does not close tenant Hikari pools | M | Existing chapter 11 example creates tenant pools without registry/Spring shutdown ownership. |
-| P3 | [#45](https://github.com/bluetape4k/exposed-workshop/issues/45) Ktor examples for chapters 10 and 11 epic | L | Parent for `#46`-`#50`; keep work module-scoped. |
-| P3 | [#46](https://github.com/bluetape4k/exposed-workshop/issues/46) Ktor multi-tenant example for chapter 10 | M | Child of `#45`. |
-| P3 | [#47](https://github.com/bluetape4k/exposed-workshop/issues/47) Ktor cache strategies example for chapter 11 | M | Child of `#45`. |
-| P3 | [#48](https://github.com/bluetape4k/exposed-workshop/issues/48) Ktor coroutine cache example for chapter 11 | M | Child of `#45`. |
-| P3 | [#49](https://github.com/bluetape4k/exposed-workshop/issues/49) Ktor routing datasource example for chapter 11 | M | Child of `#45`; should account for `#70` lifecycle fix. |
-| P3 | [#50](https://github.com/bluetape4k/exposed-workshop/issues/50) wire Ktor chapter examples into docs and verification | S | Finish after `#46`-`#49`. |
-| P3 | [#51](https://github.com/bluetape4k/exposed-workshop/issues/51) Spring Boot multi-tenant strategy epic | L | Parent for `#52`-`#56`. |
-| P3 | [#52](https://github.com/bluetape4k/exposed-workshop/issues/52) schema-per-tenant Spring Boot example | M | Child of `#51`. |
-| P3 | [#53](https://github.com/bluetape4k/exposed-workshop/issues/53) database-per-tenant Spring Boot example | M | Child of `#51`. |
-| P3 | [#54](https://github.com/bluetape4k/exposed-workshop/issues/54) Spring Security tenant authorization example | M | Child of `#51`. |
-| P3 | [#55](https://github.com/bluetape4k/exposed-workshop/issues/55) tenant onboarding/provisioning example | M | Child of `#51`. |
-| P3 | [#56](https://github.com/bluetape4k/exposed-workshop/issues/56) wire chapter 10 examples into docs and verification | S | Finish after `#52`-`#55`. |
-| P3 | [#57](https://github.com/bluetape4k/exposed-workshop/issues/57) chapter 12 production integration epic | L | Parent for `#58`-`#63`. |
-| P3 | [#58](https://github.com/bluetape4k/exposed-workshop/issues/58) Spring Boot 4 and Ktor application architecture examples | M | Child of `#57`. |
-| P3 | [#59](https://github.com/bluetape4k/exposed-workshop/issues/59) authentication/session examples | M | Child of `#57`. |
-| P3 | [#60](https://github.com/bluetape4k/exposed-workshop/issues/60) outbox realtime examples | M | Child of `#57`. |
-| P3 | [#61](https://github.com/bluetape4k/exposed-workshop/issues/61) HTTP client outbox/idempotency examples | M | Child of `#57`. |
-| P3 | [#62](https://github.com/bluetape4k/exposed-workshop/issues/62) observability/readiness examples | M | Child of `#57`. |
-| P3 | [#63](https://github.com/bluetape4k/exposed-workshop/issues/63) wire chapter 12 examples into docs and verification | S | Finish after `#58`-`#62`. |
+| P2 | [#70](https://github.com/bluetape4k/exposed-workshop/issues/70) routing datasource registry does not close tenant Hikari pools | M | 기존 chapter 11 예제가 tenant pool을 만들지만 registry/Spring shutdown 소유권을 정의하지 않습니다. |
+| P3 | [#45](https://github.com/bluetape4k/exposed-workshop/issues/45) Ktor examples for chapters 10 and 11 epic | L | `#46`-`#50`의 parent입니다. 작업은 module 단위로 유지합니다. |
+| P3 | [#46](https://github.com/bluetape4k/exposed-workshop/issues/46) Ktor multi-tenant example for chapter 10 | M | `#45`의 child입니다. |
+| P3 | [#47](https://github.com/bluetape4k/exposed-workshop/issues/47) Ktor cache strategies example for chapter 11 | M | `#45`의 child입니다. |
+| P3 | [#48](https://github.com/bluetape4k/exposed-workshop/issues/48) Ktor coroutine cache example for chapter 11 | M | `#45`의 child입니다. |
+| P3 | [#49](https://github.com/bluetape4k/exposed-workshop/issues/49) Ktor routing datasource example for chapter 11 | M | `#45`의 child입니다. `#70` lifecycle fix를 반영해야 합니다. |
+| P3 | [#50](https://github.com/bluetape4k/exposed-workshop/issues/50) wire Ktor chapter examples into docs and verification | S | `#46`-`#49` 완료 후 마무리합니다. |
+| P3 | [#51](https://github.com/bluetape4k/exposed-workshop/issues/51) Spring Boot multi-tenant strategy epic | L | `#52`-`#56`의 parent입니다. |
+| P3 | [#52](https://github.com/bluetape4k/exposed-workshop/issues/52) schema-per-tenant Spring Boot example | M | `#51`의 child입니다. |
+| P3 | [#53](https://github.com/bluetape4k/exposed-workshop/issues/53) database-per-tenant Spring Boot example | M | `#51`의 child입니다. |
+| P3 | [#54](https://github.com/bluetape4k/exposed-workshop/issues/54) Spring Security tenant authorization example | M | `#51`의 child입니다. |
+| P3 | [#55](https://github.com/bluetape4k/exposed-workshop/issues/55) tenant onboarding/provisioning example | M | `#51`의 child입니다. |
+| P3 | [#56](https://github.com/bluetape4k/exposed-workshop/issues/56) wire chapter 10 examples into docs and verification | S | `#52`-`#55` 완료 후 마무리합니다. |
+| P3 | [#57](https://github.com/bluetape4k/exposed-workshop/issues/57) chapter 12 production integration epic | L | `#58`-`#63`의 parent입니다. |
+| P3 | [#58](https://github.com/bluetape4k/exposed-workshop/issues/58) Spring Boot 4 and Ktor application architecture examples | M | `#57`의 child입니다. |
+| P3 | [#59](https://github.com/bluetape4k/exposed-workshop/issues/59) authentication/session examples | M | `#57`의 child입니다. |
+| P3 | [#60](https://github.com/bluetape4k/exposed-workshop/issues/60) outbox realtime examples | M | `#57`의 child입니다. |
+| P3 | [#61](https://github.com/bluetape4k/exposed-workshop/issues/61) HTTP client outbox/idempotency examples | M | `#57`의 child입니다. |
+| P3 | [#62](https://github.com/bluetape4k/exposed-workshop/issues/62) observability/readiness examples | M | `#57`의 child입니다. |
+| P3 | [#63](https://github.com/bluetape4k/exposed-workshop/issues/63) wire chapter 12 examples into docs and verification | S | `#58`-`#62` 완료 후 마무리합니다. |
 
-## Dependency Map
+## 의존성 맵
 
 ```text
 #70 routing datasource Hikari lifecycle
@@ -73,11 +73,11 @@ examples that leak tenant-owned datasource pools.
   -> #63 docs and verification
 ```
 
-## WIP Limits
+## WIP 제한
 
-| Lane | Limit | Current next |
+| 작업 흐름 | 제한 | 현재 다음 작업 |
 |---|---:|---|
-| Correctness / lifecycle | 1 | `#70` before routing datasource expansion. |
-| Ktor examples | 1 | Start one child under `#45`; finish `#50` after children. |
-| Spring Boot multi-tenant examples | 1 | Start one child under `#51`; finish `#56` after children. |
-| Production integration examples | 1 | Start one child under `#57`; finish `#63` after children. |
+| Correctness / lifecycle | 1 | routing datasource 확장보다 `#70`을 먼저 처리합니다. |
+| Ktor examples | 1 | `#45` 아래 child 하나를 시작하고, children 완료 후 `#50`을 마무리합니다. |
+| Spring Boot multi-tenant examples | 1 | `#51` 아래 child 하나를 시작하고, children 완료 후 `#56`을 마무리합니다. |
+| Production integration examples | 1 | `#57` 아래 child 하나를 시작하고, children 완료 후 `#63`을 마무리합니다. |

--- a/doc/Exposed-Benchmark-Review.md
+++ b/doc/Exposed-Benchmark-Review.md
@@ -24,8 +24,7 @@
 
 ## 2. Native SQL vs HQL vs CriteriaBuilder vs jOOQ — JMH 실측
 
-**출처
-**: [Zeyad Ahmed, Medium (2024-01-25)](https://medium.com/@zeyadahmedcs/comprehensive-guide-to-decoding-the-java-persistence-puzzle-jmh-benchmarking-of-native-query-hql-108fd7220c54)
+**출처**: [Zeyad Ahmed, Medium (2024-01-25)](https://medium.com/@zeyadahmedcs/comprehensive-guide-to-decoding-the-java-persistence-puzzle-jmh-benchmarking-of-native-query-hql-108fd7220c54)
 **환경**: JMH 1.37 / Java 17 / Spring Boot 3.1.2 / PostgreSQL (IMDb DB, avgt 모드)
 
 | 쿼리 방식             | findAll() 소형 DB     | findAll() 대형 DB | findAllByCategory() 중형 DB |
@@ -42,8 +41,7 @@
 
 ## 3. Spring Boot JPQL vs Native SQL vs Specification — JMH 실측
 
-**출처
-**: [Stackademic (2025)](https://blog.stackademic.com/spring-boot-query-performance-deep-dive-jpql-vs-native-vs-specification-with-benchmarks-77c6b655bb78)
+**출처**: [Stackademic (2025)](https://blog.stackademic.com/spring-boot-query-performance-deep-dive-jpql-vs-native-vs-specification-with-benchmarks-77c6b655bb78)
 **환경**: Spring Boot 3.3.2 / PostgreSQL 15 / Apple M2 / 100만 행 / HikariCP
 
 | 쿼리 방식             | 상대 성능                               |
@@ -56,8 +54,7 @@
 
 ## 4. Hibernate(CriteriaBuilder) vs jOOQ — 학술 JMH 논문
 
-**출처
-**: [Hetman & Miłosz, Lublin University of Technology, JCSI 35 (2025) 209–215](https://ph.pollub.pl/index.php/jcsi/article/download/7306/5024/34434)
+**출처**: [Hetman & Miłosz, Lublin University of Technology, JCSI 35 (2025) 209–215](https://ph.pollub.pl/index.php/jcsi/article/download/7306/5024/34434)
 **환경**: OpenJDK 17 / PostgreSQL 16.4 (bare metal) / Spring Boot 3.3.4 / Chinook DB (track 210만 건 등)
 **JMH 설정**: warmup 3회, 측정 10회 × 각 30초
 
@@ -109,8 +106,7 @@ getCategory();  // SELECT * FROM category WHERE product_id = 1
 
 ## 6. ORM Battle 2025: Hibernate vs jOOQ vs plain JDBC
 
-**출처
-**: [Devrim Ozcay, Medium (2025-06-19)](https://medium.com/javarevisited/the-great-orm-debate-hibernate-vs-jooq-vs-plain-jdbc-e271b95a2ef5)
+**출처**: [Devrim Ozcay, Medium (2025-06-19)](https://medium.com/javarevisited/the-great-orm-debate-hibernate-vs-jooq-vs-plain-jdbc-e271b95a2ef5)
 
 핵심 발견사항:
 

--- a/doc/VirtualThread-Jdbc-Benchmark.md
+++ b/doc/VirtualThread-Jdbc-Benchmark.md
@@ -1,4 +1,4 @@
-# Platform Threads vs Virtual Threads JDBC 성능 비교
+# Platform Threads와 Virtual Threads의 JDBC 성능 비교
 
 > 모든 수치는 실측 JMH / 부하테스트 결과입니다. 환경마다 차이가 있으므로 절대값보다 **배율(×)** 위주로 해석하세요.
 
@@ -8,10 +8,10 @@
 
 | 워크로드                            | Virtual Threads 향상 배율        |
 |---------------------------------|------------------------------|
-| 단순 SELECT (indexed)             | **×2.2 – ×2.6**              |
+| 단순 SELECT (인덱스 사용)             | **×2.2 – ×2.6**              |
 | 복잡 쿼리 (UPDATE + 집계)             | **×1.8**                     |
 | I/O 지연 시뮬레이션 (+10ms latency)    | **×2.3**                     |
-| CPU bound 작업                    | ×1.02 – 1.03 (거의 없음)         |
+| CPU-bound 작업                    | ×1.02 – 1.03 (거의 없음)         |
 | `SELECT 1` (MariaDB, 극단적 경량 쿼리) | **×5 – ×9** (MariaDB 공식 블로그) |
 
 ---
@@ -48,11 +48,10 @@
 | VirtualThreadPerTaskExecutor | **5,004** | **×2.27** | 최적            |
 | ForkJoinPool                 |     1,254 |     ×0.57 | 스레드 수 제한으로 역전 |
 
-> **핵심 인사이트**: 지연(I/O) 상황에서 ForkJoinPool은 스레드 수 제한 때문에 성능이 오히려 하락.
-> Virtual Threads만 I/O 대기 시 carrier thread를 반납(parking) → 효율 유지.
+> **핵심 해석**: 지연(I/O) 상황에서 ForkJoinPool은 스레드 수 제한 때문에 성능이 오히려 하락합니다.
+> Virtual Threads는 I/O 대기 중 carrier thread를 반납(parking)하므로 효율을 유지합니다.
 
-**출처
-**: [Benchmark Database Access with Java 21 Virtual Threads - adi.earth (2024)](https://adi.earth/posts/database-virtual-threads-benchmark/)
+**출처**: [Benchmark Database Access with Java 21 Virtual Threads - adi.earth (2024)](https://adi.earth/posts/database-virtual-threads-benchmark/)
 
 ---
 
@@ -71,8 +70,7 @@
 > `pool=4`로 줄이면 성능이 개선되지만 여전히 Virtual Threads가 우세.
 > MySQL Connector는 동일 테스트에서 격차가 훨씬 작음 (MariaDB Connector 최적화 효과).
 
-**출처
-**: [Benchmark JDBC connectors and Java 21 virtual threads - MariaDB (2023)](https://mariadb.com/resources/blog/benchmark-jdbc-connectors-and-java-21-virtual-threads/)
+**출처**: [Benchmark JDBC connectors and Java 21 virtual threads - MariaDB (2023)](https://mariadb.com/resources/blog/benchmark-jdbc-connectors-and-java-21-virtual-threads/)
 
 ---
 
@@ -98,8 +96,7 @@
 
 > 병렬 DB 쿼리에서 Virtual Threads의 효과가 극대화됨.
 
-**출처
-**: [Spring Boot 2025: Parallel Database Queries with Virtual Threads - JavaScript in Plain English](https://javascript.plainenglish.io/spring-boot-2025-parallel-database-queries-with-virtual-threads-benchmarks-code-5140deae9a76)
+**출처**: [Spring Boot 2025: Parallel Database Queries with Virtual Threads - JavaScript in Plain English](https://javascript.plainenglish.io/spring-boot-2025-parallel-database-queries-with-virtual-threads-benchmarks-code-5140deae9a76)
 
 ---
 
@@ -112,7 +109,7 @@
 - Virtual Threads + Hibernate
 - Reactor Core + R2DBC (비교 대상)
 
-결과: ops/s 기준 Virtual Threads + JDBC ≈ Reactor Core + R2DBC (거의 동등)
+결과: ops/s 기준으로 Virtual Threads + JDBC와 Reactor Core + R2DBC는 거의 동등했습니다.
 
 > 즉, 비동기 코드 리팩터링 없이 Virtual Threads만으로 Reactive 수준의 처리량 달성 가능.
 
@@ -125,16 +122,16 @@
 | 상황                 | 추천                              | 이유                                                             |
 |--------------------|---------------------------------|----------------------------------------------------------------|
 | **JDBC 쿼리 집중**     | Virtual Threads                 | I/O 대기 중 carrier 반납 → 효율 ×2~5                                  |
-| **CPU bound 연산**   | Platform Threads (ForkJoinPool) | Virtual 오버헤드 무의미, carrier 수 = CPU 코어 수가 최적                     |
+| **CPU-bound 연산**   | Platform Threads (ForkJoinPool) | Virtual Threads 오버헤드 이점이 거의 없고, carrier 수 = CPU 코어 수가 최적        |
 | **+latency 환경**    | Virtual Threads                 | ForkJoinPool 역전, CachedPool 메모리 위험                             |
 | **대규모 병렬 쿼리**      | Virtual Threads                 | `Thread.startVirtualThread { repo.find() }` 패턴으로 WebFlux 수준 달성 |
-| **Reactive 대체 여부** | Virtual Threads ≈ R2DBC         | ops/s 동등, 코드 복잡도는 Virtual Threads가 훨씬 낮음                       |
+| **Reactive 대체 여부** | Virtual Threads ≈ R2DBC         | ops/s는 유사하고, 코드 복잡도는 Virtual Threads가 훨씬 낮음                    |
 
 ---
 
 ## 6. Pinning 주의사항 (성능 함정)
 
-Virtual Threads가 **platform thread에 고정(pinned)** 되는 경우 → 이점 소멸:
+Virtual Threads가 **platform thread에 고정(pinned)** 되면 이점이 사라집니다.
 
 ```java
 // ❌ Pinning 발생 — synchronized 블록 내 I/O

--- a/doc/exposed-migration-guide-0.61-to-1.1.md
+++ b/doc/exposed-migration-guide-0.61-to-1.1.md
@@ -13,17 +13,17 @@
 
 ## 목차
 
-1. [패키지 구조 변경 (Breaking Change)](#1-패키지-구조-변경)
+1. [패키지 구조 변경 (호환성 중단 변경)](#1-패키지-구조-변경)
 2. [모듈별 import 매핑표](#2-모듈별-import-매핑표)
 3. [DSL API 변경사항](#3-dsl-api-변경사항)
 4. [DAO API 변경사항](#4-dao-api-변경사항)
 5. [Transaction API 변경사항](#5-transaction-api-변경사항)
-6. [Dialect Metadata 변경](#6-dialect-metadata-변경)
+6. [Dialect 메타데이터 변경](#6-dialect-metadata-변경)
 7. [Spring 통합 변경사항](#7-spring-통합-변경사항)
 8. [Coroutine 지원 변경사항](#8-coroutine-지원-변경사항)
 9. [신규 모듈](#9-신규-모듈)
-10. [Class Diagram](#10-class-diagram)
-11. [Sequence Diagram](#11-sequence-diagram)
+10. [클래스 다이어그램](#10-class-diagram)
+11. [시퀀스 다이어그램](#11-sequence-diagram)
 
 ---
 
@@ -111,7 +111,7 @@ org.jetbrains.exposed.v1.r2dbc.*     ← exposed-r2dbc
 | `org.jetbrains.exposed.sql.batchInsert`         | `org.jetbrains.exposed.v1.jdbc.batchInsert`     |
 | `org.jetbrains.exposed.sql.SizedIterable`       | `org.jetbrains.exposed.v1.jdbc.SizedIterable`   |
 
-### Transactions
+### 트랜잭션
 
 | 0.61.0                                                                          | 1.1.1                                                                               |
 |---------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
@@ -330,7 +330,7 @@ inTopLevelTransaction(
 
 ---
 
-## 6. Dialect Metadata 변경
+## 6. Dialect 메타데이터 변경
 
 테이블 메타데이터 접근 시 `currentDialect` 대신 `currentDialectMetadata`를 사용합니다:
 
@@ -439,7 +439,7 @@ suspend fun findByCode(code: String): CountryRecord? = newSuspendedTransaction {
 
 ---
 
-## 10. Class Diagram
+## 10. 클래스 다이어그램
 
 ### 10.1 Exposed Core Architecture
 
@@ -657,7 +657,7 @@ classDiagram
 
 ---
 
-## 11. Sequence Diagram
+## 11. 시퀀스 다이어그램
 
 ### 11.1 DSL: 테이블 생성 → 데이터 삽입 → 조회
 

--- a/doc/notion-exposed-1.1-update.md
+++ b/doc/notion-exposed-1.1-update.md
@@ -22,7 +22,7 @@
 
 ## 4. 준비 및 환경 설정
 
-### 패키지 구조 변경 (Breaking Change)
+### 패키지 구조 변경 (호환성 중단 변경)
 
 Exposed 1.0.0부터 **전체 패키지 경로에 `v1` 접두사**가 추가되었습니다.
 
@@ -180,7 +180,7 @@ transaction {
 }
 ```
 
-### DSL Class Diagram
+### DSL 클래스 다이어그램
 
 ```mermaid
 classDiagram
@@ -346,7 +346,7 @@ transaction {
 }
 ```
 
-### 테이블 Class Diagram
+### 테이블 클래스 다이어그램
 
 ```mermaid
 classDiagram
@@ -385,7 +385,7 @@ classDiagram
 
 ---
 
-## 7.4 Transactions
+## 7.4 트랜잭션
 
 ### transaction() 시그니처 변경
 
@@ -433,7 +433,7 @@ inTopLevelTransaction(
 ) { /* ... */ }
 ```
 
-### Transaction Sequence Diagram
+### 트랜잭션 시퀀스 다이어그램
 
 ```mermaid
 sequenceDiagram
@@ -629,7 +629,7 @@ flowchart TD
     style C fill:#f3e5f5
 ```
 
-### DAO Sequence Diagram
+### DAO 시퀀스 다이어그램
 
 ```mermaid
 sequenceDiagram
@@ -695,7 +695,7 @@ suspend fun findCountryByCode(code: String): CountryRecord? =
     }
 ```
 
-### Coroutine Sequence Diagram
+### Coroutine 시퀀스 다이어그램
 
 ```mermaid
 sequenceDiagram
@@ -782,7 +782,7 @@ class CountryRepository {
 }
 ```
 
-### Spring Transaction Architecture
+### Spring Transaction 구조
 
 ```mermaid
 classDiagram
@@ -862,7 +862,7 @@ flowchart LR
     style CACHE fill:#f3e5f5
 ```
 
-### Spring Boot + Exposed Sequence Diagram
+### Spring Boot + Exposed 시퀀스 다이어그램
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
## Summary
- Localize the remaining top-level status/reference docs to Korean-first prose.
- Fix Korean-facing headings and broken source-label Markdown in `doc/*.md` while preserving benchmark values, URLs, issue numbers, commands, and technical identifiers.
- Keep README pairs, manual parity-only paths, and LLM-facing operating docs untouched.

Closes #171.
Part of #169.
Stacked on #194.

## Validation
- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-170-korean-localization-inventory --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `git diff --check`

## DoD Status
| Check | Status | Evidence |
|---|---|---|
| Scope | PASS | Changed only `CHANGELOG.md`, `TODO.md`, `WIP.md`, and `doc/*.md` top-level reference docs |
| Exclusions | PASS | Scope audit reports README pair dirs 86, LLM-facing docs 3, manual EN/KO 0/0, and no excluded changed paths |
| Prose preservation | PASS | Benchmark values, URLs, issue numbers, commands, and technical identifiers preserved while Korean prose/headings were normalized |
| Regression test | PASS | 2 runs, 12 assertions, 0 failures |
| Whitespace | PASS | `git diff --check` |
| Gradle build | N/A | Markdown-only prose changes |
