### PR TITLE
Localize early lessons records

### DIFF
--- a/docs/lessons/2026-05-13-readme-hero-architecture.md
+++ b/docs/lessons/2026-05-13-readme-hero-architecture.md
@@ -1,21 +1,21 @@
-# README Hero And WIP Refresh
+# README 히어로와 WIP 갱신
 
-## Context
+## 배경
 
-The Exposed workshop README already had diagrams but needed the shared workbench
-visual style and a current issue-synced WIP snapshot.
+Exposed workshop README에는 이미 다이어그램이 있었지만, 공통 workbench
+시각 스타일과 현재 GitHub 이슈 상태에 맞춘 WIP 스냅샷이 필요했다.
 
-## Decision
+## 결정
 
-Store the generated image in `docs/assets/exposed-workshop-workbench.png` and
-create `WIP.md` showing no assigned open issues.
+생성한 이미지는 `docs/assets/exposed-workshop-workbench.png`에 저장하고,
+할당된 열린 이슈가 없음을 보여 주는 `WIP.md`를 만든다.
 
-## Outcome
+## 결과
 
-Both README locales now start with a visual Exposed workshop entrypoint and a
-short purpose/features section.
+두 README locale 모두 시각적인 Exposed workshop 진입점과 짧은 목적/기능
+섹션으로 시작한다.
 
-## Verification
+## 검증
 
-- Confirmed the generated asset exists as a PNG under `docs/assets`.
-- Verified both README locales reference the shared image path.
+- 생성된 asset이 `docs/assets` 아래 PNG로 존재함을 확인했다.
+- 두 README locale이 동일한 이미지 경로를 참조함을 검증했다.

--- a/docs/lessons/2026-05-17-issue-58-ktor-architecture.md
+++ b/docs/lessons/2026-05-17-issue-58-ktor-architecture.md
@@ -1,31 +1,31 @@
-# Issue 58 - Ktor Architecture Baseline
+# Issue 58 - Ktor 아키텍처 기준선
 
-## Context
+## 배경
 
-Chapter 12 starts production integration examples. The first module needed a
-small Ktor baseline before adding auth, outbox, client, or observability
-examples.
+12장은 production integration 예제로 시작한다. 첫 번째 모듈에는 auth,
+outbox, client, observability 예제를 추가하기 전에 작은 Ktor 기준선이
+필요했다.
 
-## Decision
+## 결정
 
-Use a Ktor + Exposed JDBC module with explicit route/service/repository
-boundaries. Keep blocking Exposed transactions inside a suspend repository API
-that wraps `transaction {}` with `Dispatchers.IO`.
+route/service/repository 경계가 명확한 Ktor + Exposed JDBC 모듈을 사용한다.
+blocking Exposed transaction은 `Dispatchers.IO`로 `transaction {}`을 감싸는
+suspend repository API 안에 둔다.
 
-## Outcome
+## 결과
 
-Added `12-production-integration/01-ktor-application-architecture` with Ktor
-JSON, StatusPages, CallId/CallLogging, H2 persistence, route tests, and
-English/Korean README files.
+Ktor JSON, StatusPages, CallId/CallLogging, H2 persistence, route test, 영어/한국어
+README 파일을 포함한 `12-production-integration/01-ktor-application-architecture`를
+추가했다.
 
-Claude implementation review caught two issues after the first commit: the
-fallback 500 handler did not log root causes, and the body limit only trusted
-`Content-Length`. A first fix checked size after `receiveText()`, but Claude
-correctly rejected it because the body was already buffered. The final version
-logs unexpected failures and enforces the size limit while streaming request
-body chunks before JSON decoding.
+Claude 구현 리뷰는 첫 커밋 뒤 두 문제를 잡았다. fallback 500 handler가 root
+cause를 로그로 남기지 않았고, body limit이 `Content-Length`만 신뢰했다. 첫
+수정은 `receiveText()` 이후 크기를 확인했지만, 그 시점에는 body가 이미
+buffering되어 있어 Claude가 올바르게 반려했다. 최종 버전은 예상하지 못한
+실패를 로그로 남기고, JSON decoding 전에 request body chunk를 streaming하면서
+크기 제한을 적용한다.
 
-## Verification
+## 검증
 
 - `./gradlew -q projects`
 - `./gradlew :01-ktor-application-architecture:compileKotlin`
@@ -36,18 +36,16 @@ body chunks before JSON decoding.
 - `git diff --check`
 - Claude Code implementation final re-review - PASS, P0 = 0, P1 = 0
 
