### PR TITLE
Localize benchmark report prose

### DIFF
--- a/11-high-performance/04-benchmark/BENCHMARK-REPORT.md
+++ b/11-high-performance/04-benchmark/BENCHMARK-REPORT.md
@@ -1,14 +1,14 @@
-# Cache Strategy Benchmark Report
+# 캐시 전략 벤치마크 보고서
 
-- Profile: `smoke`
-- Generated At: `2026-04-19`
-- JMH Mode: Average Time (lower is better)
+- 프로파일: `smoke`
+- 생성일: `2026-04-19`
+- JMH 모드: Average Time (낮을수록 좋음)
 
 ## 1. 캐시 전략 비교 (CacheStrategyComparisonBenchmark)
 
 실제 PostgreSQL(Testcontainers) + HikariCP 환경에서 NoCache, ReadThrough, WriteThrough 전략을 비교합니다.
 
-| Strategy | Workload | Payload (B) | Score (us/op) | Error | Unit |
+| 전략 | 워크로드 | Payload (B) | Score (us/op) | Error | Unit |
 |----------|----------|:-----------:|:-------------:|:-----:|------|
 | NO_CACHE | READ_HEAVY | 256 | 547.733 | ±460.814 | us/op |
 | NO_CACHE | READ_HEAVY | 4096 | 482.554 | ±91.551 | us/op |
@@ -51,7 +51,7 @@
 
 인메모리 Caffeine 캐시의 hit/miss 오버헤드를 비교합니다. (DB I/O 없이 순수 캐시 계층 비용)
 
-| Benchmark | Payload (B) | Score (us/op) | Error | Unit |
+| 벤치마크 | Payload (B) | Score (us/op) | Error | Unit |
 |-----------|:-----------:|:-------------:|:-----:|------|
 | dbOnlyRead | 256 | 0.001 | ±0.000 | us/op |
 | dbOnlyRead | 4096 | 0.001 | ±0.000 | us/op |
@@ -65,8 +65,8 @@
 ### 캐시 계층 오버헤드 분석
 
 - **Cache Hit**: DB 직접 읽기와 거의 동일한 성능 (< 0.01 us 차이)
-- **Cache Miss**: invalidate + reload 비용으로 ~0.1 us 추가 오버헤드
-- **Payload 크기**: 256B → 4096B 변경 시 캐시 오버헤드 변화 미미
+- **Cache Miss**: invalidate + reload 비용으로 약 0.1 us 추가 오버헤드
+- **Payload 크기**: 256B에서 4096B로 커져도 캐시 오버헤드 변화는 미미함
 
 ## 3. 결론
 

--- a/11-high-performance/04-benchmark/exposed-jpa-benchmark.md
+++ b/11-high-performance/04-benchmark/exposed-jpa-benchmark.md
@@ -7,7 +7,7 @@
 
 ---
 
-## 1. Single Entity (Person — 10컬럼) CRUD
+## 1. 단일 Entity (Person - 10컬럼) CRUD
 
 | 연산                     |     Exposed (μs) |         JPA (μs) | Exposed 배율  |
 |------------------------|-----------------:|-----------------:|-------------|
@@ -22,7 +22,7 @@
 
 ---
 
-## 2. One-to-Many (Department → 20 Employees — 8+12컬럼) CRUD
+## 2. One-to-Many (Department → 20 Employees - 8+12컬럼) CRUD
 
 | 연산                               |        Exposed (μs) |         JPA (μs) | Exposed 배율   |
 |----------------------------------|--------------------:|-----------------:|--------------|
@@ -39,7 +39,7 @@
 
 ## 3. 동시성 벤치마크 — Platform Threads vs Virtual Threads
 
-50건 동시 실행 (FixedThreadPool(50) vs VirtualThreadPerTaskExecutor), HikariCP maxPoolSize=100
+50건을 동시에 실행해 FixedThreadPool(50)과 VirtualThreadPerTaskExecutor를 비교했습니다. HikariCP `maxPoolSize=100` 기준입니다.
 
 ### Exposed
 
