### PR TITLE
Localize review records

### DIFF
--- a/docs/review/2026-06-06-issue-118-examples-workflow-review.md
+++ b/docs/review/2026-06-06-issue-118-examples-workflow-review.md
@@ -1,33 +1,32 @@
-# Issue 118 Examples Workflow Review
+# Issue 118 Examples workflow review
 
-## Scope
+## 범위
 
 - `.github/workflows/examples.yml`
 - `docs/lessons/2026-06-06-issue-118-examples-weekly.md`
 
-## Review Result
+## 리뷰 결과
 
 - P0: 0
 - P1: 0
 - P2: 0
 
-## Findings
+## 발견 사항
 
-No blocking findings.
+Blocking finding 없음.
 
-## Evidence
+## 근거
 
-- The schedule is weekly: `0 21 * * 0`.
-- `workflow_dispatch`, push path filters, and pull request path filters remain
-  present.
-- Selected downstream example modules stay in one Gradle invocation, preserving
-  sequential Testcontainers behavior.
-- Failed test reports are uploaded through `actions/upload-artifact@v5` with
+- Schedule은 weekly다: `0 21 * * 0`.
+- `workflow_dispatch`, push path filter, pull request path filter가 유지된다.
+- Selected downstream example module은 하나의 Gradle invocation에 남아 sequential
+  Testcontainers behavior를 보존한다.
+- Failed test report는 `actions/upload-artifact@v5`와 함께 upload된다.
   `if: failure()`.
-- `actionlint .github/workflows/examples.yml` passed.
-- `git diff --check` passed.
+- `actionlint .github/workflows/examples.yml` 통과.
+- `git diff --check` 통과.
 
-## Residual Risk
+## 잔여 위험
 
-GitHub Actions dispatch was not manually run before PR creation; the PR checks
-are the required live validation surface for this workflow-only change.
+PR 생성 전에 GitHub Actions dispatch를 수동 실행하지 않았다. 이 workflow-only 변경의 required
+live validation surface는 PR check다.

--- a/docs/review/2026-06-29-issue-138-bigquery-dry-run-code-review.md
+++ b/docs/review/2026-06-29-issue-138-bigquery-dry-run-code-review.md
@@ -1,72 +1,68 @@
-# Issue #138 BigQuery Dry-Run Code Review
+# Issue #138 BigQuery dry-run code review
 
-## Scope
+## 범위
 
 - Module: `13-ecosystem-integrations/01-bigquery-dry-run`
 - Issue: #138
 - Parent epic: #137
-- Change type: new credential-free workshop module, README pair, diagram, and
-  Examples workflow task wiring.
+- Change type: 새 credential-free workshop module, README pair, diagram, Examples workflow
+  task wiring.
 
-## Severity Counts
+## Severity count
 
 - P0: 0
 - P1: 0
 - P2: 0
 - P3: 0
 
-## Seven-Tier Review
+## Seven-tier review
 
 | Tier | Result | Evidence |
 |---|---|---|
-| Requirements | PASS | #138 acceptance maps to tests, README pair, diagram, and Examples workflow task. |
-| Correctness | PASS | `BigQueryContext.validateQuery` is exercised with a MockK-captured `QueryRequest`. |
-| Tests | PASS | `./gradlew :01-bigquery-dry-run:test --no-daemon` passed. |
-| Security | PASS | No executable path reads credentials, environment variables, system properties, tokens, or constructs a real BigQuery client. |
-| Operations | PASS | `.github/workflows/examples.yml` builds `:01-bigquery-dry-run:build`; `actionlint` passed. |
-| Documentation | PASS | `README.md` and `README.ko.md` have matching sections and local-link validation passed. |
-| Maintainability | PASS | The module relies on catalog/BOM-managed dependencies and small public helper functions with KDoc. |
+| Requirements | PASS | #138 acceptance가 test, README pair, diagram, Examples workflow task에 mapping된다. |
+| Correctness | PASS | `BigQueryContext.validateQuery`가 MockK-captured `QueryRequest`로 실행된다. |
+| Tests | PASS | `./gradlew :01-bigquery-dry-run:test --no-daemon` 통과. |
+| Security | PASS | 실행 경로가 credential, environment variable, system property, token을 읽거나 real BigQuery client를 만들지 않는다. |
+| Operations | PASS | `.github/workflows/examples.yml`가 `:01-bigquery-dry-run:build`를 build하고 `actionlint`가 통과했다. |
+| Documentation | PASS | `README.md`와 `README.ko.md`의 section이 대응되며 local-link validation이 통과했다. |
+| Maintainability | PASS | 모듈은 catalog/BOM-managed dependency와 KDoc이 있는 작은 public helper function에 의존한다. |
 
