### PR TITLE
Localize dependency weekly lessons

### DIFF
--- a/docs/lessons/2026-05-26-exposed-gradle-plugin.md
+++ b/docs/lessons/2026-05-26-exposed-gradle-plugin.md
@@ -1,19 +1,23 @@
-## Context
+## 배경
 
-Adopted the JetBrains Exposed Gradle plugin across Exposed workshop modules that define tables in main sources.
+Main source에서 table을 정의하는 Exposed workshop module 전반에 JetBrains Exposed Gradle
+plugin을 도입했다.
 
-## Decision
+## 결정
 
-The workshop uses a repo-local plugin alias tied to the existing Exposed version alias, not the managed `bt4k` catalog.
+Workshop은 managed `bt4k` catalog가 아니라 기존 Exposed version alias에 묶인 repo-local
+plugin alias를 사용한다.
 
-## Outcome
+## 결과
 
-Spring, multi-tenant, performance, Ktor, and production-integration examples now expose `generateMigrations` with explicit migration settings.
+Spring, multi-tenant, performance, Ktor, production-integration 예제는 이제 명시적인
+migration setting과 함께 `generateMigrations`를 노출한다.
 
-## Verification
+## 검증
 
-Ran `git diff --check`, `./gradlew -q help`, and `:spring-mvc-exposed:tasks --all`.
+`git diff --check`, `./gradlew -q help`, `:spring-mvc-exposed:tasks --all`을 실행했다.
 
-## Future Guard
+## 향후 보호 장치
 
-Keep shared test fixtures out of the migration plugin rollout unless a concrete migration output is needed for those fixtures.
+해당 fixture에 구체적인 migration output이 필요하지 않다면 shared test fixture는 migration
+plugin rollout에서 제외한다.

--- a/docs/lessons/2026-05-30-code-scanning-alerts.md
+++ b/docs/lessons/2026-05-30-code-scanning-alerts.md
@@ -1,29 +1,27 @@
-# Code scanning alerts
+# Code scanning alert
 
-## Context
+## 배경
 
-GitHub CodeQL reported workflow token permission alerts for CI, Nightly, and
-Examples, plus JavaScript alerts in README diagram tooling and checked-in
-Gatling reports.
+GitHub CodeQL은 CI, Nightly, Examples의 workflow token permission alert와 README diagram
+tooling 및 checked-in Gatling report의 JavaScript alert를 보고했다.
 
-## Decision
+## 결정
 
-Declare explicit workflow-level `contents: read` permissions first, then repair
-the alerted JavaScript helpers and remove generated report artifacts when they
-are not source documentation.
+먼저 workflow-level `contents: read` permission을 명시하고, 이후 alert가 난 JavaScript
+helper를 고치며, generated report artifact가 source documentation이 아니면 제거한다.
 
-## Outcome
+## 결과
 
-Workflow token defaults are now least-privilege for checkout-based jobs. Static
-resource fixes stay scoped to the alerted files.
+Checkout 기반 job의 workflow token default는 이제 least-privilege다. Static resource fix는
+alert가 난 file로 범위를 제한한다.
 
-## Verification
+## 검증
 
 - `actionlint .github/workflows/ci.yml .github/workflows/nightly.yml .github/workflows/examples.yml`
 - `yq` inspection of workflow permissions
 - `git diff --check`
 
-## Future guard
+## 향후 보호 장치
 
-Keep generated benchmark/report assets out of source control unless they are
-actively maintained as documentation and pass CodeQL as static web content.
+Generated benchmark/report asset이 documentation으로 적극 유지되고 static web content로
+CodeQL을 통과하지 않는 한 source control에 넣지 않는다.

--- a/docs/lessons/2026-06-01-dependencies-1-1-4-sync.md
+++ b/docs/lessons/2026-06-01-dependencies-1-1-4-sync.md
@@ -1,23 +1,20 @@
-# Dependencies 1.1.4 Sync
+# Dependencies 1.1.4 동기화
 
-## Context
+## 배경
 
-`bluetape4k-dependencies` 1.2.0 release preparation requires downstream
-workshops to match the central shared-version source of truth before the BOM
-release CI can pass.
+`bluetape4k-dependencies` 1.2.0 release preparation에서는 BOM release CI가 통과하기 전에
+downstream workshop이 central shared-version source of truth와 일치해야 한다.
 
-## Decision
+## 결정
 
-Align the workshop catalog to the latest published
-`bluetape4k-dependencies:1.1.4` baseline and central shared runtime versions.
-Do not consume `1.2.0` until it is published.
+Workshop catalog를 latest published `bluetape4k-dependencies:1.1.4` baseline 및 central
+shared runtime version과 정렬한다. `1.2.0`은 publish되기 전까지 소비하지 않는다.
 
-## Outcome
+## 결과
 
