### PR TITLE
Localize ecosystem lessons records

### DIFF
--- a/docs/lessons/2026-06-28-issue-137-ecosystem-integrations.md
+++ b/docs/lessons/2026-06-28-issue-137-ecosystem-integrations.md
@@ -1,33 +1,31 @@
-# Issue #137 Ecosystem Integrations Scaffold
+# Issue #137 Ecosystem integrations scaffold
 
-## Context
+## 배경
 
-Issue #137 is an epic for Exposed 1.11 database platform, Ktor, Spring
-Modulith, and DDD examples. Chapter 12 already owns production-service
-integration patterns, so extending it would blur the chapter purpose.
+Issue #137은 Exposed 1.11 database platform, Ktor, Spring Modulith, DDD 예제를 위한
+epic이다. 12장은 이미 production-service integration pattern을 담당하므로, 그 장을 확장하면
+chapter purpose가 흐려진다.
 
-## Decision
+## 결정
 
-Create `13-ecosystem-integrations` as a README-only chapter foundation. Child
-issues #138-#145 will add runnable modules later. The root README links only
-the chapter overview until those modules exist.
+`13-ecosystem-integrations`를 README-only chapter foundation으로 만든다. Child issue
+#138-#145가 나중에 runnable module을 추가한다. 해당 module이 생기기 전까지 root README는
+chapter overview만 link한다.
 
-## Guards
+## 보호 장치
 
 - `settings.gradle.kts` scans the chapter directory, but no Gradle child project
   is expected until a child module has its own `build.gradle.kts`.
-- The Examples workflow path filter includes the chapter, but this foundation
-  PR does not add chapter 13 Gradle tasks. Child module PRs must add their own
-  runnable tasks when they create modules.
-- External-service examples must default to local, fake, Testcontainers,
-  emulator, or documentation-only paths. Real-service execution must be explicit
-  opt-in and skipped by default in CI.
-- Root overview and module-composition visuals remain unchanged in this PR
-  because chapter 13 has zero runnable leaf modules. Update them when the first
-  runnable child module lands.
+- Examples workflow path filter는 chapter를 포함하지만, 이 foundation PR은 13장 Gradle task를
+  추가하지 않는다. Child module PR은 module을 만들 때 자체 runnable task를 추가해야 한다.
+- External-service example은 기본값을 local, fake, Testcontainers, emulator 또는
+  documentation-only path로 둬야 한다. Real-service execution은 명시적 opt-in이어야 하며
+  CI 기본값에서는 skip해야 한다.
+- 13장에 runnable leaf module이 아직 없으므로 이 PR에서는 root overview와
+  module-composition visual을 바꾸지 않는다. 첫 runnable child module이 들어올 때 갱신한다.
 
-## Verification Notes
+## 검증 참고
 
-Future child PRs should prove Gradle project discovery, add real README links
-only after files exist, and record whether their coverage belongs in weekly
-Examples, full Nightly, or a manual opt-in lane.
+향후 child PR은 Gradle project discovery를 증명하고, file이 존재한 뒤에만 실제 README link를
+추가하며, coverage가 weekly Examples, full Nightly, manual opt-in lane 중 어디에 속하는지
+기록해야 한다.

--- a/docs/lessons/2026-06-29-chapter13-diagram-connector-qa.md
+++ b/docs/lessons/2026-06-29-chapter13-diagram-connector-qa.md
@@ -1,34 +1,30 @@
-# Chapter 13 Diagram Connector QA
+# Chapter 13 diagram connector QA
 
-## Context
+## 배경
 