-## Verification Evidence
+## 검증 근거
 
-- TDD RED: targeted test first failed on unresolved
-  `validateRegionalRevenueDryRun`, then passed after production helper
-  implementation.
+- TDD RED: targeted test는 처음에 unresolved `validateRegionalRevenueDryRun`으로 실패했고,
+  production helper 구현 후 통과했다.
 - `./gradlew :01-bigquery-dry-run:test --no-daemon`: PASS.
 - `./gradlew :01-bigquery-dry-run:build --no-daemon`: PASS.
-- `./gradlew projects --quiet`: includes
+- `./gradlew projects --quiet`: 다음을 포함한다.
   `project ':01-bigquery-dry-run' - /13-ecosystem-integrations/01-bigquery-dry-run`.
 - `actionlint .github/workflows/examples.yml`: PASS.
 - README local-link Ruby check: PASS.
-- `$bluetape4k-diagram` correction: the first generic flowchart did not fully
-  satisfy the current README visual checklist, so the asset was redrawn as a
-  sequence diagram for the source-backed ordered validation flow.
-- Best-practices style parity: PASS; the sequence diagram was aligned with the
-  local `leader-redis-lettuce-sequence-02` best-practices family by using the
-  same frame/header/lifeline/activation structure, numbered pill labels,
-  semantic call/SQL/state/return colors, and solid fixed-size markers.
+- `$bluetape4k-diagram` correction: 첫 generic flowchart가 현재 README visual checklist를
+  완전히 만족하지 못해 source-backed ordered validation flow용 sequence diagram으로 asset을
+  다시 그렸다.
+- Best-practices style parity: PASS. Sequence diagram은 같은 frame/header/lifeline/activation
+  structure, numbered pill label, semantic call/SQL/state/return color, solid fixed-size marker를
+  사용해 local `leader-redis-lettuce-sequence-02` best-practices family와 정렬했다.
 - `xmllint --noout docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.svg`: PASS.
 - `python3 /Users/debop/.codex/skills/bluetape4k-diagram/references/diagram-geometry-audit.py docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.svg`: PASS,
   `geometry_failures=0`.
 - `python3 /Users/debop/.codex/skills/bluetape4k-diagram/references/diagram-endpoint-audit.py docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.svg`: PASS,
   `endpoint_failures=0`.
-- Marker/font audit: PASS; the SVG uses `Architects Daughter`, `Comic Mono`,
-  fixed `markerUnits="userSpaceOnUse"`, explicit per-role marker colors, and no
-  `context-stroke` or implicit stroke-width marker.
+- Marker/font audit: PASS. SVG는 `Architects Daughter`, `Comic Mono`, fixed
+  `markerUnits="userSpaceOnUse"`, explicit per-role marker color를 사용하며 `context-stroke`나
+  implicit stroke-width marker가 없다.
 - CairoSVG render to
   `docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.png`: PASS.
-- Rendered PNG visual QA: PASS; sequence labels, numbered badges, lifelines,
-  activation bars, arrowheads, alt region, and local-only note are legible and
-  do not overlap.
+- Rendered PNG visual QA: PASS. Sequence label, numbered badge, lifeline, activation bar,
+  arrowhead, alt region, local-only note는 읽을 수 있고 겹치지 않는다.
 - `git diff --check`: PASS.
 
-## Credential And Real-Client Scan
+## Credential 및 real-client scan
 