-The workshop no longer reports shared-version drift in the central release
-preflight.
+Workshop은 더 이상 central release preflight에서 shared-version drift를 보고하지 않는다.
 
-## Verification
+## 검증
 
-Validated from `bluetape4k-dependencies` with `sync-shared-versions.py
---workspace /Users/debop/work/bluetape4k --write --check --summary`.
+`bluetape4k-dependencies`에서 `sync-shared-versions.py --workspace
+/Users/debop/work/bluetape4k --write --check --summary`로 검증했다.

--- a/docs/lessons/2026-06-01-dependencies-1-2-0-sync.md
+++ b/docs/lessons/2026-06-01-dependencies-1-2-0-sync.md
@@ -1,23 +1,21 @@
-# Dependencies 1.2.0 Sync
+# Dependencies 1.2.0 동기화
 
-## Context
+## 배경
 
-`bluetape4k-dependencies:1.2.0` was published after the final upstream BOM
-matrix became Maven Central-visible.
+Final upstream BOM matrix가 Maven Central-visible 상태가 된 뒤
+`bluetape4k-dependencies:1.2.0`이 publish됐다.
 
-## Decision
+## 결정
 
-Move the Exposed workshop shared catalog from `1.1.4` to `1.2.0`.
+Exposed workshop shared catalog를 `1.1.4`에서 `1.2.0`으로 이동한다.
 
-## Outcome
+## 결과
 
-Workshop examples now consume the published 1.2.0 dependency-governance
-baseline.
+Workshop example은 이제 published 1.2.0 dependency-governance baseline을 소비한다.
 
-## Verification
+## 검증
 
 - `sync-shared-versions.py --workspace .. --write --check --summary` updated
   the catalog line.
-- Maven Central returned HTTP 200 for
-  `io.github.bluetape4k:bluetape4k-dependencies:1.2.0`.
-
+- Maven Central은 `io.github.bluetape4k:bluetape4k-dependencies:1.2.0`에 대해 HTTP 200을
+  반환했다.

--- a/docs/lessons/2026-06-02-catalog-2026-06-02-00-sync.md
+++ b/docs/lessons/2026-06-02-catalog-2026-06-02-00-sync.md
@@ -1,25 +1,25 @@
-# Catalog 2026-06-02-00 Sync
+# Catalog 2026-06-02-00 동기화
 
-## Context
+## 배경
 
-`bluetape4k-dependencies` cut `catalog/2026-06-02-00` after the issue #101
-security dependency train.
+Issue #101 security dependency train 이후 `bluetape4k-dependencies`가
+`catalog/2026-06-02-00`을 cut했다.
 
-## Decision
+## 결정
 
-Sync shared version aliases from the central catalog for the workshop catalog.
+Workshop catalog를 위해 central catalog의 shared version alias를 동기화한다.
 
-## Outcome
+## 결과
 
-Netty, Jackson, and Jackson 3 now match the source-of-truth dependency catalog.
+Netty, Jackson, Jackson 3는 이제 source-of-truth dependency catalog와 일치한다.
 
-## Verification
+## 검증
 
 - `scripts/sync-shared-versions.py --workspace /Users/debop/work/bluetape4k --check --summary`
 - `scripts/sync-dependabot-ignores.py --workspace /Users/debop/work/bluetape4k --check --summary`
 - `git diff --check`
 
-## Future Guidance
+## 향후 지침
 
-Workshop repositories should consume shared dependency changes through the
-central sync scripts instead of carrying local version drift.
+Workshop repository는 local version drift를 유지하지 말고 central sync script를 통해 shared
+dependency change를 소비해야 한다.

--- a/docs/lessons/2026-06-06-issue-118-examples-weekly.md
+++ b/docs/lessons/2026-06-06-issue-118-examples-weekly.md
@@ -1,30 +1,30 @@
-# Issue 118 Examples Weekly Gate
+# Issue 118 Examples weekly gate
 
-## Context
+## 배경
 
-`exposed-workshop` already had an `Examples` workflow, but issue #118 required
-the downstream example gate to run weekly instead of daily while preserving
-manual dispatch and PR/push path filters.
+`exposed-workshop`에는 이미 `Examples` workflow가 있었지만, issue #118은 manual dispatch와
+PR/push path filter를 보존하면서 downstream example gate를 daily가 아니라 weekly로 실행하라고
+요구했다.
 
-## Decision
+## 결정
 
-- Use one weekly scheduled run for selected downstream example modules.
-- Keep selected examples in a single Gradle invocation so Testcontainers-backed
-  paths do not compete across workflow jobs.
-- Upload test reports only on failure to keep passing runs lightweight.
+- Selected downstream example module에는 weekly scheduled run 하나를 사용한다.
+- Testcontainers-backed path가 workflow job 사이에서 경쟁하지 않도록 selected example을
+  하나의 Gradle invocation에 유지한다.
+- Passing run을 가볍게 유지하기 위해 failure일 때만 test report를 upload한다.
 
