### PR TITLE
Localize integration lessons records

### DIFF
--- a/docs/lessons/2026-05-21-class-diagram-hierarchy.md
+++ b/docs/lessons/2026-05-21-class-diagram-hierarchy.md
@@ -1,23 +1,29 @@
-# Class Diagram Hierarchy Audit
+# Class diagram hierarchy 감사
 
-## Context
+## 배경
 
-README class diagrams can become misleading when Mermaid-to-SVG conversion preserves a layout where inheritance or implementation arrows point downward to parent contracts.
+Mermaid-to-SVG 변환이 inheritance 또는 implementation arrow가 parent contract를 향해
+아래로 향하는 layout을 보존하면 README class diagram이 오해를 줄 수 있다.
 
-## Decision
+## 결정
 
-Keep interface, abstract, and base contract nodes above their implementors or subclasses when an inheritance or implementation edge exists. Re-route those edges as orthogonal paths so the open-triangle marker lands on the parent node.
+Inheritance 또는 implementation edge가 있으면 interface, abstract, base contract node를
+implementor나 subclass보다 위에 둔다. Open-triangle marker가 parent node에 닿도록 해당
+edge를 orthogonal path로 다시 routing한다.
 
-## Outcome
+## 결과
 
-Exposed workshop README class diagram assets were re-laid out top-down and PNGs were regenerated from the corrected SVG sources.
+Exposed workshop README class diagram asset은 top-down으로 다시 배치했고, 수정된 SVG
+source에서 PNG를 다시 생성했다.
 
-## Verification
+## 검증
 
-- Scanned all workspace class SVGs for downward `inheritLine` and `implLine` endpoints: `COUNT 0`.
-- Re-rendered changed PNG assets with `rsvg-convert`.
-- Validated changed SVG files with `xmllint --noout`.
+- 모든 workspace class SVG에서 downward `inheritLine`, `implLine` endpoint를 검사했다: `COUNT 0`.
+- 변경된 PNG asset을 `rsvg-convert`로 다시 rendering했다.
+- 변경된 SVG file을 `xmllint --noout`으로 검증했다.
 
-## Future Guidance
+## 향후 지침
 
-Before publishing README class diagrams, run an inheritance-direction scan against `docs/images/readme-diagrams/*class*.svg` and visually inspect at least one rendered PNG from each changed diagram family.
+README class diagram을 publish하기 전에 `docs/images/readme-diagrams/*class*.svg`에 대해
+inheritance-direction scan을 실행하고, 변경된 diagram family마다 rendered PNG를 최소
+하나씩 시각적으로 확인한다.

--- a/docs/lessons/2026-05-22-issue-52-schema-per-tenant.md
+++ b/docs/lessons/2026-05-22-issue-52-schema-per-tenant.md
@@ -1,39 +1,38 @@
-# Issue 52 Schema-per-Tenant Example
+# Issue 52 Schema-per-tenant 예제
 
-## Context
+## 배경
 
-Chapter 10 needed a schema-per-tenant Spring Boot example that uses one shared
-database pool and proves tenant isolation without relying on datasource routing.
-README policy also requires committed Architecture Diagram PNG images for every
-example.
+10장에는 하나의 shared database pool을 사용하고 datasource routing에 기대지 않고
+tenant isolation을 증명하는 schema-per-tenant Spring Boot 예제가 필요했다. README
+정책도 모든 예제에 committed Architecture Diagram PNG image를 요구한다.
 
-## Decision
+## 결정
 
-Keep tenant input as a closed whitelist (`acme`, `globex`) and map it to
-validated schema identifiers (`TENANT_ACME`, `TENANT_GLOBEX`). Place schema
-switching only inside `TenantTransaction`, reset every transaction to `PUBLIC`,
-roll back before evicting a Hikari connection if reset fails, and preserve
-rollback/eviction secondary failures with `addSuppressed`. Treat reset failure
-after successful work as rollback-worthy to avoid schema leakage.
+Tenant input은 closed whitelist(`acme`, `globex`)로 유지하고, 검증된 schema
+identifier(`TENANT_ACME`, `TENANT_GLOBEX`)로 mapping한다. Schema switching은
+`TenantTransaction` 안에만 두고, 모든 transaction을 `PUBLIC`으로 reset한다. Reset이
+실패하면 Hikari connection을 evict하기 전에 rollback하고, rollback/eviction secondary
+failure는 `addSuppressed`로 보존한다. 성공한 작업 이후 reset failure도 schema leakage를
+막기 위해 rollback-worthy로 취급한다.
 
-## Outcome
+## 결과
 
-Added `10-multi-tenant/04-schema-per-tenant-spring-web` with servlet header
-validation, Exposed JDBC repository access, schema setup/seed data, failure
-handling, README pairs, committed SVG+PNG diagrams, and examples workflow
-coverage. Chapter and root README indexes now include the new module.
+Servlet header validation, Exposed JDBC repository access, schema setup/seed data,
+failure handling, README pair, committed SVG+PNG diagram, examples workflow coverage를
+갖춘 `10-multi-tenant/04-schema-per-tenant-spring-web`를 추가했다. Chapter와 root
+README index도 새 모듈을 포함한다.
 
-## Verification
+## 검증
 
 - `./gradlew :04-schema-per-tenant-spring-web:test --stacktrace --continue`
   passed with 15 tests.
-- Architecture and sequence PNGs were rendered from SVG and visually opened to
-  confirm labels are dark and readable on light boxes.
+- Architecture/sequence PNG는 SVG에서 rendering한 뒤 직접 열어 light box 위 label이
+  어둡고 읽을 수 있음을 확인했다.
 - Spec/plan Claude advisor gate passed with `P0=0`, `P1=0` in
   `.omx/artifacts/claude-issue-52-spec-plan-advisor-stdin-6min-20260522215325.md`.
 
-## Future Notes
+## 향후 참고
 
-Do not use Hikari proxy object identity as proof of physical connection reuse;
-checkout proxies can differ even when the pool has one physical connection.
-For H2 examples, record `SESSION_ID()` when tests need same-session evidence.
+Physical connection reuse의 증거로 Hikari proxy object identity를 사용하지 않는다. Pool에
+physical connection이 하나뿐이어도 checkout proxy는 달라질 수 있다. H2 예제에서
+same-session evidence가 필요하면 `SESSION_ID()`를 기록한다.

--- a/docs/lessons/2026-05-22-issue-53-database-per-tenant.md
+++ b/docs/lessons/2026-05-22-issue-53-database-per-tenant.md
@@ -1,37 +1,37 @@
-# Issue 53 Database-per-Tenant Example
+# Issue 53 Database-per-tenant 예제
 
-## Context
+## 배경
 
-Issue #53 required a chapter 10 Spring MVC example that routes each tenant to a
-dedicated datasource/database instead of switching schemas on one shared pool.
+Issue #53은 하나의 shared pool에서 schema를 switching하는 대신 각 tenant를 dedicated
+datasource/database로 routing하는 10장 Spring MVC 예제를 요구했다.
 
-## Decision
+## 결정
 
-Use a closed `TenantId` whitelist, a `TenantDatabaseRegistry` that owns one
-Hikari pool and Exposed `Database` per tenant, and explicit
-`TenantTransaction.execute {}` calls so there is no default datasource fallback.
+Closed `TenantId` whitelist, tenant마다 하나의 Hikari pool과 Exposed `Database`를
+소유하는 `TenantDatabaseRegistry`, 그리고 default datasource fallback이 없도록 명시적인
+`TenantTransaction.execute {}` 호출을 사용한다.
 
-## Outcome
+## 결과
 
-Added `10-multi-tenant/05-database-per-tenant-spring-web` with English/Korean
-READMEs, architecture and sequence PNG diagrams, focused tests for isolation,
-rollback, config rejection, lifecycle close, and servlet-thread context cleanup.
-The selected examples workflow now builds the new module.
+English/Korean README, architecture/sequence PNG diagram, isolation, rollback,
+config rejection, lifecycle close, servlet-thread context cleanup을 검증하는 focused
+test를 갖춘 `10-multi-tenant/05-database-per-tenant-spring-web`를 추가했다. Selected
+examples workflow도 새 모듈을 build한다.
 
-## Verification
+## 검증
 
 - `./gradlew :05-database-per-tenant-spring-web:build --stacktrace --continue`
   passed with 14 tests.
 - `actionlint .github/workflows/examples.yml` passed.
 - `./gradlew projects --quiet` lists `:05-database-per-tenant-spring-web`.
-- README scan confirmed Architecture Diagram PNG links, no Mermaid, and existing
-  PNG files.
+- README scan으로 Architecture Diagram PNG link, Mermaid 없음, 기존 PNG file 존재를
+  확인했다.
 - Claude Step 6-R rerun:
   `.omx/artifacts/claude-issue-53-code-review-rerun-stdin-6min-20260523002013.md`
   reported `P0=0, P1=0, P2=0`.
 
-## Future Agents
+## 향후 agent 지침
 
-ThreadLocal cleanup tests must observe the servlet/filter thread, not the JUnit
-client thread. For tenant datasource examples, close partially-created pools on
-registry initialization failure and wire Spring bean shutdown explicitly.
+ThreadLocal cleanup test는 JUnit client thread가 아니라 servlet/filter thread를 관찰해야
+한다. Tenant datasource 예제에서는 registry initialization failure가 발생하면
+부분적으로 생성된 pool을 닫고 Spring bean shutdown을 명시적으로 wiring한다.