@@ -76,7 +76,7 @@
 | **VT 효과 미미**     | maxPoolSize=100에서도 VT가 유의미한 향상을 보이지 않음          |
 | **원인 1**         | Docker 로컬 PostgreSQL — 네트워크 지연이 거의 없어 I/O 대기 최소 |
 | **원인 2**         | 50건 동시 < 100 커넥션 — 커넥션 대기 없이 즉시 할당              |
-| **원인 3**         | JMH 단일 fork — OS 스케줄링 오버헤드가 VT 이점을 상쇄           |
+| **원인 3**         | JMH 단일 fork - OS 스케줄링 오버헤드가 VT 이점을 상쇄           |
 | **VT 효과 극대화 조건** | 원격 DB + 높은 네트워크 지연 + 커넥션 풀 < 동시 요청 수            |
 
 ---
@@ -97,7 +97,7 @@
 |----------------------|--------------------------|-------------------------------------------|
 | **단건 CRUD**          | **Exposed 3.9~7.7× 빠름**  | SQL 직접 생성, dirty checking/프록시 없음          |
 | **One-to-Many CRUD** | **Exposed 6.1~18.6× 빠름** | DSL 직접 SQL, JPA는 엔티티 그래프 로드+변경 감지+cascade |
-| **배치 INSERT**        | **Exposed 6.1~8.3× 빠름**  | 단일 트랜잭션 순차 INSERT vs JPA cascade+flush    |
+| **배치 INSERT**        | **Exposed 6.1~8.3× 빠름**  | 단일 트랜잭션 순차 INSERT와 JPA cascade+flush 비교 |
 | **전체 조회 (readAll)**  | **유사**                   | 둘 다 DB→엔티티 매핑, 차이 미미                      |
 | **동시성**              | **Exposed 2.8~4.2× 빠름**  | 경량 트랜잭션 + 적은 오버헤드                         |
 | **Virtual Threads**  | **효과 미미**                | 로컬 Docker DB + 충분한 커넥션 풀에서는 I/O 대기 없음     |