-## Outcome
+## 결과
 
-The workflow remains separate from CI and Nightly, retains `workflow_dispatch`
-and path filters, documents the selected gate scope inline, and publishes failed
-example reports as an artifact.
+Workflow는 CI 및 Nightly와 분리된 상태를 유지하고, `workflow_dispatch`와 path filter를
+보존하며, selected gate scope를 inline으로 문서화하고, 실패한 example report를 artifact로
+publish한다.
 
-## Verification
+## 검증
 
 - `actionlint .github/workflows/examples.yml`
 - `git diff --check`
 
-## Future Guidance
+## 향후 지침
 
-When adding new downstream examples, prefer extending the selected Examples
-workflow scope instead of moving the modules into CI or Nightly.
+새 downstream example을 추가할 때는 module을 CI나 Nightly로 옮기기보다 selected Examples
+workflow scope 확장을 우선한다.

--- a/docs/lessons/2026-06-19-readme-diagram-final-qa.md
+++ b/docs/lessons/2026-06-19-readme-diagram-final-qa.md
@@ -1,35 +1,33 @@
-# README Diagram Final QA
+# README diagram final QA
 
-## Context
+## 배경
 
-The README refresh regenerated source-derived diagrams for the root workshop and
-all modules. The final pass rendered every SVG to PNG and reviewed grouped
-contact sheets for connector placement, balanced margins, and text overflow.
+README refresh는 root workshop과 모든 module의 source-derived diagram을 다시 생성했다.
+Final pass에서는 모든 SVG를 PNG로 rendering하고, connector placement, balanced margin, text
+overflow를 보기 위해 grouped contact sheet를 검토했다.
 
-## Decision
+## 결정
 
-Diagram verification must include both render success and visual layout checks.
-XML validity and successful PNG generation are necessary, but they do not catch
-oversized canvases, uneven whitespace, or cards that become too small in README
-rendering.
+Diagram verification에는 render success와 visual layout check가 모두 포함돼야 한다. XML
+validity와 successful PNG generation은 필요하지만, oversized canvas, uneven whitespace,
+README rendering에서 너무 작아지는 card를 잡아내지는 못한다.
 
-## Outcome
+## 결과
 
-The final QA found four repeated JPA basic ERD assets whose content ended around
-the first quarter of the canvas while the SVG viewBox kept an old height. The
-fix trimmed the canvas/frame height and regenerated the paired PNG files.
+Final QA는 content가 canvas의 첫 1/4 지점에서 끝나는데 SVG viewBox는 오래된 height를
+유지하던 반복 JPA basic ERD asset 네 개를 찾았다. 수정은 canvas/frame height를 줄이고
+paired PNG file을 다시 생성했다.
 
-## Verification
+## 검증
 
-- Rendered all 175 SVG diagrams with CairoSVG.
-- Checked SVG XML validity for all 175 SVG files.
-- Verified README image references across 152 README files.
-- Audited sequence `alt` regions for near-transparent fills.
-- Inspected architecture, class, sequence, ERD, and miscellaneous contact
-  sheets for connector, margin, and text fit issues.
+- 175개 SVG diagram 전체를 CairoSVG로 rendering했다.
+- 175개 SVG file 전체의 SVG XML validity를 확인했다.
+- 152개 README file 전반의 README image reference를 검증했다.
+- Sequence `alt` region에 near-transparent fill이 있는지 감사했다.
+- Architecture, class, sequence, ERD, miscellaneous contact sheet에서 connector,
+  margin, text fit issue를 검사했다.
 
-## Next Time
+## 다음 작업
 
-For broad README diagram work, add an image dimension ratio sweep before the
-visual pass. Flag unusually tall or wide diagrams, then inspect the rendered
-PNG before committing.
+광범위한 README diagram 작업에서는 visual pass 전에 image dimension ratio sweep을 추가한다.
+비정상적으로 높거나 넓은 diagram을 표시한 뒤, commit 전에 rendered PNG를 검사한다.


### PR DESCRIPTION
## Summary

Localizes dependency-governance, examples workflow, and README diagram QA lesson records dated 2026-05-26 through 2026-06-19 into Korean.

## Scope

- Rewrites single-language lesson prose and headings in Korean.
- Preserves dependency versions, catalog names, commands, paths, issue numbers, and exact validation evidence.
- Keeps bilingual README/manual assets and LLM-facing operating documents outside the change.

## Validation

- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-174-korean-integration-lessons --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `git diff --check`

Closes #175.

## DoD Status

- [x] Dependency and weekly lessons localized to Korean.
- [x] Scope exclusions enforced by audit guard.
- [x] Whitespace validation passed.