-The Ktor Exposed integration README diagram passed SVG syntax and geometry
-checks, but the rendered PNG still showed resource connectors crossing the
-local-resource lane title/note text and later still looked like a large
-connector frame around the whole resource lane. A later review also caught a
-more serious miss: the `testApplication` to `/healthz + /readyz` connector
-passed directly through the `/api/notes` card. Another review caught helper
-connectors that mixed a rounded first bend with a sharp second bend in the same
-path.
+Ktor Exposed integration README diagram은 SVG syntax와 geometry check를 통과했지만,
+rendered PNG에서는 resource connector가 local-resource lane title/note text를 가로질렀고,
+나중에도 resource lane 전체를 감싸는 큰 connector frame처럼 보였다. 이후 review는 더 심각한
+누락도 잡았다. `testApplication`에서 `/healthz + /readyz`로 가는 connector가 `/api/notes`
+card를 직접 통과했다. 또 다른 review는 같은 path 안에서 둥근 첫 bend와 날카로운 두 번째
+bend를 섞은 helper connector를 발견했다.
 
-## Decision
+## 결정
 
-Do not fix connector-heavy diagrams by adding longer outer detours. First
-reduce routing pressure: merge cards when the source-backed distinction can
-live inside the same reader-facing card, reposition cards around the real
-relationship, and keep lane title/note bands as no-flow zones. Static audits
-are necessary but not sufficient for README diagrams.
+Connector-heavy diagram은 더 긴 outer detour를 추가하는 방식으로 고치지 않는다. 먼저 routing
+pressure를 줄인다. Source-backed distinction이 같은 reader-facing card 안에 있을 수 있으면
+card를 합치고, 실제 relationship 주변으로 card를 재배치하며, lane title/note band를 no-flow
+zone으로 유지한다. Static audit은 README diagram에 필요하지만 충분하지는 않다.
 
-## Outcome
+## 결과
 
-`05-ktor-exposed-integration-architecture-01.svg` now combines the JDBC
-datasource and dispatcher into one caller-owned resource card and keeps the
-resource connectors short, distinct, and away from lane text. The health-route
-HTTP connector now uses an upper bypass path instead of crossing the
-`/api/notes` card. The helper connector paths now use matching two-corner
-rounded S-bends instead of a rounded-then-sharp mix.
+`05-ktor-exposed-integration-architecture-01.svg`는 이제 JDBC datasource와 dispatcher를 하나의
+caller-owned resource card로 합치고, resource connector를 짧고 구분 가능하게 유지하며 lane
+text에서 떨어뜨린다. Health-route HTTP connector는 더 이상 `/api/notes` card를 가로지르지
+않고 upper bypass path를 사용한다. Helper connector path는 rounded-then-sharp mix 대신
+matching two-corner rounded S-bend를 사용한다.
 
-## Verification
+## 검증
 
 - `xmllint --noout` for the six Chapter 13 README SVGs.
 - `diagram-geometry-audit.py` for the six Chapter 13 README SVGs.
@@ -42,16 +38,13 @@ rounded S-bends instead of a rounded-then-sharp mix.
   by an immediate orthogonal `L` turn without a second rounded corner.
 - Full-size rendered PNG inspection plus a six-diagram contact sheet.
 
-## Future Work
+## 향후 작업
 
-For connector-heavy README diagrams, inspect the full-size PNG before reporting
-the diagram checklist as passed. Contact sheets are useful for coverage, but
-they do not replace targeted full-size inspection of dense connector areas.
-If a connector starts to look like a lane border or frame, redesign the card
-grouping and ports before trying another path-only patch.
-If a connector visually crosses a card body, do not rely on endpoint or corner
-audits; run a path-vs-card interior sampling check and inspect the full-size
-PNG before pushing.
-If a path contains one rounded corner, audit the rest of that same path and its
-same-class siblings; a `Q` command in one bend does not make adjacent `L` turns
-acceptable.
+Connector-heavy README diagram에서는 diagram checklist 통과를 보고하기 전에 full-size PNG를
+검사한다. Contact sheet는 coverage 확인에는 유용하지만 dense connector area에 대한 targeted
+full-size inspection을 대체하지 않는다. Connector가 lane border나 frame처럼 보이기 시작하면
+다른 path-only patch를 시도하기 전에 card grouping과 port를 다시 설계한다. Connector가
+시각적으로 card body를 가로지르면 endpoint나 corner audit에만 기대지 않는다. Push 전에
+path-vs-card interior sampling check를 실행하고 full-size PNG를 검사한다. Path에 rounded
+corner가 하나라도 있으면 같은 path의 나머지와 same-class sibling을 감사한다. 한 bend의 `Q`
+command가 인접 `L` turn을 허용하지는 않는다.