-IDE batch diagnostics reported zero problems after opening the project through
-IntelliJ, but the CLI diagnostics were not editor-fresh. Online Gradle
-resolution was blocked by an external snapshot POM for
-`io.github.bluetape4k.aws:bluetape4k-aws-bom:0.1.0`; the same targeted compile
-and test verification passed with `--offline`. CI workflow changes were not
-required: daily CI runs repository-wide Gradle tests, and the new H2-only module
-is included through `settings.gradle.kts`.
+IntelliJ에서 프로젝트를 연 뒤 IDE batch diagnostics는 문제 0건을 보고했지만,
+CLI diagnostics는 editor-fresh 상태가 아니었다. Online Gradle resolution은
+`io.github.bluetape4k.aws:bluetape4k-aws-bom:0.1.0` 외부 snapshot POM 때문에
+막혔고, 같은 targeted compile/test 검증은 `--offline`으로 통과했다. CI workflow
+변경은 필요하지 않았다. daily CI가 repository-wide Gradle test를 실행하고, 새
+H2-only 모듈은 `settings.gradle.kts`를 통해 포함되기 때문이다.
 
-## Future Guidance
+## 향후 지침
 
-For future Ktor + JDBC examples, do not call Exposed `transaction {}` directly
-from routes. Put the blocking boundary in the repository and test at least one
-parallel write path when the example demonstrates service architecture.
-Do not rely on `Content-Length` alone for request limits; also enforce the limit
-against the bytes actually read.
+향후 Ktor + JDBC 예제에서는 route에서 Exposed `transaction {}`을 직접 호출하지
+않는다. blocking 경계는 repository에 두고, 예제가 service architecture를
+보여 준다면 parallel write 경로를 최소 하나 테스트한다. request limit은
+`Content-Length`만 신뢰하지 말고 실제로 읽은 byte 기준으로도 적용한다.

--- a/docs/lessons/2026-05-17-ktor-architecture-package-split.md
+++ b/docs/lessons/2026-05-17-ktor-architecture-package-split.md
@@ -1,26 +1,25 @@
-# Ktor Architecture Package Split
+# Ktor 아키텍처 패키지 분리
 
-## Context
+## 배경
 
-The first Ktor architecture example was intentionally compact, but keeping
-routes, services, repositories, persistence, and models in one file made the
-production-integration lesson harder to scan.
+첫 Ktor 아키텍처 예제는 의도적으로 작게 만들었지만, routes, services,
+repositories, persistence, models를 한 파일에 두면 production-integration
+학습 흐름을 훑어보기 어려웠다.
 
-## Decision
+## 결정
 
-Keep customer models in one model package and split the remaining implementation
-by layer: application wiring, Ktor config, routes, service, repository, and
-persistence. Mirror that structure in tests instead of relying on one broad
-HTTP integration test. Use `Base58.randomString(8)` for short H2 database
-suffixes instead of UUID strings.
+customer model은 하나의 model package에 유지하고, 나머지 구현은 application
+wiring, Ktor config, routes, service, repository, persistence 계층으로 나눈다.
+테스트도 하나의 넓은 HTTP integration test에 기대지 않고 같은 구조를 반영한다.
+짧은 H2 database suffix에는 UUID 문자열 대신 `Base58.randomString(8)`을 사용한다.
 
-## Outcome
+## 결과
 
-The module now shows the architecture boundary through package layout. Tests are
-split across application wiring, routes, service behavior, and repository
-persistence/concurrency.
+이제 모듈은 package layout으로 아키텍처 경계를 보여 준다. 테스트는 application
+wiring, routes, service behavior, repository persistence/concurrency 단위로
+분리됐다.
 
-## Verification
+## 검증
 
 - `./gradlew --offline :01-ktor-application-architecture:compileKotlin :01-ktor-application-architecture:compileTestKotlin :01-ktor-application-architecture:test` - 13 passing
 - `./gradlew --offline detekt` - `NO-SOURCE`
@@ -28,9 +27,9 @@ persistence/concurrency.
 - IntelliJ optimize imports and batch diagnostics - zero problems, not fresh editor highlights
 - Claude Code refactor review - PASS, P0 = 0, P1 = 0
 
-## Future Guidance
+## 향후 지침
 
-For architecture-focused Ktor examples, avoid single-file implementations once
-the example includes more than routing. Keep model DTOs together when the domain
-is small, but split route, service, repository, and persistence code so readers
-can see the intended production shape immediately.
+아키텍처 중심 Ktor 예제에서 routing을 넘어서는 내용이 들어가면 single-file
+구현을 피한다. domain이 작을 때 model DTO는 함께 두되, route, service,
+repository, persistence 코드는 나눠 독자가 의도한 production shape를 바로 볼 수
+있게 한다.

--- a/docs/lessons/2026-05-18-bluetape4k-dependencies-bom.md
+++ b/docs/lessons/2026-05-18-bluetape4k-dependencies-bom.md
@@ -1,22 +1,22 @@
 # bluetape4k-dependencies BOM 전환
 
-## Context
+## 배경
 
 `exposed-workshop`가 `bluetape4k-bom`과 `bluetape4k-exposed-*` 버전을 `1.8.0-SNAPSHOT` catalog 값으로 직접 고정하고 있었다. `bluetape4k-dependencies:1.0.0`가 release BOM들을 가져오므로, workshop은 central BOM 하나를 기준으로 버전을 받아야 했다.
 