-Credential scan matches were reviewed and are limited to README policy text,
-diagram policy text, and placeholder test constants such as `PROJECT_ID =
-"analytics-project"`.
+Credential scan match를 검토했고, README policy text, diagram policy text,
+`PROJECT_ID = "analytics-project"` 같은 placeholder test constant로 제한됨을 확인했다.
 
-Executable-path real-client scan returned zero matches for:
+Executable-path real-client scan은 다음 항목에 대해 match 0건을 반환했다.
 
 - `System.getenv`
 - `System.getProperty`
@@ -77,22 +73,21 @@ Executable-path real-client scan returned zero matches for:
 - `GOOGLE_APPLICATION_CREDENTIALS`
 - real `Bigquery` builder/application construction
 
-## New-Module Registration Audit
+## 새 모듈 등록 감사
 
 | Surface | Result | Evidence |
 |---|---|---|
-| `settings.gradle.kts` | PASS | Existing chapter include discovers `:01-bigquery-dry-run`. |
-| Root README pair | PASS | Chapter 13 now links the first runnable child module. |
-| Chapter README pair | PASS | #138 status is `Ready` and links module README pair. |
-| CI workflow | N/A | Broad CI Gradle jobs discover modules; no child-specific path/job change required. |
-| Nightly workflow | N/A | Module is mock-only; weekly Examples owns runnable example coverage. |
-| Examples workflow | PASS | Existing chapter 13 path filters remain; selected build adds `:01-bigquery-dry-run:build`. |
-| Summary `needs` | N/A | Examples job graph did not change. |
-| Coverage artifacts | N/A | No Kover threshold or Codecov gate was added. |
+| `settings.gradle.kts` | PASS | 기존 chapter include가 `:01-bigquery-dry-run`을 발견한다. |
+| Root README pair | PASS | Chapter 13이 첫 runnable child module을 link한다. |
+| Chapter README pair | PASS | #138 status는 `Ready`이며 module README pair를 link한다. |
+| CI workflow | N/A | Broad CI Gradle job이 module을 발견하므로 child-specific path/job 변경이 필요 없다. |
+| Nightly workflow | N/A | Module은 mock-only이며 weekly Examples가 runnable example coverage를 소유한다. |
+| Examples workflow | PASS | 기존 chapter 13 path filter가 유지되고 selected build가 `:01-bigquery-dry-run:build`를 추가한다. |
+| Summary `needs` | N/A | Examples job graph는 바뀌지 않았다. |
+| Coverage artifacts | N/A | Kover threshold나 Codecov gate를 추가하지 않았다. |
 
-## Residual Risk
+## 잔여 위험
 
-The SQL assertions intentionally check stable fragments instead of the full SQL
-string, so minor Exposed formatting drift should not break the workshop. A
-future real BigQuery opt-in example must be opened separately and must not reuse
-this mock-only default path.
+SQL assertion은 full SQL string 대신 stable fragment를 의도적으로 확인하므로 작은 Exposed
+formatting drift가 workshop을 깨뜨리지 않아야 한다. 향후 real BigQuery opt-in example은 별도로
+열어야 하며 이 mock-only default path를 재사용하면 안 된다.

--- a/docs/review/2026-06-29-issue-139-trino-session-options-code-review.md
+++ b/docs/review/2026-06-29-issue-139-trino-session-options-code-review.md
@@ -1,21 +1,27 @@
-# Issue 139 Trino Session Options Code Review
+# Issue 139 Trino session option code review
 
 Date: 2026-06-29
 Scope: `13-ecosystem-integrations/02-trino-session-options`, README wiring, diagram assets, Examples workflow.
 
-## Verdict
+## 판정
 
-PASS. No P0/P1 findings.
+PASS. P0/P1 finding 없음.
 
-## Evidence
+## 근거
 