--- a/docs/lessons/2026-06-29-issue-138-bigquery-dry-run.md
+++ b/docs/lessons/2026-06-29-issue-138-bigquery-dry-run.md
@@ -1,39 +1,35 @@
-# Issue #138 BigQuery Dry-Run Workshop Lesson
+# Issue #138 BigQuery dry-run workshop lesson
 
-## Context
+## 배경
 
-Issue #138 is the first runnable child module under chapter 13. It demonstrates
-`bluetape4k-exposed` BigQuery dry-run validation from an Exposed-generated query
-without using cloud credentials or network calls.
+Issue #138은 13장 아래 첫 runnable child module이다. Cloud credential이나 network call 없이
+Exposed-generated query에서 `bluetape4k-exposed` BigQuery dry-run validation을 보여 준다.
 
-## Decision
+## 결정
 
-Keep the default workshop path mock-only. Build a small production helper that
-constructs the Exposed read-model query and delegates to
-`BigQueryContext.validateQuery`, while tests MockK-capture the actual Google
-API `QueryRequest` sent through `Bigquery.Jobs.query`.
+Default workshop path는 mock-only로 유지한다. Exposed read-model query를 만들고
+`BigQueryContext.validateQuery`에 위임하는 작은 production helper를 구현하며, test는
+`Bigquery.Jobs.query`를 통해 전달되는 실제 Google API `QueryRequest`를 MockK-capture한다.
 
-## Outcome
+## 결과
 
-The module verifies generated SQL fragments, dry-run request mapping, success
-responses, and BigQuery error conversion. README files explain dry-run versus
-execution and make the no-credential default explicit.
+모듈은 generated SQL fragment, dry-run request mapping, success response, BigQuery error
+conversion을 검증한다. README file은 dry-run과 execution의 차이를 설명하고 no-credential
+default를 명시한다.
 
-## Future Guidance
+## 향후 지침
 
-- For cloud-adjacent examples, name the real API boundary being mocked instead
-  of inventing a wrapper in the plan.
-- For README diagrams that show ordered calls or request/response behavior,
-  apply `$bluetape4k-diagram` as a gate before claiming completion and prefer a
-  sequence diagram over a generic flowchart.
-- Compare sequence diagrams against the local best-practices sequence family
-  before accepting style parity. For this module, `leader-redis-lettuce-sequence-02`
-  was the reference for frame/header/lifeline/activation, numbered pill labels,
-  semantic line colors, and fixed solid markers.
-- Do not report diagram checklist success from SVG/XML plus visual inspection
-  alone. Run geometry audit, endpoint audit, marker/font checks, CairoSVG CLI
-  rendering, and full-size PNG inspection before recording PASS evidence.
-- Add the runnable Gradle task to `.github/workflows/examples.yml` in the same
-  PR that introduces a child module.
-- Record explicit N/A evidence for CI, Nightly, summary `needs`, and coverage
-  artifacts when a new module does not require those surfaces.
+- Cloud-adjacent example에서는 plan에서 wrapper를 새로 꾸미지 말고 mock되는 실제 API boundary를
+  이름으로 명시한다.
+- Ordered call이나 request/response behavior를 보여 주는 README diagram은 완료 보고 전에
+  `$bluetape4k-diagram`을 gate로 적용하고, generic flowchart보다 sequence diagram을 선호한다.
+- Style parity를 받아들이기 전에 sequence diagram을 local best-practices sequence family와
+  비교한다. 이 모듈에서는 `leader-redis-lettuce-sequence-02`가 frame/header/lifeline/activation,
+  numbered pill label, semantic line color, fixed solid marker의 기준이었다.
+- SVG/XML과 visual inspection만으로 diagram checklist success를 보고하지 않는다. PASS evidence를
+  기록하기 전에 geometry audit, endpoint audit, marker/font check, CairoSVG CLI rendering,
+  full-size PNG inspection을 실행한다.
+- Child module을 도입하는 같은 PR에서 runnable Gradle task를 `.github/workflows/examples.yml`에
+  추가한다.
+- 새 모듈이 CI, Nightly, summary `needs`, coverage artifact를 요구하지 않으면 명시적인 N/A
+  evidence를 기록한다.