-## Decision
+## 결정
 
 - 루트 `dependencyManagement`는 `bluetape4k-bom` 대신 `io.github.bluetape4k:bluetape4k-dependencies:1.0.0`을 import한다.
 - bluetape4k 및 `io.github.bluetape4k.exposed` alias는 versionless로 둔다.
 - 기존 `spring-boot4-*` alias는 published artifact 이름인 `spring-boot-*`로 바꾼다.
 - 사용하지 않는 `bluetape4k-bom` alias는 제거해서 직접 import로 되돌아갈 여지를 줄인다.
 
-## Outcome
+## 결과
 
 `bluetape4k-dependencies`가 `bluetape4k-bom:1.8.0`과 `bluetape4k-exposed-bom:1.8.0`을 import하고, Gradle이 exposed/spring/bluetape4k 아티팩트 버전을 central BOM에서 해석하도록 정리했다.
 추가로 중앙 shared version 검증에 맞춰 JetBrains Exposed와 Dokka catalog alias도 각각 `1.3.0`, `2.2.0`으로 정렬했다.
 
-## Verification
+## 검증
 
 - `./gradlew -q projects`
 - `./gradlew compileKotlin compileTestKotlin`
@@ -25,9 +25,11 @@
 - `./gradlew -q :06-spring-cache:dependencyInsight --configuration compileClasspath --dependency io.github.bluetape4k:bluetape4k-spring-boot-core`
 - `git diff --check`
 - `bluetape4k-dependencies/scripts/sync-shared-versions.py --workspace <symlink-workspace> --repo exposed-workshop --check --summary`
-- After aligning Exposed/Dokka aliases: `./gradlew compileKotlin compileTestKotlin --no-daemon`
+- Exposed/Dokka alias 정렬 후: `./gradlew compileKotlin compileTestKotlin --no-daemon`
 - `./gradlew build --no-daemon` failed during `:03-functions:test` after MySQL Testcontainers connection refusal; dependency resolution and compilation had already passed.
 
-## Future Guard
+## 향후 보호 장치
 
-External advisor results about BOM coverage can be stale or based on artifact-name assumptions. Verify against the published BOM POM and `dependencyInsight` before changing artifact coordinates.
+BOM coverage에 대한 external advisor 결과는 오래됐거나 artifact-name 가정에
+기댈 수 있다. artifact coordinate를 바꾸기 전에 published BOM POM과
+`dependencyInsight`로 검증한다.

--- a/docs/lessons/2026-05-18-central-dependency-governance.md
+++ b/docs/lessons/2026-05-18-central-dependency-governance.md
@@ -1,23 +1,29 @@
-# Central Dependency Governance Sync
+# 중앙 dependency governance 동기화
 
-## Context
+## 배경
 
-Downstream Dependabot PRs were updating shared dependency versions one repository at a time, creating version drift across the bluetape4k organization.
+Downstream Dependabot PR들이 shared dependency version을 repository별로 갱신하면서
+bluetape4k 조직 전체에 version drift를 만들고 있었다.
 
-## Decision
+## 결정
 
-Shared dependency versions should be changed in `bluetape4k-dependencies` first, then materialized into this repository with `sync-shared-versions.py`. This repository also ignores centrally governed dependency names in Dependabot so future PRs route through the central source of truth.
+Shared dependency version은 먼저 `bluetape4k-dependencies`에서 변경한 뒤,
+`sync-shared-versions.py`로 이 repository에 반영한다. 이 repository의 Dependabot도
+centrally governed dependency 이름을 ignore하여 이후 PR이 중앙 source of truth를
+통해 흐르게 한다.
 
-## Outcome
+## 결과
 
-The local version catalog and `.github/dependabot.yml` now follow the central dependency-governance policy.
+local version catalog와 `.github/dependabot.yml`이 central dependency-governance
+정책을 따른다.
 
-## Verification
+## 검증
 
 - `sync-shared-versions.py --write --check --summary` for this repository
 - `sync-dependabot-ignores.py --write --check --summary` for this repository
 - `git diff --check`
 
-## Future Guard
+## 향후 보호 장치
 
-Do not merge repo-local Dependabot PRs for centrally governed dependencies. Update `bluetape4k-dependencies`, then sync this repository.
+Centrally governed dependency에 대한 repo-local Dependabot PR은 merge하지 않는다.
+`bluetape4k-dependencies`를 먼저 갱신한 뒤 이 repository를 동기화한다.

--- a/docs/lessons/2026-05-18-cte-query-builder-example.md
+++ b/docs/lessons/2026-05-18-cte-query-builder-example.md
@@ -1,22 +1,22 @@
-# CTE Query Builder Example
+# CTE Query Builder 예제
 
-## Context
+## 배경
 