--- a/docs/lessons/2026-05-22-issue-57-spring-architecture-pair.md
+++ b/docs/lessons/2026-05-22-issue-57-spring-architecture-pair.md
@@ -1,23 +1,23 @@
-# Issue 57 Spring Architecture Pair
+# Issue 57 Spring architecture pair
 
-## Context
+## 배경
 
-Issue #57 is a chapter 12 epic. WIP limits require completing one child lane at a
-time; the existing state already had the Ktor side of issue #58.
+Issue #57은 12장 epic이다. WIP limit 때문에 child lane을 한 번에 하나씩 완료해야 했고,
+기존 상태에는 이미 issue #58의 Ktor 쪽 구현이 있었다.
 
-## Decision
+## 결정
 
-Add the Spring Boot 4 application architecture pair as
-`12-production-integration/02-spring-application-architecture` instead of
-starting another topic. Keep the shape parallel to the Ktor module: HTTP layer,
-service validation, Exposed repository, H2/Hikari persistence, and focused tests.
+다른 topic을 시작하지 않고 Spring Boot 4 application architecture pair를
+`12-production-integration/02-spring-application-architecture`로 추가한다. HTTP layer,
+service validation, Exposed repository, H2/Hikari persistence, focused test 구성을 Ktor
+모듈과 나란히 유지한다.
 
-## Outcome
+## 결과
 
-Chapter 12 now has a paired Spring/Ktor architecture topic plus chapter-level
-README files that mark later production-integration topics as planned work.
+12장은 이제 paired Spring/Ktor architecture topic과 이후 production-integration topic을
+planned work로 표시하는 chapter-level README file을 갖는다.
 
-## Verification
+## 검증
 
 - `./gradlew projects --no-daemon` registered
   `:02-spring-application-architecture`.
@@ -37,12 +37,11 @@ README files that mark later production-integration topics as planned work.
 - `actionlint .github/workflows/examples.yml` passed.
 - `git diff --check` passed.
 - `:02-spring-application-architecture:detekt` is not registered.
-- Claude CLI P0/P1 advisor review returned no P0 and two P1 findings in
-  `ErrorAdvice`: avoid catching `Throwable` and log unexpected 5xx causes. Both
-  were fixed by handling `Exception` and logging the exception before returning
-  the sanitized response.
+- Claude CLI P0/P1 advisor review는 P0 없이 `ErrorAdvice`에서 P1 두 건을 반환했다:
+  `Throwable` catch 회피, unexpected 5xx cause logging. 둘 다 `Exception` 처리와
+  sanitized response 반환 전 exception logging으로 수정했다.
 
-## Future Guard
+## 향후 보호 장치
 
-For #59-#62, add Spring and Ktor coverage as pairs and update the chapter README
-table in the same change.
+#59-#62에서는 Spring/Ktor coverage를 pair로 추가하고 같은 변경에서 chapter README table을
+갱신한다.

--- a/docs/lessons/2026-05-22-issue-59-auth-session.md
+++ b/docs/lessons/2026-05-22-issue-59-auth-session.md
@@ -1,52 +1,49 @@
-# Issue 59 Auth Session Examples
+# Issue 59 Auth session 예제
 
-## Context
+## 배경
 
-Issue #59 asked for paired Spring Boot 4 and Ktor authentication/session examples
-in chapter 12. The user also required every example README to include an
-Architecture Diagram PNG.
+Issue #59는 12장에 paired Spring Boot 4/Ktor authentication/session 예제를 요구했다.
+사용자는 모든 예제 README에 Architecture Diagram PNG도 포함해야 한다고 요구했다.
 
-## Decision
+## 결정
 
-Keep both examples small and comparable:
+두 예제는 작고 비교 가능하게 유지한다.
 
-- Spring Boot uses `SecurityFilterChain`, repository-backed `UserDetailsService`,
-  BCrypt, and MVC controller endpoints.
-- Ktor uses `Authentication`, `Sessions`, service-level role checks, and
-  repository-owned `Dispatchers.IO` Exposed transactions.
-- Both modules seed the same `alice` and `admin` accounts and persist session
-  metadata in H2 through Exposed. Session rows store token hashes and expiry;
-  raw tokens are returned only at creation time.
+- Spring Boot는 `SecurityFilterChain`, repository-backed `UserDetailsService`, BCrypt,
+  MVC controller endpoint를 사용한다.
+- Ktor는 `Authentication`, `Sessions`, service-level role check, repository-owned
+  `Dispatchers.IO` Exposed transaction을 사용한다.
+- 두 모듈은 같은 `alice`, `admin` account를 seed하고 Exposed를 통해 session metadata를
+  H2에 저장한다. Session row는 token hash와 expiry를 저장하며 raw token은 생성 시점에만
+  반환한다.
 
-## Outcome
+## 결과
 
-Added `05-spring-auth-session` and `06-ktor-auth-session` under
-`12-production-integration`, with English/Korean README files and PNG
-architecture diagrams under `docs/images/readme-diagrams`. Updated the chapter
-12 English/Korean index README files so completed examples 01-08 are linked and
-the PNG Architecture Diagram requirement is explicit at the chapter level.
+`12-production-integration` 아래 `05-spring-auth-session`과 `06-ktor-auth-session`을
+추가하고, English/Korean README file과 `docs/images/readme-diagrams` 아래 PNG architecture
+diagram을 함께 두었다. 완료된 예제 01-08을 link하고 PNG Architecture Diagram 요구사항을
+chapter level에서 명시하도록 12장 English/Korean index README를 갱신했다.
 
-## Verification
+## 검증
 
 - `./gradlew :05-spring-auth-session:test :06-ktor-auth-session:test --stacktrace --continue`
   passed in 20s after the final stateless-session and cookie-hardening pass:
   Spring 5 tests, Ktor 8 tests.
 - README PNG check for the two new modules: `missing=0`,
   `missingArchitecture=0`, `mermaidResidue=0`.
-- IntelliJ diagnostics: build errors 0; changed Ktor repository file reports
-  problemCount 0 with stale file analysis because the file is not open.
-- Claude 6-Tier stdin review rerun found token-storage P1s, which were fixed
-  by hashing session tokens, adding one-hour expiry, and hiding raw tokens from
-  list responses.
-- A later Claude 6-Tier stdin review found that Spring Security could still
-  create a parallel `HttpSession`; the final code sets `SessionCreationPolicy.STATELESS`
-  and aligns the Ktor cookie with the one-hour session row TTL plus `SameSite=Lax`.
-- After rebasing on the chapter 12 diagram-image correction, chapter README scan
-  reported `readmes=16`, `missingPng=0`, `missingArchitecture=0`,
-  `mermaidResidue=0`, and `missingFiles=0`.
+- IntelliJ diagnostics: build error 0건. 변경된 Ktor repository file은 열려 있지 않아
+  stale file analysis 상태였지만 `problemCount 0`을 보고했다.
+- Claude 6-Tier stdin review rerun은 token-storage P1을 찾았고, session token hashing,
+  one-hour expiry 추가, list response에서 raw token 숨김으로 수정했다.
+- 이후 Claude 6-Tier stdin review는 Spring Security가 여전히 parallel `HttpSession`을
+  만들 수 있음을 찾았다. 최종 코드는 `SessionCreationPolicy.STATELESS`를 설정하고 Ktor
+  cookie를 one-hour session row TTL 및 `SameSite=Lax`와 맞춘다.
+- Chapter 12 diagram-image correction 위로 rebase한 뒤 chapter README scan은
+  `readmes=16`, `missingPng=0`, `missingArchitecture=0`, `mermaidResidue=0`,
+  `missingFiles=0`을 보고했다.
 
-## Future Notes
+## 향후 참고
 
-For future example modules, create the Architecture Diagram PNG before final
-README verification. Use additional UML diagrams only when the example has a
-flow or contract that the architecture diagram does not explain clearly.
+향후 예제 모듈에서는 최종 README 검증 전에 Architecture Diagram PNG를 먼저 만든다. 추가
+UML diagram은 architecture diagram이 명확히 설명하지 못하는 flow나 contract가 있을 때만
+사용한다.

--- a/docs/lessons/2026-05-22-issue-60-outbox-realtime.md
+++ b/docs/lessons/2026-05-22-issue-60-outbox-realtime.md
@@ -1,39 +1,38 @@
-# Issue 60 - Realtime Outbox Examples
+# Issue 60 - Realtime outbox 예제
 
-## Context
+## 배경
 
-Issue #60 adds paired Spring Boot 4 and Ktor examples for database-backed realtime
-delivery in chapter 12. The user also required every example README to include a
-PNG Architecture Diagram.
+Issue #60은 12장에 database-backed realtime delivery를 위한 paired Spring Boot 4/Ktor
+예제를 추가한다. 사용자는 모든 예제 README에 PNG Architecture Diagram도 포함해야 한다고
+요구했다.
 
-## Decision
+## 결정
 