--- a/docs/lessons/2026-06-29-issue-139-trino-session-options.md
+++ b/docs/lessons/2026-06-29-issue-139-trino-session-options.md
@@ -1,17 +1,22 @@
-# Issue 139 Trino Session Options Lesson
+# Issue 139 Trino session option lesson
 
-## Context
+## 배경
 
-Issue #139 adds a credential-free Trino workshop example under Chapter 13.
+Issue #139는 13장 아래 credential-free Trino workshop 예제를 추가한다.
 
-## Decision
+## 결정
 
-Keep the workshop on public APIs: validate an application-facing profile, convert it to `TrinoConnectionOptions`, and expose only a local JDBC-property preview for README and tests. Do not call internal property conversion helpers from bluetape4k-exposed.
+Workshop은 public API 위에 유지한다. Application-facing profile을 검증하고
+`TrinoConnectionOptions`로 변환하며, README와 test에는 local JDBC-property preview만 노출한다.
+`bluetape4k-exposed`의 internal property conversion helper는 호출하지 않는다.
 
-## Outcome
+## 결과
 
-The example verifies typed options and EXPLAIN request shape locally. It does not require a Trino endpoint or credentials, and it does not assert connector-specific pushdown behavior.
+예제는 typed option과 EXPLAIN request shape를 local에서 검증한다. Trino endpoint나 credential을
+요구하지 않으며 connector-specific pushdown behavior를 assert하지 않는다.
 
-## Future Guidance
+## 향후 지침
 
-For a real Trino lane, use explicit opt-in tests and compare stable EXPLAIN fragments for a known connector. Avoid full-plan snapshots because Trino plans vary by connector, version, and catalog settings.
+Real Trino lane에서는 명시적인 opt-in test를 사용하고 known connector의 stable EXPLAIN
+fragment를 비교한다. Trino plan은 connector, version, catalog setting에 따라 달라지므로
+full-plan snapshot은 피한다.

--- a/docs/lessons/2026-06-29-issue-140-cockroachdb-retry.md
+++ b/docs/lessons/2026-06-29-issue-140-cockroachdb-retry.md
@@ -1,41 +1,39 @@
-# Issue #140 CockroachDB Retry Workshop
+# Issue #140 CockroachDB retry workshop
 
-## Context
+## 배경
 
-`bluetape4k-exposed` 1.11.0 added CockroachDB PostgreSQL-wire helpers and a
-bounded serializable retry helper. `exposed-workshop` needed a runnable example
-for issue #140 under chapter 13.
+`bluetape4k-exposed` 1.11.0은 CockroachDB PostgreSQL-wire helper와 bounded serializable
+retry helper를 추가했다. `exposed-workshop`에는 13장 아래 issue #140용 runnable example이
+필요했다.
 
-## Decision
+## 결정
 
-Use public helper APIs and a deterministic SQLSTATE `40001` retry injection in
-tests. Do not create a race-based concurrent conflict test for the workshop
-default path.
+Public helper API와 test의 deterministic SQLSTATE `40001` retry injection을 사용한다.
+Workshop default path에는 race-based concurrent conflict test를 만들지 않는다.
 
-## Outcome
+## 결과
 
-The new `03-cockroachdb-retry` module demonstrates:
+새 `03-cockroachdb-retry` module은 다음을 보여 준다.
 
 - `CockroachDatabase.connect` with `CockroachServer.Launcher.cockroach`.
 - schema bootstrap for inventory and ledger tables.
 - `withCockroachTransaction` around a whole inventory reservation.