-`bluetape4k-exposed` published the `CteTable` and JDBC `withCte` APIs as
-`1.8.1-SNAPSHOT`, so the workshop can demonstrate CTEs without raw SQL.
+`bluetape4k-exposed`가 `CteTable`과 JDBC `withCte` API를 `1.8.1-SNAPSHOT`으로
+publish했으므로, workshop은 raw SQL 없이 CTE를 시연할 수 있다.
 
-## Lesson
+## 교훈
 
-Keep workshop snapshot adoption narrow. `exposed-workshop` still depends on the
-main `bluetape4k` line for general utilities, while Exposed artifacts can move
-through a dedicated `bluetape4k-exposed` version key.
+Workshop의 snapshot adoption은 좁게 유지한다. `exposed-workshop`은 일반 utility에
+대해 여전히 main `bluetape4k` line에 의존하고, Exposed artifact만 dedicated
+`bluetape4k-exposed` version key로 이동할 수 있다.
 
-## Evidence
+## 근거
 
-- Added `Ex51_CteQueryBuilder` beside the existing raw SQL `Ex50_RecursiveCTE`.
-- Verified `CteTable` and `withCte` with H2 through the `:01-dml:test` fast path.
+- 기존 raw SQL `Ex50_RecursiveCTE` 옆에 `Ex51_CteQueryBuilder`를 추가했다.
+- `:01-dml:test` fast path를 통해 H2에서 `CteTable`과 `withCte`를 검증했다.
 
-## Future Guard
+## 향후 보호 장치
 
-When adding examples for a freshly published snapshot API, separate library-line
-versions if only one artifact family needs the snapshot.
+새로 published snapshot API의 예제를 추가할 때 snapshot이 필요한 artifact family가
+하나뿐이라면 library-line version을 분리한다.

--- a/docs/lessons/2026-05-18-wip-audit-routing-datasource-lifecycle.md
+++ b/docs/lessons/2026-05-18-wip-audit-routing-datasource-lifecycle.md
@@ -1,24 +1,23 @@
-# WIP Audit Routing Datasource Lifecycle
+# WIP 감사와 Routing Datasource lifecycle
 
-## Context
+## 배경
 
-The 2026-05-18 GNO-backed exposed-workshop audit compared prior README/WIP
-refresh lessons, live GitHub issue state, and current source markers.
+2026-05-18 GNO-backed exposed-workshop audit는 이전 README/WIP refresh lesson,
+live GitHub issue 상태, 현재 source marker를 비교했다.
 
-## Decision or Finding
+## 결정 또는 발견
 
-The chapter 11 routing datasource example registers tenant-owned
-`HikariDataSource` instances but does not give the registry or a Spring lifecycle
-hook ownership of closing them. The existing config contains a TODO for
-`@PreDestroy` cleanup, and the unit test manually closes pools in `finally`,
-which confirms explicit cleanup is required.
+11장 routing datasource 예제는 tenant-owned `HikariDataSource` instance를
+등록하지만, registry나 Spring lifecycle hook에 close ownership을 주지 않았다.
+기존 config에는 `@PreDestroy` cleanup TODO가 있고, unit test가 `finally`에서 pool을
+수동으로 닫고 있어 명시적 cleanup이 필요함을 확인했다.
 
-## Outcome
+## 결과
 
-Registered GitHub issue #70 and refreshed `WIP.md` from 0 assigned issues to
-20 live assigned issues.
+GitHub issue #70을 등록하고 `WIP.md`를 할당 이슈 0건에서 live assigned issue
+20건으로 갱신했다.
 
-## Verification
+## 검증
 
 - `gno query ... --no-rerank -c bluetape4k-docs` surfaced the prior
   exposed-workshop WIP refresh lesson.
@@ -29,8 +28,8 @@ Registered GitHub issue #70 and refreshed `WIP.md` from 0 assigned issues to
 - `./gradlew :03-routing-datasource:test --tests "exposed.examples.routing.config.RoutingDataSourceConfigTest"`
   completed with `BUILD SUCCESSFUL` and `2 passing`.
 
-## Future Guidance
+## 향후 지침
 
-For datasource-routing examples, define resource shutdown ownership in the
-sample itself. Do not rely on tests to close pools manually when production
-Spring context shutdown still lacks deterministic cleanup.
+Datasource-routing 예제에서는 sample 자체에 resource shutdown ownership을 정의한다.
+production Spring context shutdown에 deterministic cleanup이 아직 없다면 test의
+수동 pool close에 기대지 않는다.

--- a/docs/lessons/2026-05-19-readme-diagram-infographics.md
+++ b/docs/lessons/2026-05-19-readme-diagram-infographics.md
@@ -1,21 +1,30 @@
-# README Diagram Infographics
+# README 다이어그램 infographic
 
-## Context
+## 배경
 