-Use separate `07-spring-outbox-realtime` and `08-ktor-outbox-realtime` modules to
-avoid collisions with existing #59 worktree module numbers. Keep the examples
-small: persist a notification row and an outbox row in one Exposed transaction,
-then publish pending rows through an in-process SSE/WebSocket hub.
+기존 #59 worktree module number와 충돌하지 않도록 `07-spring-outbox-realtime`와
+`08-ktor-outbox-realtime` 모듈을 분리해 사용한다. 예제는 작게 유지한다. 하나의 Exposed
+transaction에서 notification row와 outbox row를 저장한 뒤, pending row를 in-process
+SSE/WebSocket hub로 publish한다.
 
-## Outcome
+## 결과
 
-The Spring example uses WebFlux Server-Sent Events for one-way notification
-delivery. The Ktor example uses WebSockets for reconnect/replay and future
-bidirectional command room. Both examples record delivery failure as outbox
-state instead of dropping the event.
+Spring 예제는 one-way notification delivery에 WebFlux Server-Sent Events를 사용한다.
+Ktor 예제는 reconnect/replay와 향후 bidirectional command room을 위해 WebSockets를
+사용한다. 두 예제 모두 event를 버리지 않고 delivery failure를 outbox state로 기록한다.
 
-## Verification
+## 검증
 
 - `./gradlew :07-spring-outbox-realtime:test :08-ktor-outbox-realtime:test --stacktrace --continue`
-- README PNG links validated by script.
-- PNG diagrams rendered from SVG and visually checked.
-- Claude advisor review initially found `P0=0 P1=4`; Spring SSE dedupe,
-  Spring/Ktor live endpoint tests, and FAILED-row README semantics were fixed.
-- Claude advisor rerun with stdin and a 6-minute timeout returned `P0=0 P1=0`.
+- README PNG link는 script로 검증했다.
+- PNG diagram은 SVG에서 rendering한 뒤 시각적으로 확인했다.
+- Claude advisor review는 처음에 `P0=0 P1=4`를 찾았다. Spring SSE dedupe,
+  Spring/Ktor live endpoint test, FAILED-row README semantics를 수정했다.
+- Claude advisor rerun은 stdin과 6-minute timeout으로 `P0=0 P1=0`을 반환했다.
 
-## Future Guard
+## 향후 보호 장치
 
-When multiple issue branches add chapter 12 modules independently, avoid reusing
-the same numeric module prefix. Reconcile final ordering only during integration.
+여러 issue branch가 12장 모듈을 독립적으로 추가할 때 같은 numeric module prefix를 재사용하지
+않는다. 최종 ordering 조정은 integration 중에만 수행한다.
 
-For Claude Code CLI advisor gates, use stdin-compatible invocation and allow at
-least five minutes for review prompts; shorter RPC/tool timeouts can kill valid
-reviews before Claude responds.
+Claude Code CLI advisor gate에서는 stdin-compatible invocation을 사용하고 review prompt에
+최소 5분을 허용한다. 더 짧은 RPC/tool timeout은 Claude가 응답하기 전에 유효한 review를
+중단시킬 수 있다.

--- a/docs/lessons/2026-05-22-issue-61-http-outbox-idempotency.md
+++ b/docs/lessons/2026-05-22-issue-61-http-outbox-idempotency.md
@@ -1,27 +1,27 @@
-# Issue 61 HTTP Outbox Idempotency Examples
+# Issue 61 HTTP outbox idempotency 예제
 
-## Context
+## 배경
 
-Issue #61 added the second paired chapter 12 production-integration topic:
-Spring Boot 4 and Ktor HTTP client outbox/idempotency examples.
+Issue #61은 두 번째 paired 12장 production-integration topic인 Spring Boot 4/Ktor HTTP
+client outbox/idempotency 예제를 추가했다.
 
-## Decision
+## 결정
 
-Persist the outbound payment record before gateway dispatch, use a unique
-idempotency key as the duplicate boundary, and keep the gateway replaceable so
-tests do not require a real external HTTP service.
+Gateway dispatch 전에 outbound payment record를 저장하고, unique idempotency key를
+duplicate boundary로 사용하며, test가 실제 external HTTP service를 요구하지 않도록 gateway를
+교체 가능하게 유지한다.
 
-## Outcome
+## 결과
 
-The Spring module uses MVC, `RestClient`, controller advice, and an Exposed JDBC
-repository. The Ktor module mirrors the contract with routes, `StatusPages`, a
-Ktor HTTP client, and blocking Exposed calls isolated behind `Dispatchers.IO`.
+Spring 모듈은 MVC, `RestClient`, controller advice, Exposed JDBC repository를 사용한다.
+Ktor 모듈은 route, `StatusPages`, Ktor HTTP client, `Dispatchers.IO` 뒤로 격리한 blocking
+Exposed call로 같은 contract를 반영한다.
 
-## Verification
+## 검증
 
-Run the two module builds and the `Examples.yml` workflow path after changes.
+변경 후 두 module build와 `Examples.yml` workflow path를 실행한다.
 
-## Future Guidance
+## 향후 지침
 
-For chapter 12 paired examples, update the chapter README, root README files,
-and `.github/workflows/examples.yml` in the same PR as the runnable modules.
+12장의 paired example에서는 runnable module과 같은 PR에서 chapter README, root README file,
+`.github/workflows/examples.yml`을 갱신한다.

--- a/docs/lessons/2026-05-22-issue-62-observability-readiness.md
+++ b/docs/lessons/2026-05-22-issue-62-observability-readiness.md
@@ -1,73 +1,67 @@
-# Issue 62 Observability Readiness
+# Issue 62 Observability readiness
 
-## Context
+## 배경
 
-Issue #62 asked for paired Spring Boot 4 and Ktor examples that demonstrate
-operational diagnostics for database-backed services.
+Issue #62는 database-backed service의 operational diagnostics를 보여 주는 paired Spring
+Boot 4/Ktor 예제를 요구했다.
 
-## Decision
+## 결정
 
-Add two focused chapter 12 modules instead of folding readiness into the
-existing Ktor architecture baseline:
+Readiness를 기존 Ktor architecture baseline에 합치지 않고 focused 12장 모듈 두 개를 추가한다.
 
 - `09-spring-observability-readiness`
 - `10-ktor-observability-readiness`
 
-Spring uses Actuator readiness groups and a custom database health contributor.
-Ktor uses an explicit `/readyz` route with `CallId`, `CallLogging`, and
-`StatusPages`.
+Spring은 Actuator readiness group과 custom database health contributor를 사용한다. Ktor는
+`CallId`, `CallLogging`, `StatusPages`를 갖춘 명시적 `/readyz` route를 사용한다.
 
-## Outcome
+## 결과
 
-Both modules persist slow-operation diagnostics through Exposed JDBC, sanitize
-and propagate `X-Request-ID`, return structured errors, and test degraded
-database readiness with in-process state.
+두 모듈은 Exposed JDBC를 통해 slow-operation diagnostics를 저장하고, `X-Request-ID`를
+sanitize/propagate하며, structured error를 반환하고, in-process state로 degraded database
+readiness를 테스트한다.
 
-README architecture sections use generated PNG diagrams under
-`docs/images/readme-diagrams/` with SVG sources kept next to them.
+README architecture section은 `docs/images/readme-diagrams/` 아래 generated PNG diagram을
+사용하고 SVG source를 옆에 보관한다.
 
-The repository guidance now requires every example README to include an
-Architecture Diagram PNG/SVG pair. Add class, sequence, ERD, or other UML-style
-diagrams when the example has relationships or flows that are not obvious from
-the architecture diagram alone.
+Repository guidance는 이제 모든 예제 README에 Architecture Diagram PNG/SVG pair를 요구한다.
+Architecture diagram만으로 관계나 flow가 명확하지 않으면 class, sequence, ERD 또는 다른
+UML-style diagram을 추가한다.
 
-## Verification
+## 검증
 
 ```bash
 ./gradlew :09-spring-observability-readiness:test :10-ktor-observability-readiness:test --stacktrace --continue
 ```
 
-Result after the Claude review fixes: Spring 6 tests passing, Ktor 6 tests
-passing with `--rerun-tasks`.
+Claude review 수정 후 결과: Spring 6 test passing, Ktor 6 test passing with
+`--rerun-tasks`.
 
-README diagram links were checked for missing local PNG targets and Mermaid
-residue after the image links were added.
+Image link 추가 후 README diagram link에서 missing local PNG target과 Mermaid residue를
+확인했다.
 
-After rebasing on current chapter 12, the modules were renumbered to 09/10,
-the chapter English/Korean index README files were updated, and the regenerated
-PNG diagrams were visually opened to confirm the title and labels match 09/10.
-The final chapter README scan reported `readmes=20`, `missingPng=0`,
-`missingArchitecture=0`, `mermaidResidue=0`, and `missingFiles=0`.
-`./gradlew projects --quiet` listed both new modules, and `git diff --check`
-passed.
+현재 12장 위로 rebase한 뒤 모듈 번호를 09/10으로 다시 매기고, chapter English/Korean
+index README file을 갱신했으며, regenerated PNG diagram을 직접 열어 title과 label이 09/10에
+맞는지 확인했다. 최종 chapter README scan은 `readmes=20`, `missingPng=0`,
+`missingArchitecture=0`, `mermaidResidue=0`, `missingFiles=0`을 보고했다.
+`./gradlew projects --quiet`는 두 새 모듈을 모두 표시했고, `git diff --check`도 통과했다.
 