-- retryable conflict replay and non-retryable SQL failure boundary.
+- retryable conflict replay와 non-retryable SQL failure boundary.
 
-## Verification
+## 검증
 
 - Test: PASS, 5 tests.
 - Build: PASS.
 - Diagram validation and visual inspection: PASS.
 - Workflow lint and diff check: PASS.
 
-## Future Guidance
+## 향후 지침
 
-For CockroachDB retry examples, keep the default workshop path deterministic.
-Use live concurrent conflicts only in a separate opt-in lane if the example's
-goal is contention behavior rather than helper API usage.
+CockroachDB retry 예제에서는 default workshop path를 deterministic하게 유지한다. 예제의 목표가
+helper API 사용이 아니라 contention behavior라면 live concurrent conflict는 별도의 opt-in
+lane에서만 사용한다.
 
-For sequence diagrams, keep pill labels above their own message lines instead
-of letting the line run through the label. If endpoints attach to activation
-bars, attach to the left or right edge with a horizontal terminal segment so
-the endpoint audit does not treat activation-bar top/bottom hits as card-corner
-attachments.
+Sequence diagram에서는 line이 label을 관통하지 않도록 pill label을 자신의 message line 위에
+둔다. Endpoint가 activation bar에 붙는다면 horizontal terminal segment로 왼쪽 또는 오른쪽
+edge에 붙인다. 그래야 endpoint audit이 activation-bar top/bottom hit를 card-corner attachment로
+취급하지 않는다.

--- a/docs/lessons/2026-06-29-issue-141-starrocks-olap-local.md
+++ b/docs/lessons/2026-06-29-issue-141-starrocks-olap-local.md
@@ -1,23 +1,21 @@
-# Issue 141 - StarRocks Local-First OLAP Lesson
+# Issue 141 - StarRocks local-first OLAP lesson
 
-## Context
+## 배경
 
-StarRocks examples can be tempting to treat as Testcontainers-backed integration
-tests, but issue #141 asked for a local-first OLAP boundary.
+StarRocks 예제는 Testcontainers-backed integration test로 다루고 싶어지기 쉽지만, issue #141은
+local-first OLAP boundary를 요구했다.
 
-## Decision
+## 결정
 
-Keep the default workshop test lane local and deterministic. Use H2 for SQL
-rendering and fixture aggregation, while showing StarRocks-specific DDL shape
-through `StarRocksTable`.
+Default workshop test lane은 local 및 deterministic 상태로 유지한다. SQL rendering과 fixture
+aggregation에는 H2를 사용하고, StarRocks-specific DDL shape는 `StarRocksTable`로 보여 준다.
 
-## Outcome
+## 결과
 
-The example proves typed connection settings, OLAP DDL rendering, query shape,
-and aggregation without Docker or network access. README files document the
-separate real StarRocks validation boundary.
+예제는 Docker나 network access 없이 typed connection setting, OLAP DDL rendering, query shape,
+aggregation을 증명한다. README file은 별도의 real StarRocks validation boundary를 문서화한다.
 
-## Future Guard
+## 향후 보호 장치
 
-Do not add StarRocks containers to the default workshop CI path unless a later
-issue explicitly asks for a heavyweight opt-in or nightly lane.
+나중 issue가 heavyweight opt-in 또는 nightly lane을 명시적으로 요구하지 않는 한 default
+workshop CI path에 StarRocks container를 추가하지 않는다.

--- a/docs/lessons/2026-06-29-issue-142-exposed-ktor-integration.md
+++ b/docs/lessons/2026-06-29-issue-142-exposed-ktor-integration.md
@@ -1,31 +1,28 @@
-# Issue #142 Lesson - Explicit Ktor Exposed Integration
+# Issue #142 lesson - 명시적 Ktor Exposed integration
 
-## Context
+## 배경
 
-Issue #142 needed a chapter 13 example for the new
-`bluetape4k-exposed-ktor` helper surface without replacing the older chapter 12
-Ktor service examples.
+Issue #142에는 기존 12장 Ktor service example을 대체하지 않으면서 새로운
+`bluetape4k-exposed-ktor` helper surface를 보여 주는 13장 예제가 필요했다.
 