-- Security: default tests do not read endpoints, credentials, tokens, environment variables, or system properties.
-- Correctness: `TrinoWorkshopConnectionProfile` validates catalog, schema, source, tags, and session properties before option conversion.
-- API boundary: workshop code uses public `TrinoConnectionOptions` fields and keeps JDBC property conversion as a documentation preview, avoiding internal library APIs.
-- Pushdown scope: documentation and tests assert EXPLAIN request shape only; they do not claim connector-specific pushdown results.
-- Documentation: README locale pair and Chapter/root README links describe the same local-only behavior.
-- Diagram: SVG/PNG asset follows the bluetape4k sequence style and is validated separately.
+- Security: default test는 endpoint, credential, token, environment variable, system property를
+  읽지 않는다.
+- Correctness: `TrinoWorkshopConnectionProfile`은 option conversion 전에 catalog, schema,
+  source, tag, session property를 검증한다.
+- API boundary: workshop code는 public `TrinoConnectionOptions` field를 사용하고 JDBC property
+  conversion을 documentation preview로 유지해 internal library API를 피한다.
+- Pushdown scope: documentation과 test는 EXPLAIN request shape만 assert하며,
+  connector-specific pushdown result를 주장하지 않는다.
+- Documentation: README locale pair와 Chapter/root README link는 같은 local-only behavior를
+  설명한다.
+- Diagram: SVG/PNG asset은 bluetape4k sequence style을 따르며 별도로 검증됐다.
 
-## Residual Risk
+## 잔여 위험
 
-Real Trino connector pushdown is intentionally out of scope. A future opt-in module should verify stable EXPLAIN signals against a concrete connector instead of snapshotting the whole plan.
+Real Trino connector pushdown은 의도적으로 scope 밖이다. 향후 opt-in module은 whole plan을
+snapshot하지 말고 concrete connector에 대한 stable EXPLAIN signal을 검증해야 한다.

--- a/docs/review/2026-06-29-issue-140-cockroachdb-retry-code-review.md
+++ b/docs/review/2026-06-29-issue-140-cockroachdb-retry-code-review.md
@@ -1,35 +1,35 @@
-# Issue #140 CockroachDB Retry Code Review
+# Issue #140 CockroachDB retry code review
 
 Date: 2026-06-29
 Issue: https://github.com/bluetape4k/exposed-workshop/issues/140
 
-## Scope Reviewed
+## 검토 범위
 
-- New module `13-ecosystem-integrations/03-cockroachdb-retry`
-- CockroachDB retry workshop code and tests
+- 새 모듈 `13-ecosystem-integrations/03-cockroachdb-retry`
+- CockroachDB retry workshop code와 test
 - README.md / README.ko.md locale pair
-- Diagram source and rendered PNG
-- Chapter/root README links
+- Diagram source와 rendered PNG
+- Chapter/root README link
 - Examples workflow registration
 
-## Findings
+## 발견 사항
 
 P0: none.
 
 P1: none.
 
-## Evidence
+## 근거
 
-- Tests cover schema bootstrap, successful reservation, retryable
-  serialization failure, non-retryable SQL failure, and retry predicate.
-- Implementation uses public `bluetape4k-exposed-cockroachdb` APIs only:
+- Test는 schema bootstrap, successful reservation, retryable serialization failure,
+  non-retryable SQL failure, retry predicate를 다룬다.
+- 구현은 public `bluetape4k-exposed-cockroachdb` API만 사용한다:
   `CockroachDatabase`, `CockroachTransactionRetryOptions`,
   `withCockroachTransaction`, and retry predicate.
-- Retry conflict is deterministic SQLSTATE `40001` injection instead of a
-  timing-sensitive concurrent write race.
-- Diagram uses editable SVG plus generated PNG and no raw Mermaid.
+- Retry conflict는 timing-sensitive concurrent write race가 아니라 deterministic SQLSTATE
+  `40001` injection이다.
+- Diagram은 editable SVG와 generated PNG를 사용하며 raw Mermaid가 없다.
 
-## Verification
+## 검증
 
 - `./gradlew :03-cockroachdb-retry:test --no-daemon --no-configuration-cache`: PASS, 5 tests.
 - `./gradlew :03-cockroachdb-retry:build --no-daemon --no-configuration-cache`: PASS.