-Claude 6-Tier review found one P1 and several P2/P3 issues before PR creation:
-Spring method-level parallel tests shared `DiagnosticsState`, request IDs were
-echoed without validation, Spring readiness allowed repository exceptions to
-escape, and Ktor schema initialization could be marked complete before DDL
-success. The rerun also flagged Spring framework 4xx errors and unexpected
-exceptions in the catch-all handler; those now return structured 400 responses
-or log server-side before returning a sanitized 500. These were fixed and
-covered by the final targeted test run.
+Claude 6-Tier review는 PR 생성 전에 P1 한 건과 여러 P2/P3를 찾았다. Spring
+method-level parallel test가 `DiagnosticsState`를 공유했고, request ID가 validation 없이
+echo됐으며, Spring readiness가 repository exception을 escape하게 했고, Ktor schema
+initialization은 DDL success 전에 complete로 표시될 수 있었다. Rerun은 Spring framework
+4xx error와 catch-all handler의 unexpected exception도 지적했다. 이제 이들은 structured
+400 response를 반환하거나 sanitized 500 반환 전에 server-side log를 남긴다. 모두 수정했고
+최종 targeted test run으로 검증했다.
 
-Final Claude 6-Tier rerun artifact:
+최종 Claude 6-Tier rerun artifact:
 `.omx/artifacts/claude-issue-62-code-review-6tier-stdin-6min-20260522184325.md`.
 It reported `P0=0`, `P1=0`, `P2=0`, `P3=2`, verdict `PASS`.
 
-## Future Agents
+## 향후 agent 지침
 
-Spring Boot 4 health classes live under `org.springframework.boot.health.*`, not
-the Spring Boot 3 `org.springframework.boot.actuate.health.*` package.
+Spring Boot 4 health class는 Spring Boot 3의 `org.springframework.boot.actuate.health.*`
+package가 아니라 `org.springframework.boot.health.*` 아래에 있다.
 
-Do not echo caller-supplied correlation headers directly in examples. Cap and
-sanitize them before adding them to response headers, logs, or persisted rows.
+예제에서 caller-supplied correlation header를 그대로 echo하지 않는다. Response header, log,
+persisted row에 넣기 전에 cap과 sanitize를 적용한다.

--- a/docs/lessons/2026-05-22-issue-63-chapter-12-diagram-images.md
+++ b/docs/lessons/2026-05-22-issue-63-chapter-12-diagram-images.md
@@ -1,40 +1,36 @@
-# Issue 63 Chapter 12 Diagram Images
+# Issue 63 Chapter 12 diagram image
 
-## Context
+## 배경
 
-Chapter 12 still had Mermaid diagram blocks in the Spring application
-architecture and HTTP outbox/idempotency README pairs. The current README rule
-requires example architecture diagrams to be committed as PNG images.
+12장의 Spring application architecture 및 HTTP outbox/idempotency README pair에는 아직
+Mermaid diagram block이 남아 있었다. 현재 README rule은 예제 architecture diagram을 PNG
+image로 commit할 것을 요구한다.
 
-## Decision
+## 결정
 
-Convert the remaining Mermaid blocks to committed SVG+PNG assets under
-`docs/images/readme-diagrams/` and keep README embeds pointing to PNG files only.
-The Mermaid source remains represented by the generated SVG source asset.
-Render final PNGs through Mermaid CLI/Chromium directly, not by converting
-foreignObject-heavy Mermaid SVGs with `rsvg-convert`, because that can drop text
-while leaving the boxes visible.
+남은 Mermaid block을 `docs/images/readme-diagrams/` 아래 committed SVG+PNG asset으로
+변환하고, README embed는 PNG file만 가리키게 유지한다. Mermaid source는 generated SVG
+source asset으로 대표한다. 최종 PNG는 foreignObject-heavy Mermaid SVG를 `rsvg-convert`로
+변환하지 않고 Mermaid CLI/Chromium으로 직접 rendering한다. 해당 변환은 box는 보이게 두면서
+text를 누락할 수 있기 때문이다.
 
-## Outcome
+## 결과
 
-Updated the 02/03/04 English and Korean README files to use Architecture sections
-with PNG diagram links. Added matching SVG+PNG assets for each converted
-diagram.
+02/03/04 English/Korean README file을 PNG diagram link가 있는 Architecture section으로
+갱신했다. 변환된 각 diagram에 대응되는 SVG+PNG asset을 추가했다.
 
-## Verification
+## 검증
 
 - Chapter 12 example README scan: `readmes=8`, `missingPng=0`,
   `missingArchitecture=0`, `mermaidResidue=0`, `missingFiles=0`.
 - `git diff --check` passed.
-- PNG dimensions verified with `file`/`sips` for the three new image assets.
-- Follow-up correction: visually opened the regenerated 02/03/04 PNGs and
-  confirmed dark text is visible on the light diagram boxes.
+- 새 image asset 세 개의 PNG dimension을 `file`/`sips`로 검증했다.
+- Follow-up correction: regenerated 02/03/04 PNG를 직접 열어 light diagram box 위 dark
+  text가 보이는지 확인했다.
 
-## Future Notes
+## 향후 참고
 
-When adding chapter 12 examples, commit the diagram image assets before the
-README link lands. Use Mermaid only as an intermediate source, not as the final
-README rendering surface.
-Do not treat PNG file existence or image dimensions as sufficient validation;
-open at least one generated PNG per rendering path and confirm labels are
-visible.
+12장 예제를 추가할 때 README link를 넣기 전에 diagram image asset을 먼저 commit한다.
+Mermaid는 final README rendering surface가 아니라 intermediate source로만 사용한다. PNG file
+존재나 image dimension만으로 충분한 검증으로 보지 않는다. Rendering path마다 generated PNG를
+최소 하나 열어 label이 보이는지 확인한다.

--- a/docs/lessons/2026-05-22-issue-63-chapter-12-wiring.md
+++ b/docs/lessons/2026-05-22-issue-63-chapter-12-wiring.md
@@ -1,38 +1,36 @@
-# Issue 63 Chapter 12 Wiring
+# Issue 63 Chapter 12 wiring
 
-## Context
+## 배경
 
-Issue #63 asked to make chapter 12 production integration examples discoverable
-from root documentation and explicit about verification coverage.
+Issue #63은 12장 production integration 예제를 root documentation에서 찾을 수 있게 하고
+verification coverage를 명시하라고 요구했다.
 
-## Decision
+## 결정
 
-Keep chapter 12 module registration automatic through
-`includeModules("12-production-integration", false, false)`. Wire discoverability
-through the root English/Korean README module map and keep detailed paired
-Spring/Ktor verification commands in the chapter README.
-Add chapter 12 modules 05 through 10 to `.github/workflows/examples.yml` so the
-daily Examples workflow and chapter-change PRs cover the completed examples.
+Chapter 12 module registration은 `includeModules("12-production-integration", false,
+false)`를 통해 automatic으로 유지한다. Root English/Korean README module map으로
+discoverability를 wiring하고, detailed paired Spring/Ktor verification command는 chapter
+README에 둔다. Daily Examples workflow와 chapter-change PR이 완료된 예제를 다루도록
+`.github/workflows/examples.yml`에 12장 모듈 05-10을 추가한다.
 
-## Outcome
+## 결과
 
-The root README production integration section now lists all completed chapter
-12 examples from 01 through 10. The chapter README embeds a committed PNG
-chapter architecture diagram, records local verification, Examples workflow
-coverage, CI DB matrix coverage, and the reason no separate nightly override is
-needed for the current self-contained examples.
+Root README production integration section은 이제 완료된 12장 예제 01-10을 모두 나열한다.
+Chapter README는 committed PNG chapter architecture diagram을 embed하고, local
+verification, Examples workflow coverage, CI DB matrix coverage, 현재 self-contained
+예제에 별도 nightly override가 필요 없는 이유를 기록한다.
 
-## Verification
+## 검증
 
-Run the root README link scan and the chapter 12 README diagram scan after the
-documentation edit. Confirm Gradle project discovery with `./gradlew projects`
-or a settings scan before opening the PR.
+Documentation edit 후 root README link scan과 chapter 12 README diagram scan을 실행한다.
+PR을 열기 전에 `./gradlew projects` 또는 settings scan으로 Gradle project discovery를
+확인한다.
 
-## Future Agents
+## 향후 agent 지침
 
-When adding a new chapter 12 example, update both the chapter README pair and
-the root README pair. Keep Architecture Diagram PNG links committed, and add
-workflow-specific entries only when the new example requires external
-infrastructure or non-default CI coverage. Regenerate
-`docs/images/readme-diagrams/12-production-integration-architecture-01.svg` and
-its PNG when the chapter-level module map changes.
+새 12장 예제를 추가할 때 chapter README pair와 root README pair를 모두 갱신한다.
+Architecture Diagram PNG link는 committed 상태로 유지하고, 새 예제가 external
+infrastructure나 non-default CI coverage를 요구할 때만 workflow-specific entry를 추가한다.
+Chapter-level module map이 바뀌면
+`docs/images/readme-diagrams/12-production-integration-architecture-01.svg`와 그 PNG를
+다시 생성한다.