-## Decision
+## 결정
 
-Keep the module small and local-first:
+모듈은 작고 local-first로 유지한다.
 
-- Use H2 JDBC for CRUD through `call.exposedJdbcTransaction`.
-- Use H2 R2DBC only as a readiness probe backend.
-- Compose `bluetape4kErrorResponses()` and `bluetape4kExposedErrors()` in one
-  `StatusPages` block.
-- Keep HikariCP, R2DBC pool, and dispatcher lifecycle caller-owned.
+- `call.exposedJdbcTransaction`을 통한 CRUD에는 H2 JDBC를 사용한다.
+- H2 R2DBC는 readiness probe backend로만 사용한다.
+- 하나의 `StatusPages` block에서 `bluetape4kErrorResponses()`와 `bluetape4kExposedErrors()`를
+  compose한다.
+- HikariCP, R2DBC pool, dispatcher lifecycle은 caller-owned로 유지한다.
 
-## Outcome
+## 결과
 
-The module shows the helper boundary directly and keeps chapter 12 focused on
-production-service structure. The README diagram needed an extra rendered-PNG
-inspection pass: SVG audits passed before the resource-lane connector corridor
-was visually clean.
+모듈은 helper boundary를 직접 보여 주고 12장은 production-service structure에 집중하게 둔다.
+README diagram은 추가 rendered-PNG inspection pass가 필요했다. Resource-lane connector
+corridor가 시각적으로 깨끗해지기 전에 SVG audit은 이미 통과했기 때문이다.
 
-## Future Guidance
+## 향후 지침
 
-For future Ktor/Exposed workshop examples, use the helper when the lesson is
-readiness, sanitized errors, or dispatcher-aware transaction wiring. Keep
-hand-owned transaction examples in chapter 12 when the lesson is layered
-application architecture.
+향후 Ktor/Exposed workshop 예제에서는 lesson이 readiness, sanitized error,
+dispatcher-aware transaction wiring이면 helper를 사용한다. Lesson이 layered application
+architecture이면 hand-owned transaction 예제는 12장에 유지한다.

--- a/docs/lessons/2026-06-30-issue-143-spring-modulith-publications.md
+++ b/docs/lessons/2026-06-30-issue-143-spring-modulith-publications.md
@@ -1,28 +1,28 @@
-# Issue 143 Spring Modulith Publications
+# Issue 143 Spring Modulith publication
 
-## Context
+## 배경
 
-Issue #143 added `13-ecosystem-integrations/06-spring-modulith-publications`,
-a local Spring Modulith publication-store example backed by
-`bluetape4k-exposed-spring-modulith`.
+Issue #143은 `bluetape4k-exposed-spring-modulith`를 기반으로 하는 local Spring Modulith
+publication-store 예제 `13-ecosystem-integrations/06-spring-modulith-publications`를
+추가했다.
 
-## Decision
+## 결정
 
-- Use in-memory H2 and an explicit `springTransactionManager` bean so the
-  Exposed Modulith auto-configuration can create the publication repository.
-- Provide an explicit Jackson 3 `EventSerializer`; without it, the repository
-  condition chain is harder for workshop readers to diagnose.
-- Keep the example focused on three operational paths: completed publication,
-  failed publication resubmission, and unloadable event rows.
+- Exposed Modulith auto-configuration이 publication repository를 만들 수 있도록 in-memory H2와
+  명시적 `springTransactionManager` bean을 사용한다.
+- 명시적인 Jackson 3 `EventSerializer`를 제공한다. 이것이 없으면 workshop reader가 repository
+  condition chain을 진단하기 어렵다.
+- 예제는 completed publication, failed publication resubmission, unloadable event row라는 세
+  operational path에 집중한다.
 
-## Diagram Guard
+## Diagram 보호 장치
 