-README files used Mermaid code blocks for architecture, class, sequence, ERD, and other diagrams. The workspace-wide visual direction changed to reviewed pastel infographic PNGs with SVG source assets kept for reuse.
+README 파일들은 architecture, class, sequence, ERD 등 여러 다이어그램에 Mermaid
+code block을 사용했다. Workspace-wide 시각 방향은 재사용 가능한 SVG source asset을
+함께 보관하는 reviewed pastel infographic PNG로 바뀌었다.
 
-## Decision
+## 결정
 
-Replace README Mermaid blocks with generated PNG image links and store matching SVG sources next to the PNG files. Use English-only diagram text, Architects Daughter for large labels, Comic Mono for detail text, and diagram-specific layouts for architecture, class, sequence, and ERD diagrams.
+README Mermaid block을 generated PNG image link로 바꾸고, 대응되는 SVG source를 PNG
+파일 옆에 저장한다. Diagram text는 English-only로 유지하고, 큰 label에는
+Architects Daughter, detail text에는 Comic Mono를 사용하며, architecture, class,
+sequence, ERD diagram마다 전용 layout을 적용한다.
 
-## Outcome
+## 결과
 
-Rendered README diagrams with the shared 2026-05-19 style guide from bluetape4k.github.io/docs/readme-diagram-samples. Root README assets follow repo-local asset placement rules when present.
+bluetape4k.github.io/docs/readme-diagram-samples의 shared 2026-05-19 style guide로
+README diagram을 rendering했다. Root README asset은 존재할 때 repo-local asset
+placement rule을 따른다.
 
-## Verification
+## 검증
 
-Generated PNG/SVG assets with rsvg-convert and checked README links during the cross-repository conversion pass.
+Cross-repository conversion pass에서 rsvg-convert로 PNG/SVG asset을 생성하고 README
+link를 확인했다.
 
-## Future Guidance
+## 향후 지침
 
-Keep README diagrams as PNG embeds with SVG sources for editing. Do not fall back to raw Mermaid or simple Mermaid theme recoloring when visual consistency matters.
+README diagram은 편집용 SVG source와 함께 PNG embed로 유지한다. 시각 일관성이
+중요할 때 raw Mermaid나 단순 Mermaid theme recoloring으로 되돌리지 않는다.

--- a/docs/lessons/2026-05-20-benchmark-result-charts.md
+++ b/docs/lessons/2026-05-20-benchmark-result-charts.md
@@ -1,28 +1,28 @@
-# 2026-05-20 — Benchmark result charts
+# 2026-05-20 — Benchmark result chart
 
-## Context
+## 배경
 
-Workshop benchmark documents had measured tables and one ASCII comparison block,
-but no direct chart images for latency and throughput interpretation.
+Workshop benchmark 문서에는 측정 table과 ASCII 비교 block 하나가 있었지만, latency와
+throughput 해석에 바로 쓸 수 있는 chart image가 없었다.
 
-## Decision
+## 결정
 
-Add static SVG + PNG charts under `docs/images/readme-charts/` and link them from
-benchmark report documents. Keep source tables and citations in place.
+`docs/images/readme-charts/` 아래 static SVG + PNG chart를 추가하고 benchmark report
+문서에서 link한다. Source table과 citation은 그대로 유지한다.
 
-## Outcome
+## 결과
 
-Charts were added for cache strategy latency, read-through cache hit/miss cost,
-Exposed vs JPA CRUD latency, concurrent CRUD latency, and virtual-thread JDBC
-throughput/load-test summaries.
+Cache strategy latency, read-through cache hit/miss cost, Exposed vs JPA CRUD
+latency, concurrent CRUD latency, virtual-thread JDBC throughput/load-test
+summary chart를 추가했다.
 
-## Verification
+## 검증
 
 - `xmllint --noout docs/images/readme-charts/*.svg`
 - `identify docs/images/readme-charts/*.png`
-- Searched touched benchmark documents for remaining Mermaid/ASCII chart blocks.
+- 수정한 benchmark 문서에 Mermaid/ASCII chart block이 남아 있는지 검색했다.
 
-## Future
+## 향후 지침
 
-For literature-review documents, chart only tables with explicit numeric values
-and avoid turning qualitative claims into artificial numbers.
+Literature-review 문서에서는 명시적인 numeric value가 있는 table만 chart로 만들고,
+qualitative claim을 인위적인 숫자로 바꾸지 않는다.

--- a/docs/lessons/2026-05-20-mybatis-dynamic-sql-2-catalog-sync.md
+++ b/docs/lessons/2026-05-20-mybatis-dynamic-sql-2-catalog-sync.md
@@ -1,22 +1,22 @@
-# MyBatis Dynamic SQL 2 Catalog Sync
+# MyBatis Dynamic SQL 2 catalog 동기화
 
-## Context
+## 배경
 
-`bluetape4k-dependencies` promoted MyBatis Dynamic SQL to 2.0.0 and Fory Kotlin
-to 0.17.0 as shared catalog versions.
+`bluetape4k-dependencies`가 MyBatis Dynamic SQL 2.0.0과 Fory Kotlin 0.17.0을
+shared catalog version으로 승격했다.
 