--- a/docs/lessons/2026-05-22-issue-70-routing-datasource-lifecycle.md
+++ b/docs/lessons/2026-05-22-issue-70-routing-datasource-lifecycle.md
@@ -1,35 +1,33 @@
-# Issue 70 Routing Datasource Lifecycle
+# Issue 70 Routing datasource lifecycle
 
-## Context
+## 배경
 
-Issue #70 reported that the chapter 11 routing datasource example created
-tenant Hikari pools but did not give Spring a deterministic shutdown hook.
+Issue #70은 11장 routing datasource 예제가 tenant Hikari pool을 만들지만 Spring에
+deterministic shutdown hook을 주지 않는다고 보고했다.
 
-## Decision
+## 결정
 
-Make `DataSourceRegistry` `AutoCloseable` and let `InMemoryDataSourceRegistry`
-own shutdown for currently registered closeable data sources. Deduplicate by
-identity so a shared datasource registered under multiple keys is closed once.
-Document that replacing an existing key does not close the old datasource.
+`DataSourceRegistry`를 `AutoCloseable`로 만들고, `InMemoryDataSourceRegistry`가 현재
+등록된 closeable data source의 shutdown을 소유하게 한다. 여러 key 아래 등록된 shared
+datasource가 한 번만 close되도록 identity 기준으로 deduplicate한다. 기존 key를 교체해도 old
+datasource를 닫지 않는다는 점을 문서화한다.
 
-## Outcome
+## 결과
 
-The TODO in `RoutingDataSourceConfig` was removed. The routing datasource example
-now closes registry-owned Hikari pools during Spring shutdown, and `Examples.yml`
-builds the routing module together with selected chapter 12 examples. The
-workflow disables Gradle configuration cache for this mixed example build because
-the routing module's GraalVM AOT tasks triggered a local configuration-cache
-serialization failure.
+`RoutingDataSourceConfig`의 TODO를 제거했다. Routing datasource 예제는 이제 Spring
+shutdown 중 registry-owned Hikari pool을 닫고, `Examples.yml`은 selected chapter 12 예제와
+함께 routing module을 build한다. Routing module의 GraalVM AOT task가 local
+configuration-cache serialization failure를 유발했기 때문에 이 mixed example build에서는
+Gradle configuration cache를 비활성화한다.
 
-## Verification
+## 검증
 
 - `actionlint .github/workflows/examples.yml`
 - `./gradlew :03-routing-datasource:test --no-daemon` — 29 passing
 - `./gradlew :03-routing-datasource:build :01-ktor-application-architecture:build :02-spring-application-architecture:build :03-spring-http-outbox-idempotency:build :04-ktor-http-outbox-idempotency:build --no-daemon --no-configuration-cache --continue`
 - Claude advisor artifact: `.omx/artifacts/ask-claude-code-review-issue-70-routing-datasource-final2-20260522103201.md` — P0=0, P1=0
 
-## Future Guard
+## 향후 보호 장치
 
-When adding example-owned pools, make the owner `AutoCloseable` and add tests
-for idempotent close, shared-instance close-once behavior, and suppressed
-exception propagation.
+Example-owned pool을 추가할 때 owner를 `AutoCloseable`로 만들고 idempotent close,
+shared-instance close-once behavior, suppressed exception propagation을 테스트한다.

--- a/docs/lessons/2026-05-23-dependencies-1-1-1-sync.md
+++ b/docs/lessons/2026-05-23-dependencies-1-1-1-sync.md
@@ -1,31 +1,28 @@
-# Dependencies 1.1.1 Sync
+# Dependencies 1.1.1 동기화
 
-## Context
+## 배경
 
-`bluetape4k-dependencies` 1.1.0 was superseded by 1.1.1 after the artifact
-availability audit found generated aliases for non-published mock web
-application modules. This workshop consumes the shared catalog and should stay
-aligned with the release train.
+Artifact availability audit가 publish되지 않은 mock web application module의 generated
+alias를 찾은 뒤 `bluetape4k-dependencies` 1.1.0은 1.1.1로 대체됐다. 이 workshop은 shared
+catalog를 소비하므로 release train과 정렬돼 있어야 한다.
 
-## Decision
+## 결정
 
-Consume `bluetape4k-dependencies = "1.1.1"` through the standard shared-version
-sync path. Do not add workshop-local overrides for artifacts that the central
-catalog has already removed.
+Standard shared-version sync path를 통해 `bluetape4k-dependencies = "1.1.1"`을 소비한다.
+Central catalog가 이미 제거한 artifact에 대해 workshop-local override를 추가하지 않는다.
 
-## Outcome
+## 결과
 
-PR #96 aligned this repository to the 1.1.1 catalog and merged after CI passed.
+PR #96은 이 repository를 1.1.1 catalog와 정렬했고 CI 통과 후 merge됐다.
 
-## Verification
+## 검증
 
-- GitHub PR #96 status checks passed before merge.
+- GitHub PR #96 status check는 merge 전에 통과했다.
 - Workspace-level `scripts/sync-shared-versions.py --workspace .. --check --summary`
   passed after the downstream PRs were merged.
 
-## Future Guidance
+## 향후 지침
 
-When the shared catalog patch fixes publication availability, wait until Maven
-Central `repo1` resolves the new version before rerunning downstream CI. Keep
-workshop dependency drift fixes in the catalog whenever they affect multiple
-bluetape4k repositories.
+Shared catalog patch가 publication availability를 수정할 때는 Maven Central `repo1`이 새
+version을 resolve할 때까지 기다린 뒤 downstream CI를 다시 실행한다. 여러 bluetape4k
+repository에 영향을 주는 workshop dependency drift fix는 catalog에 유지한다.

--- a/docs/lessons/2026-05-23-issue-54-spring-security-tenant-authorization.md
+++ b/docs/lessons/2026-05-23-issue-54-spring-security-tenant-authorization.md
@@ -1,42 +1,39 @@
-# Issue 54 Spring Security Tenant Authorization
+# Issue 54 Spring Security tenant authorization
 
-## Context
+## 배경
 
-Chapter 10 needed a Spring Security multi-tenant example where the selected
-tenant is authorized from authenticated identity, not trusted from
-`X-Tenant-ID` alone.
+10장에는 선택된 tenant를 `X-Tenant-ID`만으로 신뢰하지 않고 authenticated identity에서
+authorize하는 Spring Security multi-tenant 예제가 필요했다.
 
-## Decision
+## 결정
 
-Add a dedicated Spring Web example module that accepts three demo credential
-sources: JWT bearer token, API key, and demo session header. The module rejects
-mixed credential sources, resolves the authenticated tenant before selector
-validation, binds `TenantContext` only after tenant match, and clears the
-context in `finally`.
+JWT bearer token, API key, demo session header라는 세 가지 demo credential source를
+받는 dedicated Spring Web 예제 모듈을 추가한다. 이 모듈은 mixed credential source를
+거부하고, selector validation 전에 authenticated tenant를 resolve하며, tenant match 이후에만
+`TenantContext`를 bind하고 `finally`에서 context를 지운다.
 
-Architecture diagrams remain PNG-first in README files, with SVG sources stored
-under `docs/images/readme-diagrams/`.
+Architecture diagram은 README file에서 PNG-first로 유지하고, SVG source는
+`docs/images/readme-diagrams/` 아래에 저장한다.
 
-## Outcome
+## 결과
 
-The new module includes English/Korean README files, architecture and request
-flow PNG diagrams, selected examples CI wiring, and 30 tests covering auth,
-tenant mismatch, malformed claims/selectors, cross-tenant isolation, context
-cleanup, rollback, registry lifecycle, and source-text architecture guards.
+새 모듈에는 English/Korean README file, architecture/request flow PNG diagram, selected
+examples CI wiring, 그리고 auth, tenant mismatch, malformed claims/selectors,
+cross-tenant isolation, context cleanup, rollback, registry lifecycle,
+source-text architecture guard를 다루는 30개 test가 포함된다.
 
-## Verification
+## 검증
 
 - `./gradlew :06-spring-security-tenant-authorization-spring-web:build --stacktrace --continue --console=plain`
 - `actionlint .github/workflows/examples.yml`
 - `git diff --check`
-- README scan confirmed no Mermaid in the new module README files.
-- Diagram assets were rendered as 1280x760 RGB PNGs and visually inspected.
-- Claude advisor/code-review artifacts reached `P0=0, P1=0`, final artifact:
+- README scan으로 새 module README file에 Mermaid가 없음을 확인했다.
+- Diagram asset은 1280x760 RGB PNG로 rendering하고 시각적으로 검사했다.
+- Claude advisor/code-review artifact는 `P0=0, P1=0`에 도달했다. Final artifact:
   `.omx/artifacts/claude-issue-54-code-review-final-stdin-6min-20260523013657.md`.
 
-## Future Guidance
+## 향후 지침
 
-For security examples, review health endpoint bypass behavior against both
-custom filters and `SecurityFilterChain` authorization rules. When demo auth
-fixtures are intentionally insecure, make the production boundary explicit in
-KDoc and README text.
+Security 예제에서는 custom filter와 `SecurityFilterChain` authorization rule 양쪽에서
+health endpoint bypass behavior를 검토한다. Demo auth fixture가 의도적으로 insecure하다면
+KDoc과 README text에 production boundary를 명시한다.