@@ -37,12 +37,11 @@ P1: none.
 - `actionlint .github/workflows/examples.yml`: PASS.
 - `xmllint --noout docs/images/readme-diagrams/13-cockroachdb-retry-sequence-01.svg`: PASS.
 - `cairosvg docs/images/readme-diagrams/13-cockroachdb-retry-sequence-01.svg -o docs/images/readme-diagrams/13-cockroachdb-retry-sequence-01.png -s 2`: PASS.
-- Diagram rendered PNG inspected visually: PASS.
+- Diagram rendered PNG를 시각적으로 검사했다: PASS.
 - `git diff --check`: PASS.
 
-## Residual Risk
+## 잔여 위험
 
-The retryable failure path is deterministic and documents the public retry
-signature, but it is not a live concurrent write conflict. That is intentional
-for workshop stability and should only be widened if a later issue needs a
-dedicated contention example.
+Retryable failure path는 deterministic하며 public retry signature를 문서화하지만, live
+concurrent write conflict는 아니다. 이는 workshop 안정성을 위한 의도적 선택이며, 나중 issue가
+dedicated contention example을 필요로 할 때만 넓혀야 한다.

--- a/docs/review/2026-06-29-issue-141-starrocks-olap-local-code-review.md
+++ b/docs/review/2026-06-29-issue-141-starrocks-olap-local-code-review.md
@@ -1,40 +1,39 @@
-# Issue 141 - StarRocks Local-First OLAP Code Review
+# Issue 141 - StarRocks local-first OLAP code review
 
-## Scope
+## 범위
 
-- New module `13-ecosystem-integrations/04-starrocks-olap-local`
+- 새 모듈 `13-ecosystem-integrations/04-starrocks-olap-local`
 - StarRocks alias in `gradle/libs.versions.toml`
 - README locale pair, root/chapter indexes, Examples workflow
 - Diagram asset `13-starrocks-olap-local-architecture-01.svg/png`
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0
 
-## Review Notes
+## 리뷰 노트
 
-- The implementation uses the public `bluetape4k-exposed-starrocks` API:
+- 구현은 public `bluetape4k-exposed-starrocks` API를 사용한다:
   `StarRocksConnectionOptions` and `StarRocksTable`.
-- Default tests are H2-only and do not instantiate Testcontainers or contact a
-  StarRocks backend.
-- DDL tests intentionally validate rendered shape only. Real StarRocks storage,
-  partitioning, distribution, and cloud behavior remain out of scope and are
-  documented as opt-in.
-- Diagram validation followed `$bluetape4k-diagram`: source-backed scope,
-  editable SVG, CairoSVG-rendered PNG, XML parse, geometry audit, endpoint audit,
-  marker/style scan, and full-size PNG inspection.
+- Default test는 H2-only이며 Testcontainers를 instantiate하거나 StarRocks backend에 접속하지
+  않는다.
+- DDL test는 의도적으로 rendered shape만 검증한다. Real StarRocks storage, partitioning,
+  distribution, cloud behavior는 scope 밖이며 opt-in으로 문서화됐다.
+- Diagram validation은 `$bluetape4k-diagram`을 따랐다: source-backed scope, editable SVG,
+  CairoSVG-rendered PNG, XML parse, geometry audit, endpoint audit, marker/style scan,
+  full-size PNG inspection.
 
-## Verification Evidence
+## 검증 근거
 
-- RED: `:04-starrocks-olap-local:test` failed on unresolved workshop symbols.
-- GREEN: `:04-starrocks-olap-local:test` passed with 5 tests, 0 failures, 0
-  errors, 0 skipped.
-- Build: `:04-starrocks-olap-local:test :04-starrocks-olap-local:build` passed.
-- Matrix guard: `:04-starrocks-olap-local:test -PuseDB=H2` passed.
-- Registration: `./gradlew projects --quiet` listed `:04-starrocks-olap-local`.
+- RED: `:04-starrocks-olap-local:test`는 unresolved workshop symbol에서 실패했다.
+- GREEN: `:04-starrocks-olap-local:test`는 test 5개, failure 0, error 0, skipped 0으로
+  통과했다.
+- Build: `:04-starrocks-olap-local:test :04-starrocks-olap-local:build` 통과.
+- Matrix guard: `:04-starrocks-olap-local:test -PuseDB=H2` 통과.
+- Registration: `./gradlew projects --quiet`가 `:04-starrocks-olap-local`을 표시했다.
 - Workflow/static: `actionlint .github/workflows/examples.yml`,
   `node /Users/debop/work/bluetape4k/.omx/scripts/audit-readme-diagrams.mjs .`,