-## Decision
+## 결정
 
-Materialize the shared catalog change in the Exposed workshop repository and
-verify the build still compiles.
+Shared catalog 변경을 Exposed workshop repository에 반영하고 build가 계속 compile되는지
+검증한다.
 
-## Outcome
+## 결과
 
-`gradle/libs.versions.toml` now carries MyBatis Dynamic SQL 2.0.0 and Fory
-Kotlin 0.17.0.
+`gradle/libs.versions.toml`은 이제 MyBatis Dynamic SQL 2.0.0과 Fory Kotlin 0.17.0을
+담고 있다.
 
-## Verification
+## 검증
 
 - `./gradlew build -x test --no-daemon`
 
-The build completed with existing unrelated warnings.
+Build는 기존 unrelated warning과 함께 완료됐다.

--- a/docs/lessons/2026-05-20-readme-class-erd-routing.md
+++ b/docs/lessons/2026-05-20-readme-class-erd-routing.md
@@ -1,23 +1,30 @@
-# README Class/ERD Routing
+# README Class/ERD routing
 
-## Context
+## 배경
 
-README class and ERD images were regenerated across the bluetape4k workspace for reuse in documentation, blog posts, and presentations.
+README class와 ERD image는 documentation, blog post, presentation 재사용을 위해
+bluetape4k workspace 전반에서 다시 생성됐다.
 
-## Decision
+## 결정
 
-Use orthogonal connector routing with blocker-aware lane selection for class and ERD diagrams. Keep pastel colors and existing typography, but avoid cubic curves and connector paths that cross component interiors.
+Class와 ERD diagram에는 blocker-aware lane selection을 갖춘 orthogonal connector
+routing을 사용한다. Pastel color와 기존 typography는 유지하되, cubic curve와 component
+내부를 가로지르는 connector path는 피한다.
 
-## Outcome
+## 결과
 
-The regenerated class/ERD SVGs use relation-aware component placement, straight horizontal/vertical lanes, smaller arrow markers, and top/bottom ports with vertical first and final segments, and horizontal lanes placed near row midlines instead of component edges.
+다시 생성된 class/ERD SVG는 relation-aware component placement, straight
+horizontal/vertical lane, 더 작은 arrow marker, vertical first/final segment를 갖는
+top/bottom port, component edge 대신 row midline 근처에 배치된 horizontal lane을
+사용한다.
 
-## Verification
+## 검증
 
 - `node --check .omx/scripts/refine-readme-diagrams.mjs`
-- Changed class/ERD SVGs: cubic connector count `0`
-- Changed class/ERD SVGs: card-interior crossing candidates `0`
+- 변경된 class/ERD SVG: cubic connector count `0`
+- 변경된 class/ERD SVG: card-interior crossing candidate `0`
 
-## Future Guidance
+## 향후 지침
 
-When diagrams are regenerated, preserve the blocker-aware route scoring and inspect contact sheets before accepting broad image churn.
+Diagram을 다시 생성할 때는 blocker-aware route scoring을 유지하고, 광범위한 image churn을
+받아들이기 전에 contact sheet를 검토한다.

--- a/docs/lessons/2026-05-20-readme-diagram-image-validation.md
+++ b/docs/lessons/2026-05-20-readme-diagram-image-validation.md
@@ -1,24 +1,22 @@
-# README Diagram Image Validation
+# README diagram image 검증
 
-## Context
+## 배경
 
-README diagram assets were regenerated with the reviewed pastel infographic
-style.
+README diagram asset은 reviewed pastel infographic style로 다시 생성됐다.
 
-## Decision
+## 결정
 
-Keep PNG README embeds with matching SVG sources. Mermaid `init` and theme
-configuration blocks must be ignored when rendering ERD images because they are
-not database tables.
+PNG README embed는 대응되는 SVG source와 함께 유지한다. Mermaid `init`와 theme
+configuration block은 database table이 아니므로 ERD image를 rendering할 때 무시해야
+한다.
 
-## Outcome
+## 결과
 
-The workshop README diagram assets were regenerated without changing README
-links. ERD images no longer show `init:` or `themeVariables` pseudo-tables.
-Class diagrams use wider vertical spacing so inheritance arrows keep visible
-stems.
+Workshop README diagram asset은 README link 변경 없이 다시 생성됐다. ERD image는 더
+이상 `init:`나 `themeVariables` pseudo-table을 보여 주지 않는다. Class diagram은
+inheritance arrow stem이 보이도록 더 넓은 vertical spacing을 사용한다.
 
-## Verification
+## 검증
 
 - Full regeneration: `rendered=294`, `missing=[]`.
 - README image links: `missing=0`.
@@ -28,20 +26,18 @@ stems.
 - `init`/theme ERD residue: `0`.
 - Whitespace check: `git diff --check`.
 
-## Future Guidance
+## 향후 지침
 