--- a/docs/lessons/2026-05-24-dependencies-1-1-3-sync.md
+++ b/docs/lessons/2026-05-24-dependencies-1-1-3-sync.md
@@ -1,31 +1,29 @@
-# Dependencies 1.1.3 Sync
+# Dependencies 1.1.3 동기화
 
-## Context
+## 배경
 
-`exposed-workshop` was still consuming `bluetape4k-dependencies = "1.1.1"`.
-The published release tag `bluetape4k-dependencies` `1.1.3` is the catalog
-baseline for downstream sync; the local post-release branch may already carry
-the next development version.
+`exposed-workshop`은 아직 `bluetape4k-dependencies = "1.1.1"`을 소비하고 있었다.
+Published release tag `bluetape4k-dependencies` `1.1.3`은 downstream sync의 catalog
+baseline이며, local post-release branch는 이미 다음 development version을 담고 있을 수 있다.
 
-## Decision
+## 결정
 
-Keep `bluetape4k-dependencies` as the only bluetape4k BOM source and update the
-catalog version to `1.1.3`. Do not add direct `bluetape4k-bom`,
-`bluetape4k-exposed-bom`, or per-example JetBrains Exposed BOM imports; example
-modules should consume the versions already managed by the root dependency
-management setup.
+`bluetape4k-dependencies`를 유일한 bluetape4k BOM source로 유지하고 catalog version을
+`1.1.3`으로 갱신한다. Direct `bluetape4k-bom`, `bluetape4k-exposed-bom`, per-example
+JetBrains Exposed BOM import는 추가하지 않는다. Example module은 root dependency management
+setup이 이미 관리하는 version을 소비해야 한다.
 
-## Outcome
+## 결과
 
-The local catalog now resolves bluetape4k and bluetape4k-exposed versions
-through `io.github.bluetape4k:bluetape4k-dependencies:1.1.3`, and example
-modules no longer import `libs.jetbrains.exposed.bom` directly.
+Local catalog는 이제 `io.github.bluetape4k:bluetape4k-dependencies:1.1.3`을 통해
+bluetape4k와 bluetape4k-exposed version을 resolve하고, example module은 더 이상
+`libs.jetbrains.exposed.bom`을 직접 import하지 않는다.
 
-- `git show 1.1.3:gradle/libs.versions.toml` confirmed the tag catalog declares
-  `bluetape4k-dependencies = "1.1.3"`.
-- `rg` over Gradle files found no direct `libs.jetbrains.exposed.bom`,
-  `libs.bluetape4k.dependencies`, `bluetape4k-bom`, or
-  `bluetape4k-exposed-bom` usage.
+- `git show 1.1.3:gradle/libs.versions.toml`로 tag catalog가
+  `bluetape4k-dependencies = "1.1.3"`을 선언함을 확인했다.
+- Gradle file에 대한 `rg`는 direct `libs.jetbrains.exposed.bom`,
+  `libs.bluetape4k.dependencies`, `bluetape4k-bom`, `bluetape4k-exposed-bom` 사용이
+  없음을 확인했다.
 - `./gradlew -q :exposed-shared-tests:dependencyInsight --configuration compileClasspath --dependency org.jetbrains.exposed:exposed-core`
   resolved `org.jetbrains.exposed:exposed-core:1.3.0`.
 - `./gradlew compileTestKotlin --no-daemon` passed.

--- a/docs/lessons/2026-05-24-issue-109-readme-diagram-style.md
+++ b/docs/lessons/2026-05-24-issue-109-readme-diagram-style.md
@@ -1,24 +1,23 @@
-# Issue 109 README Diagram Style
+# Issue 109 README diagram style
 
-## Context
+## 배경
 
-README diagram assets included many direct Mermaid-rendered SVG/PNG pairs, and
-several newer diagrams missed the workspace typography contract.
+README diagram asset에는 Mermaid가 직접 rendering한 SVG/PNG pair가 많았고, 일부 newer
+diagram은 workspace typography contract를 지키지 않았다.
 
-## Decision
+## 결정
 
-Regenerate every README diagram asset under `docs/assets/readme-diagrams/` and
-`docs/images/readme-diagrams/` from recovered labels using deterministic
-pastel SVG templates. Keep PNG links in README files and matching SVG sources
-next to the PNG files.
+`docs/assets/readme-diagrams/`와 `docs/images/readme-diagrams/` 아래 모든 README diagram
+asset을 recovered label과 deterministic pastel SVG template로 다시 생성한다. README file의
+PNG link와 PNG 옆 matching SVG source를 유지한다.
 
-## Outcome
+## 결과
 
-Replaced Mermaid-rendered assets with custom architecture, class, sequence, and
-ERD diagrams. Large labels use Architects Daughter, detail text uses a
-Comic-style fallback stack, and connector routing stays in gaps between boxes.
+Mermaid-rendered asset을 custom architecture, class, sequence, ERD diagram으로 교체했다.
+Large label은 Architects Daughter를 사용하고, detail text는 Comic-style fallback stack을
+사용하며, connector routing은 box 사이 gap에 머문다.
 
-## Verification
+## 검증
 
 - README-linked diagram assets: `missing=0`.
 - README local SVG diagram links: `0`.
@@ -27,7 +26,7 @@ Comic-style fallback stack, and connector routing stays in gaps between boxes.
 - README diagram SVGs missing Architects Daughter: `0`.
 - PNG render files missing or tiny: `0`.
 
-## Future Guidance
+## 향후 지침
 
-Keep chart assets out of README diagram regeneration passes. Limit the target
-set to `readme-diagrams/` unless a task explicitly asks to redraw charts.
+README diagram regeneration pass에서는 chart asset을 제외한다. Task가 chart redraw를
+명시적으로 요구하지 않는 한 target set은 `readme-diagrams/`로 제한한다.

--- a/docs/lessons/2026-05-24-issue-111-source-derived-readme-diagrams.md
+++ b/docs/lessons/2026-05-24-issue-111-source-derived-readme-diagrams.md
@@ -1,23 +1,30 @@
-# Issue 111 Source-Derived README Diagrams
+# Issue 111 Source-derived README diagram
 
-## Context
+## 배경
 
-The first README diagram refresh still depended too much on existing SVG labels. That preserved stale Mermaid-like structure and allowed non-guide assets to survive.
+첫 README diagram refresh는 여전히 기존 SVG label에 과도하게 의존했다. 그 결과 stale
+Mermaid-like structure가 보존되고 non-guide asset이 남을 수 있었다.
 
-## Decision
+## 결정
 
-Regenerate README diagram assets from README context plus current Kotlin sources. Parent README diagrams must include child Gradle module sources when the parent directory has no direct source set. Localized READMEs must not drive image text; `README.md` is the preferred source for image titles and labels.
+README context와 현재 Kotlin source에서 README diagram asset을 다시 생성한다. Parent
+directory에 direct source set이 없으면 parent README diagram은 child Gradle module source를
+포함해야 한다. Localized README는 image text를 결정하지 않는다. Image title과 label에는
+`README.md`를 preferred source로 사용한다.
 
-## Outcome
+## 결과
 
-All 175 README diagram SVG/PNG pairs were regenerated with source-derived architecture panels, UML-like class sections with supertypes above concrete implementations, sequence interaction bands, and ERD table compartments with FK relationships.
+175개 README diagram SVG/PNG pair를 모두 다시 생성했다. 결과물은 source-derived architecture
+panel, concrete implementation 위에 supertype을 두는 UML-like class section, sequence
+interaction band, FK relationship을 갖춘 ERD table compartment를 포함한다.
 
-## Verification
+## 검증
 
 - `node scripts/regenerate-readme-diagrams.js`
 - README diagram audit: `missing=0`, `svgRefs=0`, `fontMissing=0`, `rawMermaid=0`, `nonEnglish=0`
 - `git diff --check`
 
-## Future Guidance
+## 향후 지침
 
-Do not repair diagram assets by editing SVG text in place. Fix the source model or generator first, then regenerate SVG and PNG together.
+SVG text를 제자리에서 편집해 diagram asset을 수리하지 않는다. Source model 또는 generator를
+먼저 수정한 뒤 SVG와 PNG를 함께 다시 생성한다.

--- a/docs/lessons/2026-05-24-issue-46-ktor-multitenant.md
+++ b/docs/lessons/2026-05-24-issue-46-ktor-multitenant.md
@@ -1,21 +1,25 @@
-# Issue 46 Ktor Multitenant Example
+# Issue 46 Ktor multitenant 예제
 
-## Context
+## 배경
 
-Issue #46 asked for a Ktor equivalent to the chapter 10 Spring multi-tenant examples.
+Issue #46은 10장 Spring multi-tenant 예제에 대응되는 Ktor equivalent를 요구했다.
 
-## Decision
+## 결정
 
-Use a Ktor plugin for tenant header validation and a coroutine `ThreadContextElement` for request-scoped tenant binding. Keep schema switching explicit inside the Exposed repository transaction.
+Tenant header validation에는 Ktor plugin을, request-scoped tenant binding에는 coroutine
+`ThreadContextElement`를 사용한다. Schema switching은 Exposed repository transaction 안에서
+명시적으로 유지한다.
 
-## Outcome
+## 결과
 