-  and `git diff --check` passed.
-- Diagram: XML parse, geometry audit, endpoint audit, marker/style scan, PNG
-  render, and visual inspection passed.
+  `git diff --check` 통과.
+- Diagram: XML parse, geometry audit, endpoint audit, marker/style scan, PNG render,
+  visual inspection 통과.

--- a/docs/review/2026-06-29-issue-142-exposed-ktor-integration-code-review.md
+++ b/docs/review/2026-06-29-issue-142-exposed-ktor-integration-code-review.md
@@ -1,32 +1,30 @@
-# Issue #142 Code Review - Explicit Ktor Exposed Integration
+# Issue #142 code review - 명시적 Ktor Exposed integration
 
-## Scope
+## 범위
 
-Reviewed the new `13-ecosystem-integrations/05-ktor-exposed-integration`
-example, catalog aliases, README links, Examples workflow registration, and
-diagram assets.
+새 `13-ecosystem-integrations/05-ktor-exposed-integration` 예제, catalog alias, README link,
+Examples workflow registration, diagram asset을 검토했다.
 
-## Findings
+## 발견 사항
 
-- No blocking findings.
+- Blocking finding 없음.
 
-## Evidence
+## 근거
 
 - `./gradlew :05-ktor-exposed-integration:test --no-daemon --no-configuration-cache`
-  failed first with unresolved production symbols, confirming the TDD RED step.
+  는 처음에 unresolved production symbol로 실패해 TDD RED step을 확인했다.
 - `./gradlew :05-ktor-exposed-integration:build --no-daemon --no-configuration-cache`
-  passed after implementation.
-- `./gradlew projects --no-daemon --no-configuration-cache` listed
+  는 구현 후 통과했다.
+- `./gradlew projects --no-daemon --no-configuration-cache`가 다음을 표시했다.
   `:05-ktor-exposed-integration`.
-- `git diff --check` passed.
-- `$bluetape4k-diagram` checks passed:
+- `git diff --check` 통과.
+- `$bluetape4k-diagram` check 통과:
   - `diagram-geometry-audit.py`: `geometry_failures=0`
   - `diagram-endpoint-audit.py`: `endpoint_failures=0`
-  - CairoSVG rendered the PNG at `3200 x 2240`.
-  - Rendered PNG was visually inspected after connector-corridor fixes.
+  - CairoSVG가 PNG를 `3200 x 2240`으로 rendering했다.
+  - Connector-corridor fix 이후 rendered PNG를 시각적으로 검사했다.
 
-## Residual Risk
+## 잔여 위험
 
-- The example uses local H2 JDBC/R2DBC resources only. That is intentional for
-  the workshop feedback loop; it does not prove behavior against a production
-  database backend.
+- 예제는 local H2 JDBC/R2DBC resource만 사용한다. 이는 workshop feedback loop를 위한 의도적
+  선택이며 production database backend에 대한 behavior를 증명하지 않는다.

--- a/docs/review/2026-07-01-issue-188-duckdb-embedded-analytics-code-review.md
+++ b/docs/review/2026-07-01-issue-188-duckdb-embedded-analytics-code-review.md
@@ -1,8 +1,8 @@
-# Issue 188 - DuckDB Embedded Analytics Code Review
+# Issue 188 - DuckDB embedded analytics code review
 
-## Scope
+## 범위
 
-- New module `13-ecosystem-integrations/09-duckdb-embedded-analytics`
+- 새 모듈 `13-ecosystem-integrations/09-duckdb-embedded-analytics`
 - DuckDB alias in `gradle/libs.versions.toml`
 - README locale pair, chapter index rows, Examples workflow registration
 - Diagram assets:
@@ -10,36 +10,33 @@
   - `13-duckdb-embedded-analytics-flow-01.svg/png`
   - `13-duckdb-embedded-analytics-sequence-01.svg/png`
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0
 
-## Review Notes
+## 리뷰 노트
 
-- The implementation uses public `bluetape4k-exposed-duckdb` transaction and
-  Flow helpers. The only local JDBC wrapper mirrors the DuckDB generated-key
-  overload compatibility boundary needed by Exposed.
-- The session keeps a root `DuckDBConnection` open and provides duplicate
-  transaction connections. This avoids the per-connection in-memory catalog
-  trap and keeps file-backed behavior stable across Exposed transactions.
-- `queryFlow` is documented as transaction-safe materialization followed by
-  Flow consumption. The module does not claim row-by-row JDBC streaming outside
-  the transaction.
-- No Docker, credentials, or remote services are used by the default test path.
-- Diagram validation followed `$bluetape4k-diagram`: source-backed scope,
-  editable SVG, CairoSVG-rendered PNG, XML parse, connector/geometry/endpoint
-  audits, sequence-style audit, and full-size PNG inspection.
+- 구현은 public `bluetape4k-exposed-duckdb` transaction 및 Flow helper를 사용한다. 유일한
+  local JDBC wrapper는 Exposed에 필요한 DuckDB generated-key overload compatibility boundary를
+  반영한다.
+- Session은 root `DuckDBConnection` 하나를 열어 두고 duplicate transaction connection을 제공한다.
+  이는 per-connection in-memory catalog trap을 피하고 Exposed transaction 사이에서 file-backed
+  behavior를 안정적으로 유지한다.
+- `queryFlow`는 transaction-safe materialization 이후 Flow consumption으로 문서화됐다. 모듈은
+  transaction 밖 row-by-row JDBC streaming을 주장하지 않는다.
+- Default test path는 Docker, credential, remote service를 사용하지 않는다.
+- Diagram validation은 `$bluetape4k-diagram`을 따랐다: source-backed scope, editable SVG,
+  CairoSVG-rendered PNG, XML parse, connector/geometry/endpoint audit, sequence-style audit,
+  full-size PNG inspection.
 
-## Verification Evidence
+## 검증 근거
 
-- Test: `./gradlew :09-duckdb-embedded-analytics:test --no-daemon` passed with
-  7 tests.
-- Build: `./gradlew :09-duckdb-embedded-analytics:build --no-daemon` passed.
-- Registration: `./gradlew projects --no-daemon` listed
+- Test: `./gradlew :09-duckdb-embedded-analytics:test --no-daemon`는 test 7개로 통과했다.
+- Build: `./gradlew :09-duckdb-embedded-analytics:build --no-daemon` 통과.
+- Registration: `./gradlew projects --no-daemon`가 다음을 표시했다.
   `:09-duckdb-embedded-analytics`.
-- Workflow/static: `actionlint .github/workflows/examples.yml` and
-  `git diff --check` passed.
-- Diagram: connector audit reported `intrusions=0` and `crossings=0` for all
-  three SVGs; geometry audit reported `geometry_failures=0`; endpoint audit and
-  sequence-style audit passed.
+- Workflow/static: `actionlint .github/workflows/examples.yml`와 `git diff --check` 통과.
+- Diagram: connector audit는 세 SVG 모두에서 `intrusions=0`, `crossings=0`을 보고했고,
+  geometry audit는 `geometry_failures=0`을 보고했으며 endpoint audit과 sequence-style audit도
+  통과했다.


### PR DESCRIPTION
## Summary

Localizes all `docs/review/*.md` review records into Korean.

## Scope

- Rewrites review findings, verdicts, reviewer notes, and residual-risk prose in Korean.
- Preserves severity labels, file paths, module paths, commands, symbols, code snippets, and exact validation evidence.
- Keeps `docs/superpowers/**` review/research notes for their dedicated slices.

## Validation

- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-176-korean-ecosystem-lessons --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `git diff --check`

Closes #177.

## DoD Status

- [x] Review records localized to Korean.
- [x] Scope exclusions enforced by audit guard.
- [x] Whitespace validation passed.