@@ -181,10 +181,10 @@
 ## 벤치마크 실행 방법
 
 ```bash
-# smoke 프로파일 (빠른 검증, ~3분)
+# smoke 프로파일 (빠른 검증, 약 3분)
 ./gradlew :04-benchmark:smokeBenchmark
 
-# main 프로파일 (정밀 측정, ~14분)
+# main 프로파일 (정밀 측정, 약 14분)
 ./gradlew :04-benchmark:benchmark
 
 # Markdown 리포트 생성

--- a/11-high-performance/04-benchmark/self-improve-report.md
+++ b/11-high-performance/04-benchmark/self-improve-report.md
@@ -3,21 +3,21 @@
 > 실행일: 2026-04-19
 > 브랜치: `improve/cache_strategy_benchmark_improvement`
 > 벤치마크: `./gradlew :04-benchmark:smokeBenchmark`
-> Primary Metric: `readThroughCacheHit_256` (lower is better)
+> 주요 지표: `readThroughCacheHit_256` (낮을수록 좋음)
 
 ## 요약
 
 | 항목             | 값                             |
 |----------------|-------------------------------|
-| 상태             | completed (max_iterations 도달) |
+| 상태             | completed (`max_iterations` 도달) |
 | 총 반복           | 3/3                           |
-| Baseline Score | 0.003 us/op                   |
-| Best Score     | 0.002 us/op                   |
+| 기준 점수          | 0.003 us/op                   |
+| 최고 점수          | 0.002 us/op                   |
 | 개선폭            | 0.001 us/op (33%)             |
 
 ## 라운드별 성과
 
-| Round | 접근 방식              | 주요 변경                                                 | Score (us/op) | 결과                         |
+| 라운드 | 접근 방식              | 주요 변경                                                 | Score (us/op) | 결과                         |
 |-------|--------------------|-------------------------------------------------------|---------------|----------------------------|
 | 1     | pattern_compliance | KLogging, Serializable, runCatching 패턴 적용             | 0.002470      | bluetape4k-patterns 준수     |
 | 2     | benchmark_strategy | CacheStrategyComparisonBenchmark 추가                   | 0.002         | 3전략 × 2워크로드 × 2페이로드 = 12조합 |
@@ -41,12 +41,12 @@
 | ReadThrough  | 477.809                  | 517.396                   | 1.0x (효과 미미)     |
 | WriteThrough | 467.935                  | 493.774                   | 1.0x (효과 미미)     |
 
-### 핵심 인사이트
+### 핵심 해석
 
-1. **READ_HEAVY 환경에서 캐시 효과 극대화**: WriteThrough가 11.5배, ReadThrough가 6.3배 성능 향상
-2. **WRITE_HEAVY 환경에서 캐시 효과 제한적**: 모든 전략이 유사한 성능 (쓰기 비율이 높으면 DB 접근 불가피)
-3. **WriteThrough > ReadThrough**: 쓰기 시 캐시를 즉시 갱신하므로 읽기 시 항상 캐시 히트
-4. **Payload 크기 영향 미미**: 256B vs 4096B 차이가 크지 않음 (캐시는 참조만 저장)
+1. **READ_HEAVY 환경에서 캐시 효과 극대화**: WriteThrough는 11.5배, ReadThrough는 6.3배 성능을 개선했습니다.
+2. **WRITE_HEAVY 환경에서 캐시 효과 제한적**: 쓰기 비율이 높으면 DB 접근이 불가피하므로 모든 전략이 유사한 성능을 보였습니다.
+3. **WriteThrough > ReadThrough**: 쓰기 시 캐시를 즉시 갱신하므로 이후 읽기는 항상 캐시 히트에 가깝습니다.
+4. **Payload 크기 영향 미미**: 256B와 4096B의 차이가 크지 않았습니다. 캐시는 payload 본문보다 참조 관리 비용의 영향을 더 크게 받습니다.
 
 ## ReadThroughCacheBenchmark 결과
 
@@ -82,19 +82,19 @@
 
 ## 변경된 파일 목록
 
-### Round 1 (bluetape4k-patterns 준수)
+### 라운드 1 (`bluetape4k-patterns` 준수)
 
 - `04-benchmark/src/main/kotlin/.../cache/ReadThroughCacheBenchmark.kt` — KLogging, Serializable 추가
 - `04-benchmark/src/main/kotlin/.../routing/RoutingKeyResolverBenchmark.kt` — KLogging 추가
 - `04-benchmark/src/main/kotlin/.../crud/*.kt` — 모든 CRUD 벤치마크에 KLogging 추가
 
-### Round 2 (CacheStrategyComparisonBenchmark)
+### 라운드 2 (`CacheStrategyComparisonBenchmark`)
 
 - `04-benchmark/src/main/kotlin/.../cache/CacheStrategy.kt` — NoCacheStrategy, ReadThroughStrategy, WriteThroughStrategy
 - `04-benchmark/src/main/kotlin/.../cache/CacheBenchmarkSetup.kt` — PostgreSQL + HikariCP + Testcontainers 인프라
 - `04-benchmark/src/main/kotlin/.../cache/CacheStrategyComparisonBenchmark.kt` — 12조합 JMH 벤치마크
 
-### Round 3 (문서화)
+### 라운드 3 (문서화)
 
 - `04-benchmark/README.md` — Benchmarks 테이블, Class Structure 다이어그램, Parameters, Results 추가
 - `04-benchmark/README.ko.md` — 한국어 버전 동기화


### PR DESCRIPTION
## Summary
- Localize benchmark-report reader prose and table labels to Korean.
- Preserve raw benchmark scores, commands, class/method names, strategy keys, URLs, and branch/commit evidence.
- Keep README pairs, manual parity-only paths, and LLM-facing operating docs untouched.

Closes #172.
Part of #169.
Stacked on #195.

## Validation
- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-171-korean-top-level-docs --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `git diff --check`

## DoD Status
| Check | Status | Evidence |
|---|---|---|
| Scope | PASS | Changed only the three benchmark report Markdown files under `11-high-performance/04-benchmark` |
| Exclusions | PASS | Scope audit reports README pair dirs 86, LLM-facing docs 3, manual EN/KO 0/0, and no excluded changed paths |
| Benchmark provenance | PASS | Raw scores, command lines, benchmark class/method names, strategy keys, URLs, and commit evidence preserved |
| Regression test | PASS | 2 runs, 12 assertions, 0 failures |
| Whitespace | PASS | `git diff --check` |
| Gradle build | N/A | Markdown-only benchmark prose changes |