-Added `10-multi-tenant/07-multitenant-ktor` with H2-backed tenant schemas, focused route tests, English/Korean README files, and a reusable architecture diagram.
+H2-backed tenant schema, focused route test, English/Korean README file, reusable architecture
+diagram을 갖춘 `10-multi-tenant/07-multitenant-ktor`를 추가했다.
 
-## Verification
+## 검증
 
-Passed: `repo-test-summary -- ./gradlew :07-multitenant-ktor:test` with four passing tests.
+통과: `repo-test-summary -- ./gradlew :07-multitenant-ktor:test`, passing test 4개.
 
-## Future Guidance
+## 향후 지침
 
-For Ktor tenant examples, keep tenant resolution separate from repository schema switching so tests can prove missing header, invalid tenant, cleanup, and isolation behavior independently.
+Ktor tenant 예제에서는 tenant resolution을 repository schema switching과 분리해 test가
+missing header, invalid tenant, cleanup, isolation behavior를 독립적으로 증명할 수 있게 한다.

--- a/docs/lessons/2026-05-24-issue-47-ktor-cache-strategies.md
+++ b/docs/lessons/2026-05-24-issue-47-ktor-cache-strategies.md
@@ -1,21 +1,25 @@
-# Issue 47 Ktor Cache Strategies
+# Issue 47 Ktor cache strategy
 
-## Context
+## 배경
 
-Issue #47 asked for a Ktor counterpart to the chapter 11 Spring cache strategy example.
+Issue #47은 11장 Spring cache strategy 예제에 대응되는 Ktor counterpart를 요구했다.
 
-## Decision
+## 결정
 
-Keep the example framework-neutral: Ktor routes, an application service with explicit cache strategy methods, Exposed JDBC persistence, and a simple in-memory cache that exposes hit/miss counters in tests.
+예제는 framework-neutral하게 유지한다. Ktor route, 명시적인 cache strategy method를 가진
+application service, Exposed JDBC persistence, test에서 hit/miss counter를 노출하는 simple
+in-memory cache를 사용한다.
 
-## Outcome
+## 결과
 
-Added `11-high-performance/05-cache-strategies-ktor` with cache-aside, read-through, write-through, invalidation, English/Korean README files, and a rendered architecture diagram.
+Cache-aside, read-through, write-through, invalidation, English/Korean README file, rendered
+architecture diagram을 갖춘 `11-high-performance/05-cache-strategies-ktor`를 추가했다.
 
-## Verification
+## 검증
 
-Passed: `repo-test-summary -- ./gradlew :05-cache-strategies-ktor:test` with three passing tests.
+통과: `repo-test-summary -- ./gradlew :05-cache-strategies-ktor:test`, passing test 3개.
 
-## Future Guidance
+## 향후 지침
 
-Prefer observable route responses and counters for workshop cache examples so users can see whether a scenario hit cache, missed cache, or fell back to the database.
+Workshop cache 예제에서는 사용자가 scenario의 cache hit, cache miss, database fallback 여부를
+볼 수 있도록 observable route response와 counter를 선호한다.

--- a/docs/lessons/2026-05-24-issue-48-ktor-coroutine-cache.md
+++ b/docs/lessons/2026-05-24-issue-48-ktor-coroutine-cache.md
@@ -1,21 +1,27 @@
-# Issue 48 Ktor Coroutine Cache
+# Issue 48 Ktor coroutine cache
 
-## Context
+## 배경
 
-Issue #48 asked for a Ktor coroutine cache example near the existing Spring coroutine cache module.
+Issue #48은 기존 Spring coroutine cache module 근처에 Ktor coroutine cache 예제를 요구했다.
 
-## Decision
+## 결정
 
-Use suspend route handlers, `newSuspendedTransaction(Dispatchers.IO, ...)` for JDBC work, a coroutine-friendly per-key `Mutex`, and explicit cancellation rethrowing in `StatusPages`.
+Suspend route handler, JDBC work용 `newSuspendedTransaction(Dispatchers.IO, ...)`,
+coroutine-friendly per-key `Mutex`, `StatusPages`에서 명시적인 cancellation rethrowing을
+사용한다.
 
-## Outcome
+## 결과
 
-Added `11-high-performance/06-cache-strategies-coroutines-ktor` with read-through, write-through, invalidation, concurrent request tests, English/Korean README files, and a rendered architecture diagram.
+Read-through, write-through, invalidation, concurrent request test, English/Korean README file,
+rendered architecture diagram을 갖춘 `11-high-performance/06-cache-strategies-coroutines-ktor`를
+추가했다.
 
-## Verification
+## 검증
 
-Passed: `repo-test-summary -- ./gradlew :06-cache-strategies-coroutines-ktor:test` with four passing tests, including concurrent read-through load coalescing.
+통과: `repo-test-summary -- ./gradlew :06-cache-strategies-coroutines-ktor:test`, concurrent
+read-through load coalescing을 포함해 passing test 4개.
 
-## Future Guidance
+## 향후 지침
 
-Coroutine cache examples should prove concurrent request behavior, not only sequential cache hits. Keep `runBlocking` out of production request paths.
+Coroutine cache 예제는 sequential cache hit뿐 아니라 concurrent request behavior를 증명해야
+한다. Production request path에는 `runBlocking`을 두지 않는다.

--- a/docs/lessons/2026-05-24-issue-49-ktor-routing-datasource.md
+++ b/docs/lessons/2026-05-24-issue-49-ktor-routing-datasource.md
@@ -1,21 +1,27 @@
-# Issue 49 Ktor Routing DataSource
+# Issue 49 Ktor routing DataSource
 
-## Context
+## 배경
 
-Issue #49 asked for a Ktor routing datasource example near the existing Spring routing datasource module.
+Issue #49는 기존 Spring routing datasource module 근처에 Ktor routing datasource 예제를
+요구했다.
 
-## Decision
+## 결정
 
-Use a Ktor plugin to select `READ` or `WRITE` from request method or `X-Data-Source`, then bind that role through a coroutine context element before repository access.
+Ktor plugin으로 request method 또는 `X-Data-Source`에서 `READ`나 `WRITE`를 선택하고,
+repository access 전에 coroutine context element를 통해 해당 role을 bind한다.
 
-## Outcome
+## 결과
 
-Added `11-high-performance/07-routing-datasource-ktor` with two H2-backed datasource roles, observable route responses, selection counters, English/Korean README files, and a rendered architecture diagram.
+두 H2-backed datasource role, observable route response, selection counter, English/Korean README
+file, rendered architecture diagram을 갖춘 `11-high-performance/07-routing-datasource-ktor`를
+추가했다.
 
-## Verification
+## 검증
 
-Passed: `repo-test-summary -- ./gradlew :07-routing-datasource-ktor:test` with five passing routing selection tests.
+통과: `repo-test-summary -- ./gradlew :07-routing-datasource-ktor:test`, passing routing
+selection test 5개.
 
-## Future Guidance
+## 향후 지침
 
-Routing datasource examples should expose the selected role in tests, because it is easier to verify than inferring routing from side effects.
+Routing datasource 예제는 test에서 selected role을 노출해야 한다. Side effect에서 routing을
+추론하는 것보다 검증하기 쉽기 때문이다.

--- a/docs/lessons/2026-05-24-issue-50-wire-ktor-examples.md
+++ b/docs/lessons/2026-05-24-issue-50-wire-ktor-examples.md
@@ -1,21 +1,26 @@
-# Issue 50 Wire Ktor Chapter Examples
+# Issue 50 Ktor chapter example wiring
 
-## Context
+## 배경
 
-Issue #50 asked to wire the new Ktor chapter examples into documentation and verification guidance.
+Issue #50은 새 Ktor chapter example을 documentation과 verification guidance에 연결하라고
+요구했다.
 
-## Decision
+## 결정
 
-Record the chapter 11 Ktor module links, test tasks, and CI/nightly coverage decision in both English and Korean README files. Treat the Ktor modules as H2-only examples that do not need container-backed nightly coverage.
+11장 Ktor module link, test task, CI/nightly coverage decision을 English/Korean README file에
+모두 기록한다. Ktor module은 container-backed nightly coverage가 필요 없는 H2-only 예제로
+취급한다.
 
-## Outcome
+## 결과
 
-Updated `11-high-performance/README.md` and `README.ko.md` with Ktor cache, coroutine cache, and routing datasource modules plus verification commands.
+`11-high-performance/README.md`와 `README.ko.md`에 Ktor cache, coroutine cache, routing
+datasource module 및 verification command를 추가했다.
 
-## Verification
+## 검증
 
-Passed: `git diff --check`.
+통과: `git diff --check`.
 
-## Future Guidance
+## 향후 지침
 
-Docs PRs that depend on feature PRs may reference not-yet-merged module directories, but they should clearly list the prerequisite module PRs in the PR body.
+Feature PR에 의존하는 docs PR은 아직 merge되지 않은 module directory를 참조할 수 있지만,
+PR body에 prerequisite module PR을 명확히 나열해야 한다.

--- a/docs/lessons/2026-05-24-issue-55-tenant-onboarding.md
+++ b/docs/lessons/2026-05-24-issue-55-tenant-onboarding.md
@@ -1,21 +1,25 @@
-# Issue 55 Tenant Onboarding
+# Issue 55 Tenant onboarding
 
-## Context
+## 배경
 
-Issue #55 asked for a chapter 10 tenant onboarding and provisioning example.
+Issue #55는 10장 tenant onboarding/provisioning 예제를 요구했다.
 