-Connector scripts can miss same-line overlap when two routes share a corridor.
-After automated audits pass, inspect the full-size PNG and check for same-color
-or cross-color route sharing by eye. In this example the retry route was moved
-to the lower recovery corridor so it no longer shares the migration-guard path.
+두 route가 corridor를 공유하면 connector script가 same-line overlap을 놓칠 수 있다. Automated
+audit이 통과한 뒤 full-size PNG를 검사하고 same-color 또는 cross-color route sharing을 눈으로
+확인한다. 이 예제에서는 retry route를 lower recovery corridor로 옮겨 더 이상 migration-guard
+path를 공유하지 않게 했다.
 
-## Verification
+## 검증
 
 - `./gradlew :06-spring-modulith-publications:test --no-daemon --no-configuration-cache`
 - `./gradlew :06-spring-modulith-publications:build --no-daemon --no-configuration-cache`

--- a/docs/lessons/2026-06-30-issue-144-ddd-aggregate-repository.md
+++ b/docs/lessons/2026-06-30-issue-144-ddd-aggregate-repository.md
@@ -1,24 +1,22 @@
-# 2026-06-30 Issue #144 - DDD aggregate repository example
+# 2026-06-30 Issue #144 - DDD aggregate repository 예제
 
-## Context
+## 배경
 
-Issue #144 adds the first chapter 13 domain-architecture example. The module
-needed to show a DDD aggregate without turning Exposed table classes into the
-domain model.
+Issue #144는 첫 13장 domain-architecture 예제를 추가한다. 이 모듈은 Exposed table class를
+domain model로 바꾸지 않으면서 DDD aggregate를 보여 줘야 했다.
 
-## Decision
+## 결정
 
-Use a small `PurchaseOrder` aggregate with value objects, command methods,
-pending events, and an `OrderRepository` that maps state, owned lines, and event
-rows inside one Exposed transaction.
+Value object, command method, pending event를 가진 작은 `PurchaseOrder` aggregate와, 하나의
+Exposed transaction 안에서 state, owned line, event row를 mapping하는 `OrderRepository`를
+사용한다.
 
-## Outcome
+## 결과
 
-The example stays local-first with H2. Tests cover aggregate invariants,
-persistence, rollback after event insertion, and domain event capture order.
+예제는 H2 기반 local-first로 유지된다. Test는 aggregate invariant, persistence, event insertion
+후 rollback, domain event capture order를 다룬다.
 
-## Future Guard
+## 향후 보호 장치
 
-For the next DDD or Modulith example, keep the aggregate/business boundary
-visible in tests first, then add Exposed mapping and diagrams. Do not let table
-classes become the aggregate API.
+다음 DDD 또는 Modulith 예제에서는 먼저 test에서 aggregate/business boundary를 보이게 한 뒤
+Exposed mapping과 diagram을 추가한다. Table class가 aggregate API가 되게 하지 않는다.

--- a/docs/lessons/2026-06-30-issue-145-ddd-modulith-boundaries.md
+++ b/docs/lessons/2026-06-30-issue-145-ddd-modulith-boundaries.md
@@ -1,23 +1,22 @@
-# Issue #145 DDD Modulith Boundaries Lesson
+# Issue #145 DDD Modulith boundary lesson
 
-## Context
+## 배경
 
-The module demonstrates DDD bounded contexts with Spring Modulith verification
-and Exposed persistence.
+모듈은 Spring Modulith verification과 Exposed persistence로 DDD bounded context를 보여 준다.
 
-## Decision
+## 결정
 
-Keep schema initialization inside each module package. A shared root initializer
-that imports `orders.internal` or `shipping.internal` is itself a boundary
-violation and `ApplicationModules.verify()` correctly rejects it.
+Schema initialization은 각 module package 안에 둔다. `orders.internal` 또는
+`shipping.internal`을 import하는 shared root initializer 자체가 boundary violation이며,
+`ApplicationModules.verify()`가 이를 올바르게 거부한다.
 
-## Outcome
+## 결과
 