-For ERDs, treat renderer config blocks as non-domain metadata. For small ERDs,
-compact output is acceptable when text remains readable and no relation is
-hidden.
+ERD에서는 renderer config block을 non-domain metadata로 취급한다. 작은 ERD에서는 text가
+읽히고 relation이 숨겨지지 않는다면 compact output을 허용할 수 있다.
 
-## 2026-05-20 Class Routing Follow-up
+## 2026-05-20 Class routing follow-up
 
-`03-exposed-basic-class-01` was rebuilt from the current `UserCities` shared
-sample instead of preserving the old compact two-entity snapshot. The corrected
-diagram includes `CountryTable`, `CityTable`, `UserTable`, `UserToCityTable`,
-`Country`, `City`, and `User`, with table/entity mapping lanes and a routed
-bridge lane for the many-to-many relationship.
+`03-exposed-basic-class-01`은 오래된 compact two-entity snapshot을 보존하지 않고 현재
+`UserCities` shared sample에서 다시 만들었다. 수정된 diagram은 `CountryTable`,
+`CityTable`, `UserTable`, `UserToCityTable`, `Country`, `City`, `User`를 포함하며,
+table/entity mapping lane과 many-to-many relationship을 위한 routed bridge lane을
+갖는다.
 
-Future class diagrams should prefer source-verified relationship clusters over
-symmetrical two-by-two layouts when the source has a bridge table or extra
-parent entity.
+Source에 bridge table이나 추가 parent entity가 있다면 향후 class diagram은 대칭적인
+two-by-two layout보다 source-verified relationship cluster를 우선한다.

--- a/docs/lessons/2026-05-20-readme-diagram-layout-fixes.md
+++ b/docs/lessons/2026-05-20-readme-diagram-layout-fixes.md
@@ -1,19 +1,23 @@
-# README Diagram Layout Fixes
+# README diagram layout 수정
 
-## Context
+## 배경
 
-Follow-up visual QA found two layout defects in generated README diagrams:
+Follow-up visual QA에서 생성된 README diagram의 layout defect 두 가지를 찾았다.
 
-- some architecture connectors were rendered as very short line segments where only the arrow head was visible
-- sequence participant header labels were vertically biased toward the top of the header box
+- 일부 architecture connector는 arrow head만 보일 정도로 매우 짧은 line segment로 rendering됐다.
+- sequence participant header label은 header box의 위쪽으로 치우쳐 있었다.
 
-A related sequence issue was also fixed: self-calls previously rendered as zero-length arrows, which looked like a standalone arrow head.
+관련 sequence 문제도 함께 수정했다. self-call이 이전에는 zero-length arrow로 rendering되어
+독립된 arrow head처럼 보였기 때문이다.
 
-## Decision
+## 결정
 
-Keep the existing diagram style and update only geometry in the generated SVG/PNG assets. Architecture connector line segments must span the visible gap between adjacent cards. Sequence participant labels must use the same vertical-centering baseline as architecture cards. Sequence self-calls should render as a small loop instead of a zero-length line.
+기존 diagram style은 유지하고 generated SVG/PNG asset의 geometry만 갱신한다.
+Architecture connector line segment는 인접 card 사이의 visible gap을 가로질러야 한다.
+Sequence participant label은 architecture card와 같은 vertical-centering baseline을
+사용해야 한다. Sequence self-call은 zero-length line 대신 작은 loop로 rendering해야 한다.
 
-## Verification
+## 검증
 
 - README image link check: missing=0, localSvgImageLinks=0, mermaidResidue=0
 - PNG/SVG shape check: shapeCandidates=0
@@ -21,8 +25,10 @@ Keep the existing diagram style and update only geometry in the generated SVG/PN
 - sequence header alignment check: seqTop=0
 - sequence zero-length arrow check: zeroSeq=0
 - `git diff --check`
-- visual samples reviewed for exposed root architecture and representative sequence diagrams
+- exposed root architecture와 대표 sequence diagram의 visual sample을 검토했다.
 
-## Future Guidance
+## 향후 지침
 
-Treat arrow head-only connectors as a failed rendering even when the SVG is syntactically valid. Geometry checks should cover architecture connector length, sequence header baseline, and sequence self-call arrows before PR creation.
+SVG가 문법적으로 유효하더라도 arrow head-only connector는 rendering 실패로 취급한다.
+PR 생성 전에 geometry check가 architecture connector length, sequence header baseline,
+sequence self-call arrow를 다루도록 한다.

--- a/docs/lessons/2026-05-20-readme-overview-visual-placement.md
+++ b/docs/lessons/2026-05-20-readme-overview-visual-placement.md
@@ -1,38 +1,39 @@
-# 2026-05-20 — README overview visual placement
+# 2026-05-20 — README overview visual 배치
 
-## Context
+## 배경
 