-## Decision
+## 결정
 
-Keep the example focused on tenant catalog persistence plus schema provisioning and cleanup, with service-level tests proving success, duplicates, and failure cleanup.
+예제는 tenant catalog persistence, schema provisioning, cleanup에 집중한다. Success,
+duplicate, failure cleanup은 service-level test로 증명한다.
 
-## Outcome
+## 결과
 
-Added `10-multi-tenant/08-tenant-onboarding-spring-web` with Spring Web wiring, Exposed schema provisioning, English/Korean README files, and a rendered architecture diagram.
+Spring Web wiring, Exposed schema provisioning, English/Korean README file, rendered architecture
+diagram을 갖춘 `10-multi-tenant/08-tenant-onboarding-spring-web`를 추가했다.
 
-## Verification
+## 검증
 
-Passed: `repo-test-summary -- ./gradlew :08-tenant-onboarding-spring-web:test` with three passing onboarding tests.
+통과: `repo-test-summary -- ./gradlew :08-tenant-onboarding-spring-web:test`, passing onboarding
+test 3개.
 
-## Future Guidance
+## 향후 지침
 
-Onboarding examples should persist catalog metadata only after provisioning succeeds, and tests should explicitly prove partial resources are removed after failure.
+Onboarding 예제는 provisioning이 성공한 뒤에만 catalog metadata를 저장해야 하며, test는 실패
+후 partial resource가 제거됨을 명시적으로 증명해야 한다.

--- a/docs/lessons/2026-05-24-issue-56-wire-chapter-10-strategies.md
+++ b/docs/lessons/2026-05-24-issue-56-wire-chapter-10-strategies.md
@@ -1,21 +1,25 @@
-# Issue 56 Wire Chapter 10 Strategies
+# Issue 56 Chapter 10 strategy wiring
 
-## Context
+## 배경
 
-Issue #56 asked to wire chapter 10 Spring Boot strategy examples into documentation and verification.
+Issue #56은 10장 Spring Boot strategy example을 documentation과 verification에 연결하라고
+요구했다.
 
-## Decision
+## 결정
 
-Add the tenant onboarding module to chapter 10 English/Korean README files with module links, test/build tasks, and a CI/nightly coverage decision.
+Tenant onboarding module을 module link, test/build task, CI/nightly coverage decision과 함께
+10장 English/Korean README file에 추가한다.
 
-## Outcome
+## 결과
 
-Updated `10-multi-tenant/README.md` and `README.ko.md` for `08-tenant-onboarding-spring-web`.
+`08-tenant-onboarding-spring-web`를 위해 `10-multi-tenant/README.md`와 `README.ko.md`를
+갱신했다.
 
-## Verification
+## 검증
 
-Passed: `git diff --check`.
+통과: `git diff --check`.
 
-## Future Guidance
+## 향후 지침
 
-Docs PRs for strategy wiring should list dependent feature PRs and record whether new modules require nightly container coverage.
+Strategy wiring docs PR은 dependent feature PR을 나열하고, 새 module이 nightly container
+coverage를 요구하는지 기록해야 한다.

--- a/docs/lessons/2026-05-24-issue-99-r2dbc-parity-audit.md
+++ b/docs/lessons/2026-05-24-issue-99-r2dbc-parity-audit.md
@@ -1,28 +1,30 @@
-# Issue 99 R2DBC Parity Audit
+# Issue 99 R2DBC parity 감사
 
-## Context
+## 배경
 
-`exposed-workshop` needed a final roadmap parity pass against `exposed-r2dbc-workshop` after the Ktor, chapter 10, and
-chapter 12 example issues were completed.
+Ktor, 10장, 12장 example issue가 완료된 뒤 `exposed-workshop`에는
+`exposed-r2dbc-workshop` 대비 최종 roadmap parity pass가 필요했다.
 
-## Decision
+## 결정
 
-Track parity by concept, not by exact module name. Blocking JDBC modules and R2DBC modules keep separate architecture
-choices when the underlying Exposed API model differs.
+Parity는 정확한 module name이 아니라 concept 기준으로 추적한다. Underlying Exposed API model이
+다르면 blocking JDBC module과 R2DBC module은 별도의 architecture choice를 유지한다.
 
-## Outcome
+## 결과
 
-The audit found no portable gaps. `README.md`, `README.ko.md`, and the research note now record which issues and modules
-cover each overlapping topic, and mark R2DBC connection-factory routing plus JDBC DAO/transaction-template/cache/benchmark
-topics as platform-specific.
+감사는 portable gap이 없음을 확인했다. `README.md`, `README.ko.md`, research note는 이제 각
+overlapping topic을 어떤 issue와 module이 다루는지 기록하고, R2DBC connection-factory
+routing 및 JDBC DAO/transaction-template/cache/benchmark topic을 platform-specific으로
+표시한다.
 
-## Verification
+## 검증
 
-- Confirmed `exposed-workshop` has only issue `#99` open.
-- Confirmed `exposed-r2dbc-workshop` has no open issues.
-- Checked closed roadmap issue sets: `exposed-workshop#45`-`#63`, `exposed-r2dbc-workshop#32`-`#49`, `#69`, and `#89`.
+- `exposed-workshop`에 열린 issue가 `#99`뿐임을 확인했다.
+- `exposed-r2dbc-workshop`에 열린 issue가 없음을 확인했다.
+- Closed roadmap issue set을 확인했다: `exposed-workshop#45`-`#63`,
+  `exposed-r2dbc-workshop#32`-`#49`, `#69`, `#89`.
 
-## Next time
+## 다음 작업
 
-When adding future example roadmap issues, first check the parity table and create counterpart issues only for portable
-teaching concepts.
+향후 example roadmap issue를 추가할 때는 parity table을 먼저 확인하고, portable teaching
+concept에 대해서만 counterpart issue를 만든다.

--- a/docs/lessons/2026-05-24-readme-diagram-policy-refresh.md
+++ b/docs/lessons/2026-05-24-readme-diagram-policy-refresh.md
@@ -1,33 +1,32 @@
-# README Diagram Policy Refresh
+# README diagram policy 갱신
 
-## Context
+## 배경
 
-The README diagram policy requires committed PNG embeds with editable SVG
-sources. README files should not keep raw Mermaid blocks, ASCII tree diagrams,
-or Mermaid renderer type names as user-facing diagram labels.
+README diagram policy는 editable SVG source를 동반한 committed PNG embed를 요구한다.
+README file은 raw Mermaid block, ASCII tree diagram, Mermaid renderer type name을
+user-facing diagram label로 유지해서는 안 된다.
 
-## Decision
+## 결정
 
-Regenerate root README diagrams from current repository structure, add a
-dedicated package-layout diagram for the Ktor chapter 12 architecture example,
-and keep README links pointing to PNG files only.
+현재 repository structure에서 root README diagram을 다시 생성하고, Ktor 12장 architecture
+example에는 dedicated package-layout diagram을 추가하며, README link는 PNG file만 가리키게
+유지한다.
 
-## Outcome
+## 결과
 
-The root feature map, API structure, overview, learning path, module structure,
-and module composition chart now use refreshed SVG/PNG assets. The Ktor package
-tree is represented as a diagram asset instead of a text tree, and Mermaid type
-labels such as `classDiagram` and `flowchart` were removed from README headings
-and alt text.
+Root feature map, API structure, overview, learning path, module structure,
+module composition chart는 이제 refreshed SVG/PNG asset을 사용한다. Ktor package tree는 text
+tree 대신 diagram asset으로 표현되고, `classDiagram`, `flowchart` 같은 Mermaid type label은
+README heading과 alt text에서 제거됐다.
 
-## Verification
+## 검증
 
-- README scan confirmed no raw Mermaid blocks.
-- README scan confirmed no ASCII tree diagram code blocks.
-- README scan confirmed local image links resolve and do not point to SVG files.
-- PNG dimensions were checked for all newly generated or regenerated assets.
+- README scan으로 raw Mermaid block이 없음을 확인했다.
+- README scan으로 ASCII tree diagram code block이 없음을 확인했다.
+- README scan으로 local image link가 resolve되고 SVG file을 가리키지 않음을 확인했다.
+- 새로 생성되거나 다시 생성된 모든 asset의 PNG dimension을 확인했다.
 
-## Next time
+## 다음 작업
 
-Use Mermaid or structured source only as an intermediate input. Commit the final
-PNG and matching SVG source before linking a README.
+Mermaid 또는 structured source는 intermediate input으로만 사용한다. README에 link하기 전에
+final PNG와 matching SVG source를 commit한다.


### PR DESCRIPTION
## Summary

Localizes the `docs/lessons` records dated 2026-05-21 through 2026-05-24 into Korean.

## Scope

- Rewrites multi-tenant, production-integration, dependency, and diagram lessons in Korean.
- Preserves Gradle commands, module paths, issue numbers, versions, artifact coordinates, review evidence, and exact check results.
- Keeps bilingual README/manual assets and LLM-facing operating documents outside the change.

## Validation

- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-173-korean-early-lessons --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `git diff --check`

Closes #174.

## DoD Status

- [x] Integration lessons localized to Korean.
- [x] Scope exclusions enforced by audit guard.
- [x] Whitespace validation passed.