-The example uses `orders.events` as the single named interface and includes a
-negative test fixture proving that direct `shipping -> orders.internal`
-dependencies fail verification.
+예제는 `orders.events`를 single named interface로 사용하고, direct
+`shipping -> orders.internal` dependency가 verification에 실패함을 증명하는 negative test
+fixture를 포함한다.
 
-## Future Guidance
+## 향후 지침
 
-For Modulith examples, run `ApplicationModules.verify()` before documenting the
-architecture. Treat failures as real design feedback, not only test failures.
+Modulith 예제에서는 architecture를 문서화하기 전에 `ApplicationModules.verify()`를 실행한다.
+Failure는 단순 test failure가 아니라 실제 design feedback으로 취급한다.

--- a/docs/lessons/2026-07-01-issue-188-duckdb-embedded-analytics.md
+++ b/docs/lessons/2026-07-01-issue-188-duckdb-embedded-analytics.md
@@ -1,28 +1,26 @@
-# Issue 188 DuckDB Embedded Analytics Lesson
+# Issue 188 DuckDB embedded analytics lesson
 
-## Context
+## 배경
 
-The blog backlog for ecosystem integrations needed more source-backed examples
-before article writing. DuckDB adds a local analytics lane that does not require
-a remote service, credentials, Docker, or cloud setup.
+Ecosystem integration blog backlog는 article writing 전에 source-backed example을 더 필요로
+했다. DuckDB는 remote service, credential, Docker, cloud setup이 필요 없는 local analytics
+lane을 추가한다.
 
-## Decision
+## 결정
 
-Use a file-backed DuckDB database and keep one root `DuckDBConnection` open for
-the workshop session. Exposed receives duplicated transaction connections so
-separate transactions observe the same local database. The README explicitly
-states that `queryFlow` is a coroutine consumption boundary after transaction
-materialization, not raw JDBC streaming outside the transaction.
+File-backed DuckDB database를 사용하고 workshop session 동안 root `DuckDBConnection` 하나를
+열어 둔다. Exposed는 duplicated transaction connection을 받아 별도 transaction이 같은 local
+database를 관찰하게 한다. README는 `queryFlow`가 transaction 밖 raw JDBC streaming이 아니라
+transaction materialization 이후 coroutine consumption boundary임을 명시한다.
 
-## Outcome
+## 결과
 
-The module verifies schema creation, batch insert, aggregate projection,
-rendered SQL shape, validation failures, and Flow consumption locally. The
-README pair embeds architecture, example-flow, and sequence diagrams with SVG
-sources and PNG renders.
+모듈은 schema creation, batch insert, aggregate projection, rendered SQL shape, validation
+failure, Flow consumption을 local에서 검증한다. README pair는 SVG source와 PNG render가 있는
+architecture, example-flow, sequence diagram을 embed한다.
 
-## Future Guidance
+## 향후 지침
 
-For DuckDB follow-up examples, add Parquet/CSV scans, Arrow integration, or
-extension loading as separate modules. Keep this module focused on the Exposed
-+ embedded analytics boundary and avoid introducing real-service assumptions.
+DuckDB follow-up 예제에서는 Parquet/CSV scan, Arrow integration, extension loading을 별도
+모듈로 추가한다. 이 모듈은 Exposed + embedded analytics boundary에 집중시키고 real-service
+assumption을 도입하지 않는다.


### PR DESCRIPTION
## Summary

Localizes chapter 13 ecosystem integration lesson records dated 2026-06-28 through 2026-07-01 into Korean.

## Scope

- Rewrites ecosystem integration lesson prose and headings in Korean.
- Preserves platform/API identifiers, module paths, issue numbers, commands, diagram audit names, and exact acceptance evidence.
- Keeps bilingual README/manual assets and LLM-facing operating documents outside the change.

## Validation

- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-175-korean-dependency-weekly-lessons --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `git diff --check`

Closes #176.

## DoD Status

- [x] Ecosystem integration lessons localized to Korean.
- [x] Scope exclusions enforced by audit guard.
- [x] Whitespace validation passed.