-README diagrams and charts need to be treated as source-backed documentation,
-not as decorative generated assets. The current pass used the 2026 reference
-documents and the shared README diagram style guide, but source code and build
-layout remained the authority for module names and grouping.
+README diagram과 chart는 decorative generated asset이 아니라 source-backed
+documentation으로 취급해야 한다. 이번 pass는 2026 reference document와 shared README
+diagram style guide를 사용했지만, module name과 grouping의 권위는 source code와 build
+layout에 두었다.
 
-## Decision
+## 결정
 
-Add English-only SVG+PNG README overview visuals for the root README and place
-the overview diagram before installation, usage, or build instructions. Move
-existing Architecture/Diagram sections upward when they were appended after
-usage examples.
+Root README용 English-only SVG+PNG README overview visual을 추가하고, overview diagram을
+installation, usage, build instruction보다 앞에 둔다. 기존 Architecture/Diagram section이
+usage example 뒤에 추가돼 있었다면 위로 옮긴다.
 
-## Outcome
+## 결과
 
-`exposed-workshop` now has a root README overview diagram and module composition chart, and
-its README visual placement follows the overview-first rule. Generated labels
-avoid localized text inside the images.
+`exposed-workshop`에는 이제 root README overview diagram과 module composition chart가
+있고, README visual placement는 overview-first rule을 따른다. Generated label은 image
+안에서 localized text를 피한다.
 
-## Verification
+## 검증
 
-- Generated SVG files parsed with `xmllint --noout`.
-- Generated PNG files rendered with `rsvg-convert`.
-- Workspace README image-link scan reported zero missing local images.
-- Workspace Architecture/Diagram ordering scan reported zero remaining sections
-  behind Installation, Usage, Examples, or Build headings.
-- Generated root overview SVG text contained no non-ASCII characters.
+- Generated SVG file은 `xmllint --noout`으로 parse했다.
+- Generated PNG file은 `rsvg-convert`로 rendering했다.
+- Workspace README image-link scan은 missing local image 0건을 보고했다.
+- Workspace Architecture/Diagram ordering scan은 Installation, Usage, Examples,
+  Build heading 뒤에 남은 section 0건을 보고했다.
+- Generated root overview SVG text에는 non-ASCII character가 없었다.
 
-## Future Note
+## 향후 참고
 
-Do not append architecture diagrams to the end of README files. Keep overview
-or architecture diagrams near the top, then place class, sequence, ERD, or flow
-diagrams beside the section they explain.
+Architecture diagram을 README 파일 끝에 붙이지 않는다. Overview 또는 architecture
+diagram은 상단 근처에 두고, class, sequence, ERD, flow diagram은 설명하는 section
+옆에 둔다.
 
-Root overview diagrams and composition charts place BOM first when present and Examples or Additional examples last when present; middle groups keep the source-backed orientation order unless a repo-specific README calls for alphabetic grouping.
+Root overview diagram과 composition chart는 BOM이 있으면 먼저 배치하고, Examples 또는
+Additional examples가 있으면 마지막에 둔다. 가운데 group은 repo-specific README가
+alphabetic grouping을 요구하지 않는 한 source-backed orientation order를 유지한다.

--- a/docs/lessons/2026-05-20-source-verified-readme-diagrams.md
+++ b/docs/lessons/2026-05-20-source-verified-readme-diagrams.md
@@ -1,17 +1,20 @@
-# Source-Verified README Diagrams
+# Source-verified README diagram
 
-## Context
+## 배경
 
-High-performance cache strategy class diagrams used the old `entityTable` property name.
+High-performance cache strategy class diagram이 오래된 `entityTable` property name을
+사용했다.
 
-## Decision
+## 결정
 
-Update diagram members to the current `table` override used by JDBC and coroutine cache repositories.
+Diagram member를 JDBC와 coroutine cache repository가 사용하는 현재 `table` override로
+갱신한다.
 
-## Verification
+## 검증
 
-Confirm repository source declarations before rerendering README diagram PNGs.
+README diagram PNG를 다시 rendering하기 전에 repository source declaration을 확인한다.
 
-## Future Guidance
+## 향후 지침
 
-Class diagrams should show current public/override members only. Do not preserve stale member names from historical refactoring plans.
+Class diagram에는 현재 public/override member만 표시한다. 과거 refactoring plan에서 온
+오래된 member name을 보존하지 않는다.


### PR DESCRIPTION
## Summary

Localizes the early `docs/lessons` decision records dated 2026-05-13 through 2026-05-20 into Korean.

## Scope

- Rewrites single-language lessons prose and headings in Korean.
- Preserves commands, issue numbers, repository paths, class names, artifact coordinates, and validation evidence.
- Keeps bilingual README/manual assets and LLM-facing operating documents outside the change.

## Validation

- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-172-korean-benchmark-reports --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `git diff --check`

Closes #173.

## DoD Status

- [x] Single-language lessons prose localized to Korean.
- [x] Scope exclusions enforced by audit guard.
- [x] Whitespace validation passed.
