### PR TITLE
Localize superpowers design specs

### DIFF
--- a/docs/superpowers/specs/2026-04-10-memory-hybrid-enforcement-design.md
+++ b/docs/superpowers/specs/2026-04-10-memory-hybrid-enforcement-design.md
@@ -1,4 +1,4 @@
-# Memory Hybrid Enforcement Design
+# Memory hybrid enforcement 설계
 
 ## 개요
 

--- a/docs/superpowers/specs/2026-05-17-issue-58-ktor-architecture-design.md
+++ b/docs/superpowers/specs/2026-05-17-issue-58-ktor-architecture-design.md
@@ -1,62 +1,59 @@
-# Issue 58 - Ktor Application Architecture Design
+# Issue 58 - Ktor application architecture 설계
 
-## Context
+## 배경
 
-Issue #58 starts chapter 12 production integration work with the smallest Ktor
-example in `exposed-workshop`. The module should become the baseline shape for
-later chapter 12 examples without pulling in auth, outbox, WebSocket, external
-client, or observability scope.
+Issue #58은 `exposed-workshop`에서 가장 작은 Ktor 예제로 12장 production integration 작업을
+시작한다. 이 모듈은 auth, outbox, WebSocket, external client, observability scope를 끌어오지
+않고 이후 12장 예제의 baseline shape가 되어야 한다.
 
-## Goal
+## 목표
 
-Add `12-production-integration/01-ktor-application-architecture`, a minimal
-Ktor + Exposed JDBC example that demonstrates explicit application assembly,
-feature routes, service/repository boundaries, JSON serialization, error
-mapping, and route tests.
+명시적 application assembly, feature route, service/repository boundary, JSON
+serialization, error mapping, route test를 보여 주는 최소 Ktor + Exposed JDBC 예제
+`12-production-integration/01-ktor-application-architecture`를 추가한다.
 
-## Non-Goals
+## 비목표
 
-- No Spring Boot dependency in this module.
-- No Testcontainers; use in-memory H2 for the first baseline example.
-- No authentication, sessions, WebSocket, external HTTP client, or metrics.
-- No shared abstraction for future chapter 12 modules until duplication is real.
+- 이 모듈에는 Spring Boot dependency를 넣지 않는다.
+- Testcontainers 없음. 첫 baseline example에는 in-memory H2를 사용한다.
+- Authentication, session, WebSocket, external HTTP client, metrics 없음.
+- Duplication이 실제로 나타나기 전까지 future chapter 12 module용 shared abstraction 없음.
 
-## Design
+## 설계
 
-- Register the chapter in `settings.gradle.kts` with the existing
-  `includeModules("12-production-integration", false, false)` helper.
-- Add Ktor aliases to `gradle/libs.versions.toml` using the current official
-  Ktor 3.4.3 coordinates already used in `bluetape4k-projects`.
-- Use `kotlin("plugin.serialization")` for DTOs and Ktor kotlinx JSON support.
-- Use a small `Customer` domain:
+- 기존 `includeModules("12-production-integration", false, false)` helper로 chapter를
+  `settings.gradle.kts`에 등록한다.
+- `bluetape4k-projects`에서 이미 사용하는 현재 official Ktor 3.4.3 coordinate로
+  `gradle/libs.versions.toml`에 Ktor alias를 추가한다.
+- DTO와 Ktor kotlinx JSON support에는 `kotlin("plugin.serialization")`을 사용한다.
+- 작은 `Customer` domain을 사용한다.
   - `Customers` Exposed table.
   - `CustomerRepository` interface.
-  - `ExposedCustomerRepository` implementation exposing `suspend` functions
-    and wrapping every blocking JDBC `transaction {}` call in
-    `withContext(Dispatchers.IO)`.
-  - `CustomerService` for validation and route-friendly errors.
-- Use Ktor `ContentNegotiation`, `StatusPages`, `CallLogging`, `CallId`, and
-  feature route functions.
-- Configure JSON with `ignoreUnknownKeys = true` and enforce a small request
-  body limit for the demo API.
-- Map `IllegalArgumentException` to HTTP 400, missing records to HTTP 404, and
-  unexpected exceptions to sanitized HTTP 500 JSON responses.
-- Use `testApplication` for route tests with a unique H2 JDBC URL per test.
+  - `suspend` function을 노출하고 모든 blocking JDBC `transaction {}` 호출을
+    `withContext(Dispatchers.IO)`로 감싸는 `ExposedCustomerRepository` 구현.
+  - Validation과 route-friendly error를 위한 `CustomerService`.
+- Ktor `ContentNegotiation`, `StatusPages`, `CallLogging`, `CallId`, feature route function을
+  사용한다.
+- JSON은 `ignoreUnknownKeys = true`로 설정하고 demo API에는 작은 request body limit을
+  적용한다.
+- `IllegalArgumentException`은 HTTP 400, missing record는 HTTP 404, unexpected exception은
+  sanitized HTTP 500 JSON response로 mapping한다.
+- Route test에는 test마다 unique H2 JDBC URL을 사용하는 `testApplication`을 사용한다.
 
-## Acceptance Criteria
+## 수용 기준
 
-- `:01-ktor-application-architecture:compileKotlin` passes.
-- `:01-ktor-application-architecture:test` passes.
-- Tests cover create, get, list, not found, malformed JSON, at least two
-  validation failure paths, and a parallel insert smoke path.
-- `README.md` and `README.ko.md` exist for the module.
-- KDoc for public/internal module entrypoints explains the contract in English.
-- `git diff --check` passes.
+- `:01-ktor-application-architecture:compileKotlin` 통과.
+- `:01-ktor-application-architecture:test` 통과.
+- Test는 create, get, list, not found, malformed JSON, 최소 두 validation failure path,
+  parallel insert smoke path를 다룬다.
+- 모듈에 `README.md`와 `README.ko.md`가 존재한다.
+- Public/internal module entrypoint의 KDoc은 contract를 English로 설명한다.
+- `git diff --check` 통과.
 
-## Risks
+## 위험
 
-- Blocking Exposed JDBC is acceptable only behind the repository-owned
-  `Dispatchers.IO` boundary. README must state that higher-throughput
-  non-blocking persistence belongs in the R2DBC workshop.
-- Version catalog changes affect the whole repo; keep aliases minimal and reuse
-  the Ktor 3.4.3 version from existing bluetape4k examples.
+- Blocking Exposed JDBC는 repository-owned `Dispatchers.IO` boundary 뒤에서만 허용된다.
+  README는 higher-throughput non-blocking persistence가 R2DBC workshop에 속한다고 명시해야
+  한다.
+- Version catalog 변경은 repo 전체에 영향을 준다. Alias를 최소화하고 기존 bluetape4k 예제의
+  Ktor 3.4.3 version을 재사용한다.

--- a/docs/superpowers/specs/2026-05-22-issue-52-schema-per-tenant-design.md
+++ b/docs/superpowers/specs/2026-05-22-issue-52-schema-per-tenant-design.md
@@ -1,123 +1,105 @@
-# Issue 52 Schema-Per-Tenant Design
+# Issue 52 Schema-per-tenant 설계
 
-## Context
+## 배경
 
-Issue #52 adds a chapter 10 Spring Boot example for tenant-specific schema
-routing on shared database infrastructure. The example should focus on strict
-tenant resolution, schema switching, tenant-local persistence, and cross-tenant
-isolation.
+Issue #52는 shared database infrastructure에서 tenant-specific schema routing을 보여 주는 10장
+Spring Boot 예제를 추가한다. 예제는 strict tenant resolution, schema switching,
+tenant-local persistence, cross-tenant isolation에 집중해야 한다.
 
-## Scope
+## 범위
 
-- Add `10-multi-tenant/04-schema-per-tenant-spring-web`.
-- Resolve tenants from `X-Tenant-ID` with explicit missing and unknown tenant
-  handling.
-- Use one shared Hikari datasource and Exposed JDBC transactions.
-- Create one schema per tenant and run table operations after selecting the
-  tenant schema.
-- Test missing tenant, unknown tenant, valid tenant routing, and isolation.
-- Add README pairs and committed Architecture Diagram PNG/SVG.
+- `10-multi-tenant/04-schema-per-tenant-spring-web`를 추가한다.
+- `X-Tenant-ID`에서 tenant를 resolve하고 missing/unknown tenant를 명시적으로 처리한다.
+- 하나의 shared Hikari datasource와 Exposed JDBC transaction을 사용한다.
+- Tenant마다 하나의 schema를 만들고 tenant schema를 선택한 뒤 table operation을 실행한다.
+- Missing tenant, unknown tenant, valid tenant routing, isolation을 테스트한다.
+- README pair와 committed Architecture Diagram PNG/SVG를 추가한다.
 
-## Design
+## 설계
 
-The module uses a strict servlet filter to set a request-local `TenantContext`.
-Unlike the earlier chapter 10 baseline modules, missing tenant headers fail with
-HTTP 400 instead of falling back to a default tenant. Repository operations use
-one `tenantTransaction { }` wrapper before touching the shared `InventoryItems`
-table. Repositories must not issue ad hoc schema switching calls.
+모듈은 strict servlet filter로 request-local `TenantContext`를 설정한다. 이전 10장 baseline
+module과 달리 missing tenant header는 default tenant로 fallback하지 않고 HTTP 400으로 실패한다.
+Repository operation은 shared `InventoryItems` table을 건드리기 전에 하나의
+`tenantTransaction { }` wrapper를 사용한다. Repository는 ad hoc schema switching call을 내면
+안 된다.
 
-Every Exposed transaction MUST explicitly `SET SCHEMA` at the start; no code may
-implicitly rely on a pooled connection's prior schema state. The helper also
-resets the schema to `PUBLIC` before the transaction returns so Hikari connection
-reuse cannot expose a previous tenant's schema to the next borrower.
-Schema switching must use Exposed `Schema` objects and `SchemaUtils.setSchema`;
-raw SQL such as `exec("SET SCHEMA $name")` is forbidden even for whitelisted
-tenant values.
-Mapped schema identifiers must match `^[A-Z_][A-Z0-9_]{0,63}$` before a
-`Schema` object is created.
+모든 Exposed transaction은 시작 시 명시적으로 `SET SCHEMA`를 수행해야 한다. 어떤 코드도 pooled
+connection의 이전 schema state에 암묵적으로 의존하면 안 된다. Helper는 transaction 반환 전에
+schema를 `PUBLIC`으로 reset하여 Hikari connection reuse가 이전 tenant schema를 다음 borrower에게
+노출하지 못하게 한다. Schema switching은 Exposed `Schema` object와 `SchemaUtils.setSchema`를
+사용해야 한다. Whitelisted tenant value라도 `exec("SET SCHEMA $name")` 같은 raw SQL은 금지한다.
+Mapped schema identifier는 `Schema` object를 만들기 전에 `^[A-Z_][A-Z0-9_]{0,63}$`와
+일치해야 한다.
 
-If resetting to `PUBLIC` fails, the underlying JDBC connection must not be
-silently returned to the pool as healthy. The reset-failure path must evict the
-current Hikari connection through `HikariDataSource.evictConnection(connection)`
-or an equivalent pool-level eviction hook before rethrowing the failure.
-Tests must prove a later tenant request cannot inherit the previous tenant
-schema after reset failure handling.
-The helper obtains the physical JDBC connection from the current Exposed
-transaction via `TransactionManager.current().connection.connection as
-java.sql.Connection`; this is the Hikari-borrowed proxy connection handed to
-Exposed, not an unwrapped physical driver connection. `tenantTransaction` must
-use this shape:
+`PUBLIC` reset이 실패하면 underlying JDBC connection을 healthy 상태로 pool에 조용히 반환하면
+안 된다. Reset-failure path는 failure를 다시 던지기 전에
+`HikariDataSource.evictConnection(connection)` 또는 동등한 pool-level eviction hook으로 현재
+Hikari connection을 evict해야 한다. Test는 reset failure 처리 후 나중 tenant request가 이전
+tenant schema를 상속할 수 없음을 증명해야 한다. Helper는 현재 Exposed transaction에서
+`TransactionManager.current().connection.connection as java.sql.Connection`으로 physical JDBC
+connection을 얻는다. 이는 unwrapped physical driver connection이 아니라 Exposed에 전달된
+Hikari-borrowed proxy connection이다. `tenantTransaction`은 다음 shape를 사용해야 한다.
 `transaction { try { SchemaUtils.setSchema(tenantSchema); block() } finally { resetter.resetToPublic(proxyConnection) } }`.
-The reset therefore runs while the connection is still bound to the active
-Exposed transaction, before Exposed commits, rolls back, or releases it.
-Reset behavior is implemented behind a `SchemaResetter` seam so tests can inject
-a failing reset and assert that the connection eviction hook is invoked.
-When reset fails, the implementation must mark the current transaction for
-rollback or call rollback on the active transaction before evicting the
-Hikari-borrowed proxy connection. If Exposed later raises a secondary
-commit/rollback/connection-closed error, the original reset failure must remain
-the primary exception and the secondary failure must be attached with
-`addSuppressed`.
-If `block()` throws and `resetToPublic()` also throws, the original `block()`
-failure remains primary, the reset failure is added as suppressed, and the
-connection is evicted before rethrowing the original failure. If `block()`
-succeeds but reset fails, `tenantTransaction` rolls back the business work to
-preserve isolation, evicts the connection, logs a warning with tenant and
-operation context, and throws `TenantSchemaResetFailedException`.
+따라서 reset은 Exposed가 commit, rollback, release를 수행하기 전 active Exposed transaction에
+connection이 아직 bound된 상태에서 실행된다. Reset behavior는 `SchemaResetter` seam 뒤에
+구현하여 test가 failing reset을 inject하고 connection eviction hook 호출을 assert할 수 있게
+한다. Reset이 실패하면 구현은 Hikari-borrowed proxy connection을 evict하기 전에 현재
+transaction을 rollback으로 표시하거나 active transaction에 rollback을 호출해야 한다. 이후
+Exposed가 secondary commit/rollback/connection-closed error를 발생시키면 original reset failure가
+primary exception으로 남아야 하며 secondary failure는 `addSuppressed`로 붙어야 한다.
+`block()`이 throw하고 `resetToPublic()`도 throw하면 original `block()` failure가 primary로 남고,
+reset failure는 suppressed로 추가되며, original failure를 다시 던지기 전에 connection을
+evict한다. `block()`은 성공했지만 reset이 실패하면 `tenantTransaction`은 isolation 보존을 위해
+business work를 rollback하고, connection을 evict하며, tenant/operation context가 담긴 warning을
+로그로 남긴 뒤 `TenantSchemaResetFailedException`을 던진다.
 
-Tenant headers are mapped only through the `TenantId` whitelist. The raw request
-header is never concatenated into SQL; missing, blank, or unknown tenant values
-are rejected before schema selection.
-Tenant header values longer than 64 characters are rejected before lookup.
-The servlet filter must wrap downstream handling in `try/finally` and always
-call `TenantContext.clear()`. This example is servlet-synchronous only; it does
-not support async servlet dispatch, WebFlux, `@Async`, or coroutine context
-propagation.
+Tenant header는 `TenantId` whitelist를 통해서만 mapping된다. Raw request header는 SQL에 절대
+concatenate하지 않으며, missing, blank, unknown tenant value는 schema selection 전에 거부한다.
+64자를 넘는 tenant header value도 lookup 전에 거부한다. Servlet filter는 downstream handling을
+`try/finally`로 감싸고 항상 `TenantContext.clear()`를 호출해야 한다. 이 예제는
+servlet-synchronous 전용이며 async servlet dispatch, WebFlux, `@Async`, coroutine context
+propagation을 지원하지 않는다.
 
 Tenants:
 
 - `acme` -> `TENANT_ACME`
 - `globex` -> `TENANT_GLOBEX`
 
-The sample domain is intentionally small: inventory items keyed by SKU. Seed
-data differs per schema so tests can prove that each tenant reads its own data.
-An `ApplicationRunner` creates both tenant schemas idempotently before inserting
-seed data, so repeated test/application starts do not race DDL. The runner must
-complete during Spring application startup; integration tests only run after the
-`ApplicationContext` is ready.
+Sample domain은 의도적으로 작다. SKU를 key로 하는 inventory item만 다룬다. Seed data는
+schema마다 달라 test가 각 tenant가 자기 data를 읽는다는 점을 증명할 수 있다.
+`ApplicationRunner`는 seed data를 insert하기 전에 두 tenant schema를 idempotent하게 만들어
+반복 test/application start가 DDL race를 만들지 않게 한다. Runner는 Spring application startup
+중 완료돼야 하며, integration test는 `ApplicationContext`가 ready 상태가 된 뒤에만 실행된다.
 
-Security model: this example trusts `X-Tenant-ID` only to demonstrate routing.
-Production systems must derive the tenant from an authenticated session, token,
-or server-side account mapping instead of trusting a caller-controlled header.
-The reset target `PUBLIC` is H2-specific. PostgreSQL uses `public` plus
-`search_path` semantics, so production PostgreSQL implementations must adapt the
-reset strategy instead of copying the H2 command blindly.
-README files must call out the rollback-on-reset-failure trade-off: if a
-successful business write cannot safely reset the connection schema afterward,
-the example discards the write to preserve tenant isolation.
+Security model: 이 예제는 routing을 보여 주기 위해서만 `X-Tenant-ID`를 신뢰한다. Production
+system은 caller-controlled header를 신뢰하지 말고 authenticated session, token, server-side
+account mapping에서 tenant를 도출해야 한다. Reset target `PUBLIC`은 H2-specific이다.
+PostgreSQL은 `public`과 `search_path` semantics를 사용하므로 production PostgreSQL 구현은 H2
+command를 그대로 복사하지 말고 reset strategy를 조정해야 한다. README file은
+rollback-on-reset-failure trade-off를 명시해야 한다. 성공한 business write 이후 connection
+schema를 안전하게 reset할 수 없다면 예제는 tenant isolation을 보존하기 위해 해당 write를
+버린다.
 
-## Verification
+## 검증
 
-- `./gradlew projects` must discover `:04-schema-per-tenant-spring-web`.
+- `./gradlew projects`는 `:04-schema-per-tenant-spring-web`를 발견해야 한다.
 - `./gradlew :04-schema-per-tenant-spring-web:test`.
-- Isolation tests must force Hikari connection reuse with
-  `maximumPoolSize=1` and `minimumIdle=1`, then prove that tenant A work followed
-  by tenant B work cannot see tenant A data.
-- Isolation assertions must include tenant A inserting a unique SKU and tenant B
-  receiving 404 or an empty result for that exact SKU on the reused connection.
-- Reset-failure tests must simulate a failing `PUBLIC` reset, verify the
-  eviction hook is invoked, and verify the next tenant request remains isolated.
-- Reuse tests must assert the same physical Hikari connection is reused, for
-  example by recording `System.identityHashCode` of
+- Isolation test는 `maximumPoolSize=1`, `minimumIdle=1`로 Hikari connection reuse를 강제한
+  뒤, tenant A work 다음 tenant B work가 tenant A data를 볼 수 없음을 증명해야 한다.
+- Isolation assertion은 tenant A가 unique SKU를 insert하고, tenant B가 reused connection에서
+  해당 SKU에 대해 404 또는 empty result를 받는 사례를 포함해야 한다.
+- Reset-failure test는 failing `PUBLIC` reset을 simulate하고, eviction hook 호출 및 다음 tenant
+  request의 isolation 유지 여부를 검증해야 한다.
+- Reuse test는 예를 들어 다음 값의 `System.identityHashCode`를 기록해 같은 physical Hikari
+  connection이 재사용됨을 assert해야 한다.
   `TransactionManager.current().connection.connection`.
-- Eviction tests must treat that connection as the Hikari proxy and verify pool
-  eviction with Hikari pool stats or a changed proxy identity on the next borrow,
-  while preserving the original reset failure as the primary exception.
-- Reset-failure tests must assert `addSuppressed` behavior for both
-  `block()`-failure plus reset-failure and reset-failure plus Exposed cleanup
-  secondary failure cases when those paths are exercised.
-- README scan must show committed PNG Architecture Diagram links and no Mermaid
-  blocks.
-- `.github/workflows/examples.yml` must build the new module.
-- Nightly DB shard decision must be recorded; the module is H2-focused and does
-  not require a new Testcontainers shard.
+- Eviction test는 그 connection을 Hikari proxy로 취급하고 Hikari pool stat 또는 다음 borrow에서
+  바뀐 proxy identity로 pool eviction을 검증해야 하며, original reset failure를 primary
+  exception으로 보존해야 한다.
+- Reset-failure test는 해당 path가 실행될 때 `block()`-failure plus reset-failure 및
+  reset-failure plus Exposed cleanup secondary failure 양쪽의 `addSuppressed` behavior를
+  assert해야 한다.
+- README scan은 committed PNG Architecture Diagram link와 Mermaid block 없음 상태를 보여야 한다.
+- `.github/workflows/examples.yml`은 새 모듈을 build해야 한다.
+- Nightly DB shard decision을 기록해야 한다. 이 모듈은 H2-focused이며 새 Testcontainers shard가
+  필요하지 않다.

--- a/docs/superpowers/specs/2026-05-22-issue-53-database-per-tenant-design.md
+++ b/docs/superpowers/specs/2026-05-22-issue-53-database-per-tenant-design.md
@@ -1,104 +1,95 @@
-# Issue 53 Database-Per-Tenant Design
+# Issue 53 Database-per-tenant 설계
 
-## Context
+## 배경
 
-Issue #53 extends the Chapter 10 Spring Boot multi-tenant strategy set after
-the schema-per-tenant example from issue #52. The goal is to teach tenant
-routing at the datasource/database boundary: each accepted tenant maps to its
-own datasource and Exposed `Database`, and every repository transaction runs
-against the selected tenant database.
+Issue #53은 issue #52의 schema-per-tenant 예제 이후 10장 Spring Boot multi-tenant strategy
+set을 확장한다. 목표는 datasource/database boundary에서 tenant routing을 가르치는 것이다. 즉
+허용된 각 tenant는 자체 datasource와 Exposed `Database`로 mapping되고, 모든 repository
+transaction은 선택된 tenant database에서 실행된다.
 
-This is a Type A Full Design change because it adds a new example module,
-public README material, CI wiring, and a routing boundary that future examples
-can compare against.
+이는 새 example module, public README material, CI wiring, 향후 예제가 비교할 routing
+boundary를 추가하므로 Type A Full Design change다.
 
-## Scope
+## 범위
 
-- Add `10-multi-tenant/05-database-per-tenant-spring-web`.
-- Use Spring MVC and Exposed JDBC with two H2 in-memory tenant databases:
-  `acme` and `globex`.
-- Resolve tenant from `X-Tenant-ID` through a strict whitelist.
-- Route Exposed transactions through a `TenantDatabaseRegistry`.
-- Seed each tenant database independently.
-- Test tenant isolation, missing tenant, unknown tenant, no-default fallback,
-  and datasource lifecycle assumptions.
-- Add English/Korean READMEs with committed Architecture Diagram PNG and an
-  additional sequence diagram PNG.
-- Wire the module into Chapter 10 docs, root README files, and selected
-  examples CI.
+- `10-multi-tenant/05-database-per-tenant-spring-web`를 추가한다.
+- 두 H2 in-memory tenant database와 함께 Spring MVC 및 Exposed JDBC를 사용한다:
+  `acme`와 `globex`.
+- Strict whitelist를 통해 `X-Tenant-ID`에서 tenant를 resolve한다.
+- Exposed transaction은 `TenantDatabaseRegistry`를 통해 route한다.
+- 각 tenant database를 독립적으로 seed한다.
+- Tenant isolation, missing tenant, unknown tenant, no-default fallback, datasource lifecycle
+  assumption을 테스트한다.
+- Committed architecture diagram PNG와 추가 sequence diagram PNG가 있는 English/Korean README를
+  추가한다.
+- 모듈을 Chapter 10 docs, root README file, selected examples CI에 연결한다.
 
-Out of scope:
+범위 제외:
 
-- Runtime tenant provisioning. Issue #55 owns onboarding/provisioning.
-- Spring Security-bound tenant authorization. Issue #54 owns auth coupling.
-- Container-backed database matrix coverage for this module. The example uses
-  H2 to keep PR CI fast; the CI decision is documented in README and lessons.
+- Runtime tenant provisioning. Issue #55가 onboarding/provisioning을 소유한다.
+- Spring Security-bound tenant authorization. Issue #54가 auth coupling을 소유한다.
+- 이 모듈의 container-backed database matrix coverage. 예제는 PR CI를 빠르게 유지하기 위해 H2를
+  사용하며, CI decision은 README와 lesson에 문서화한다.
 
-## Design
+## 설계
 
-### Tenant Resolution
+### Tenant resolution
 
-`TenantFilter` reads `X-Tenant-ID`, normalizes it with trim/lowercase, and
-maps it to `TenantId`. Accepted values are `acme` and `globex`.
+`TenantFilter`는 `X-Tenant-ID`를 읽고 trim/lowercase로 normalize한 뒤 `TenantId`에 mapping한다.
+허용 값은 `acme`와 `globex`다.
 
-Missing tenant is a caller error and returns HTTP 400. Unknown tenant is not
-silently mapped to a default database; it returns HTTP 404. This intentionally
-rejects fallback routing because a default datasource would hide isolation
-misconfiguration and can leak tenant data.
+Missing tenant는 caller error이며 HTTP 400을 반환한다. Unknown tenant는 default database로
+조용히 mapping하지 않고 HTTP 404를 반환한다. Default datasource는 isolation misconfiguration을
+숨기고 tenant data를 leak할 수 있으므로 fallback routing을 의도적으로 거부한다.
 
-`TenantContext` remains request scoped through `ThreadLocal`, matching the
-Spring MVC chapter pattern and the issue #52 module.
+`TenantContext`는 Spring MVC chapter pattern 및 issue #52 module과 맞게 `ThreadLocal`을 통해
+request scoped 상태로 유지된다.
 
-`TenantFilter` must always clear `TenantContext` in `finally`, including
-controller/repository exception paths. The filter is registered with highest
-precedence so all downstream MVC handlers and error handlers see the resolved
-tenant and no later request can inherit stale `ThreadLocal` state.
+`TenantFilter`는 controller/repository exception path를 포함해 항상 `finally`에서
+`TenantContext`를 clear해야 한다. Filter는 highest precedence로 등록되어 모든 downstream MVC
+handler와 error handler가 resolved tenant를 볼 수 있고, 이후 request가 stale `ThreadLocal`
+state를 상속하지 못하게 한다.
 
-This example intentionally does not perform tenant authorization. The README
-must warn that `X-Tenant-ID` is trusted only for workshop routing; production
-systems must bind the tenant to authenticated claims or server-side session
-state. Issue #54 owns that security-bound example.
+이 예제는 의도적으로 tenant authorization을 수행하지 않는다. README는 `X-Tenant-ID`를 workshop
+routing 용도로만 신뢰한다고 경고해야 한다. Production system은 tenant를 authenticated claim
+또는 server-side session state에 bind해야 한다. Issue #54가 해당 security-bound 예제를
+소유한다.
 
-### Database Registry
+### Database registry
 
-`TenantDataSourceProperties` defines per-tenant Hikari settings under
-`app.tenants`. `DatabaseConfiguration` builds one `HikariDataSource` and one
-Exposed `Database` per configured `TenantId`. The H2 URLs must include
-`DB_CLOSE_DELAY=-1` so each tenant database survives connection churn for the
-life of the application context. The Hikari defaults are pinned in code:
-maximum pool size 4, minimum idle 1, connection timeout 5 seconds, and pool
-name `tenant-{id}` unless YAML overrides a non-safety field.
+`TenantDataSourceProperties`는 `app.tenants` 아래 per-tenant Hikari setting을 정의한다.
+`DatabaseConfiguration`은 configured `TenantId`마다 하나의 `HikariDataSource`와 하나의 Exposed
+`Database`를 만든다. 각 tenant database가 application context 생명주기 동안 connection churn을
+견디도록 H2 URL에는 `DB_CLOSE_DELAY=-1`이 포함돼야 한다. YAML이 non-safety field를 override하지
+않는 한 Hikari default는 code에 고정한다: maximum pool size 4, minimum idle 1, connection
+timeout 5 seconds, pool name `tenant-{id}`.
 
 `TenantDatabaseRegistry` exposes:
 
 - `databaseFor(tenantId: TenantId): Database`
 - `dataSourceFor(tenantId: TenantId): DataSource`
 - `configuredTenants(): Set<TenantId>`
-- `close()` for lifecycle cleanup
+- lifecycle cleanup을 위한 `close()`
 
-The registry validates at bean initialization that every `TenantId` has a
-datasource and that no unknown tenant key appears in configuration. Unknown
-or incomplete tenant configuration fails startup, not the first request.
-The registry is the only place that owns datasource lifecycle and closes all
-owned `HikariDataSource` instances through a `@PreDestroy`/`DisposableBean`
-hook.
+Registry는 bean initialization 시 모든 `TenantId`에 datasource가 있고 unknown tenant key가
+configuration에 없음을 검증한다. Unknown 또는 incomplete tenant configuration은 첫 request가
+아니라 startup을 실패시킨다. Registry는 datasource lifecycle을 소유하는 유일한 위치이며
+`@PreDestroy`/`DisposableBean` hook으로 모든 owned `HikariDataSource` instance를 닫는다.
 
-### Transaction Boundary
+### Transaction boundary
 
-`TenantTransaction.execute { ... }` obtains the current `TenantId` from
-`TenantContext`, resolves its Exposed `Database`, and runs `transaction(db)`.
+`TenantTransaction.execute { ... }`는 `TenantContext`에서 current `TenantId`를 얻고 해당 Exposed
+`Database`를 resolve한 뒤 `transaction(db)`를 실행한다.
 
-Repositories must not pick a datasource directly. They depend on
-`TenantTransaction` so the tenant/database routing boundary is explicit and
-auditable.
+Repository는 datasource를 직접 선택하면 안 된다. Repository는 `TenantTransaction`에 의존해
+tenant/database routing boundary를 명시적이고 감사 가능하게 만든다.
 
-Rollback behavior is owned by the Exposed transaction. Tests must prove that a
-failing tenant write rolls back only in that tenant database and does not alter
-another tenant database.
+Rollback behavior는 Exposed transaction이 소유한다. Test는 실패한 tenant write가 해당 tenant
+database에서만 rollback되고 다른 tenant database를 변경하지 않음을 증명해야 한다.
 
 ### Domain
 
-The new module reuses the inventory domain shape from issue #52:
+새 모듈은 issue #52의 inventory domain shape를 재사용한다.
 
 - `InventoryItems` table
 - `InventoryItemRecord`
@@ -107,42 +98,40 @@ The new module reuses the inventory domain shape from issue #52:
 - `InventoryService`
 - `InventoryController`
 
-The table name is the same in every tenant database, but physical storage is
-separate because each tenant has a different JDBC URL and Exposed `Database`.
+Table name은 모든 tenant database에서 같지만, 각 tenant가 다른 JDBC URL과 Exposed `Database`를
+갖기 때문에 physical storage는 분리된다.
 
 ### Seeding
 
-`InventorySeeder` iterates configured tenants, creates `InventoryItems`, and
-seeds tenant-specific rows through the same repository/transaction path used by
-requests. DDL bootstrap must run once per tenant database before seed writes.
-The seed operation is idempotent for repeated context starts by checking
-whether tenant rows already exist before inserting default rows. Tests assert
-`acme` and `globex` see different seed data.
+`InventorySeeder`는 configured tenant를 순회하고 `InventoryItems`를 만든 뒤 request가 사용하는
+동일한 repository/transaction path로 tenant-specific row를 seed한다. DDL bootstrap은 seed write
+전에 tenant database마다 한 번씩 실행돼야 한다. Seed
+operation은 default row insert 전에 tenant row 존재 여부를 확인해 반복 context start에서도
+idempotent하다. Test는 `acme`와 `globex`가 서로 다른 seed data를 본다고 assert한다.
 
-### Error Contract
+### Error contract
 
-- Missing `X-Tenant-ID`: 400 with `MISSING_TENANT`.
-- Unknown `X-Tenant-ID`: 404 with `UNKNOWN_TENANT`.
-- Registry missing datasource for a known tenant: startup failure.
-- No default tenant/database fallback is allowed.
+- Missing `X-Tenant-ID`: `MISSING_TENANT`와 함께 400.
+- Unknown `X-Tenant-ID`: `UNKNOWN_TENANT`와 함께 404.
+- Known tenant의 datasource가 registry에 없으면 startup failure.
+- Default tenant/database fallback은 허용하지 않는다.
 
-Error responses use a stable JSON shape:
+Error response는 stable JSON shape를 사용한다.
 
 ```json
 {"code":"MISSING_TENANT","message":"X-Tenant-ID header is required"}
 ```
 
-### README Diagrams
+### README diagram
 
-Both README files link the same committed PNG files under
-`docs/images/readme-diagrams/`:
+두 README file은 `docs/images/readme-diagrams/` 아래 같은 committed PNG file을 link한다.
 
 - `10-multi-tenant-05-database-per-tenant-spring-web-architecture-01.png`
 - `10-multi-tenant-05-database-per-tenant-spring-web-sequence-02.png`
 
-SVG sources are committed next to the PNGs. Diagram text is English.
+SVG source는 PNG 옆에 commit한다. Diagram text는 English다.
 
-## Verification
+## 검증
 
 Local verification:
 
@@ -150,38 +139,35 @@ Local verification:
 - `./gradlew :05-database-per-tenant-spring-web:build --stacktrace --continue`
 - `./gradlew projects --quiet | rg '05-database-per-tenant-spring-web'`
 - `actionlint .github/workflows/examples.yml`
-- README diagram scan for Architecture Diagram PNG links and no Mermaid blocks.
-- Visual inspection of generated PNGs for readable contrast.
+- Architecture Diagram PNG link와 Mermaid block 없음 상태를 확인하는 README diagram scan.
+- Generated PNG의 readable contrast에 대한 visual inspection.
 
 Required test coverage:
 
-- Parallel alternating requests through the MVC thread pool cannot leak
-  `TenantContext`.
-- A failing tenant write rolls back in the selected tenant only.
-- DDL bootstrap creates `InventoryItems` in every configured tenant database.
-- Unknown tenant config keys and missing known tenant config fail fast.
-- Registry close closes all owned Hikari datasources.
+- MVC thread pool을 통한 parallel alternating request는 `TenantContext`를 leak할 수 없다.
+- 실패한 tenant write는 selected tenant에서만 rollback된다.
+- DDL bootstrap은 configured tenant database마다 `InventoryItems`를 만든다.
+- Unknown tenant config key와 missing known tenant config는 fail fast한다.
+- Registry close는 모든 owned Hikari datasource를 닫는다.
 
-Review gates:
+Review gate:
 
-- Step 2-R/3-R advisor review on this spec and plan using Claude Code CLI via
-  stdin with timeout >= 5 minutes.
-- Step 6-R code review after implementation using the 6-Tier frame plus Claude
-  Code CLI via stdin with timeout >= 5 minutes.
+- 이 spec/plan에 대해 stdin과 timeout >= 5 minutes를 사용하는 Claude Code CLI로 Step 2-R/3-R
+  advisor review를 수행한다.
+- 구현 후 6-Tier frame과 stdin 및 timeout >= 5 minutes를 사용하는 Claude Code CLI로 Step 6-R
+  code review를 수행한다.
 
-## CI Decision
+## CI 결정
 
-This module should run in selected examples CI because it uses H2-only tenant
-databases and does not start Testcontainers. Full repository DB matrix coverage
-will still run through the existing CI workflow when non-doc files change, but
-the module itself is designed to remain fast and deterministic.
+이 모듈은 H2-only tenant database를 사용하고 Testcontainers를 시작하지 않으므로 selected
+examples CI에서 실행해야 한다. Non-doc file이 변경되면 full repository DB matrix coverage는
+기존 CI workflow로 계속 실행되지만, 모듈 자체는 빠르고 deterministic하게 유지되도록 설계됐다.
 
-## Advisor Gate
+## Advisor gate
 
 - Initial artifact:
   `.omx/artifacts/claude-issue-53-spec-plan-advisor-stdin-6min-20260522235409.md`
 - Result: FAIL, P0=2, P1=6.
-- Accepted edits: ThreadLocal cleanup/filter ordering, H2 URL lifecycle,
-  README auth-trust warning, registry lifecycle hook, concurrent isolation
-  tests, rollback tests, DDL bootstrap, stable error JSON, and fail-fast
-  configuration validation.
+- 반영한 수정: ThreadLocal cleanup/filter ordering, H2 URL lifecycle, README auth-trust warning,
+  registry lifecycle hook, concurrent isolation test, rollback test, DDL bootstrap, stable error
+  JSON, fail-fast configuration validation.

--- a/docs/superpowers/specs/2026-05-22-issue-61-http-outbox-idempotency-design.md
+++ b/docs/superpowers/specs/2026-05-22-issue-61-http-outbox-idempotency-design.md
@@ -1,65 +1,64 @@
-# Issue 61 HTTP Outbox Idempotency Design
+# Issue 61 HTTP outbox idempotency 설계
 
-## Context
+## 배경
 
-Issue #61 adds a chapter 12 pair that demonstrates safe outbound HTTP integration
-for Spring Boot 4 and Ktor services backed by Exposed JDBC.
+Issue #61은 Exposed JDBC 기반 Spring Boot 4/Ktor service의 safe outbound HTTP integration을
+보여 주는 12장 pair를 추가한다.
 
-Prior retrieval:
+이전 검색:
 
 - `gno query "HTTP client outbox idempotency external API persisted outbound requests retry duplicate permanent failure examples" -c bluetape4k-docs --no-rerank`
 - `gno query "Spring Boot Ktor Exposed outbox idempotency retry transaction cancellation testcontainers cautions" -c bluetape4k-docs --no-rerank`
 - `gno query "outbox idempotency external API retry duplicate key permanent failure Kotlin Exposed" -c wiki --no-rerank`
 
-Relevant cautions:
+관련 주의사항:
 
-- Keep blocking Exposed JDBC work inside repositories.
-- Ktor routes must not call `transaction {}` directly.
-- Duplicate writes must be explicit through an idempotency key.
-- Retryable and permanent failures must persist different states.
+- Blocking Exposed JDBC work는 repository 안에 둔다.
+- Ktor route는 `transaction {}`을 직접 호출하면 안 된다.
+- Duplicate write는 idempotency key를 통해 명시적이어야 한다.
+- Retryable failure와 permanent failure는 서로 다른 state로 저장돼야 한다.
 
-## Scope
+## 범위
 
-Add two modules:
+두 모듈을 추가한다.
 
 - `12-production-integration/03-spring-http-outbox-idempotency`
 - `12-production-integration/04-ktor-http-outbox-idempotency`
 
-Both modules expose:
+두 모듈 모두 다음 endpoint를 노출한다.
 
-- `POST /payments` to persist an outbound payment request and dispatch it.
-- `POST /payments/{id}/retry` to retry retryable failures.
-- `GET /payments/{id}` and `GET /payments` to inspect stored outbox records.
-- `/` and `/health` discovery endpoints.
+- `POST /payments`: outbound payment request를 저장하고 dispatch한다.
+- `POST /payments/{id}/retry`: retryable failure를 다시 시도한다.
+- `GET /payments/{id}` 및 `GET /payments`: 저장된 outbox record를 조회한다.
+- `/` 및 `/health` discovery endpoint.
 
-## Domain Contract
+## Domain contract
 
-`PaymentRequest` contains `orderId`, `amountCents`, and `idempotencyKey`.
+`PaymentRequest`는 `orderId`, `amountCents`, `idempotencyKey`를 포함한다.
 
-The service must:
+Service는 다음을 만족해야 한다.
 
-1. Normalize and validate caller input.
-2. Insert a pending outbox row before calling the external client.
-3. Return the existing record for duplicate idempotency keys.
-4. Mark 2xx external responses as `SUCCEEDED`.
-5. Mark retryable failures as `RETRYABLE_FAILED`.
-6. Mark client/permanent failures as `PERMANENT_FAILED`.
-7. Retry only `RETRYABLE_FAILED` records.
+1. Caller input을 normalize/validate한다.
+2. External client 호출 전에 pending outbox row를 insert한다.
+3. Duplicate idempotency key에는 existing record를 반환한다.
+4. 2xx external response를 `SUCCEEDED`로 표시한다.
+5. Retryable failure를 `RETRYABLE_FAILED`로 표시한다.
+6. Client/permanent failure를 `PERMANENT_FAILED`로 표시한다.
+7. `RETRYABLE_FAILED` record만 retry한다.
 
-## Implementation Notes
+## 구현 메모
 
-- Spring production client uses `RestClient`.
-- Ktor production client uses Ktor `HttpClient`.
-- Tests use fake clients and do not call real external services.
-- Exposed table names are stack-specific to avoid collision:
+- Spring production client는 `RestClient`를 사용한다.
+- Ktor production client는 Ktor `HttpClient`를 사용한다.
+- Test는 fake client를 사용하며 real external service를 호출하지 않는다.
+- Collision을 피하기 위해 Exposed table name은 stack-specific으로 둔다.
   - `spring_payment_outbox`
   - `ktor_payment_outbox`
-- Public README files explain the Spring vs Ktor tradeoff.
+- Public README file은 Spring vs Ktor tradeoff를 설명한다.
 
-## Acceptance Criteria
+## 수용 기준
 
-- Both modules build and test independently.
-- Success, retryable failure, duplicate idempotency key, and permanent failure
-  paths are covered.
-- `.github/workflows/examples.yml` builds the new modules.
-- Root and chapter README files list the new pair.
+- 두 모듈은 독립적으로 build/test된다.
+- Success, retryable failure, duplicate idempotency key, permanent failure path를 다룬다.
+- `.github/workflows/examples.yml`은 새 모듈을 build한다.
+- Root 및 chapter README file은 새 pair를 나열한다.

--- a/docs/superpowers/specs/2026-05-23-issue-54-spring-security-tenant-authorization-design.md
+++ b/docs/superpowers/specs/2026-05-23-issue-54-spring-security-tenant-authorization-design.md
@@ -1,86 +1,81 @@
-# Issue 54 Spring Security Tenant Authorization Design
+# Issue 54 Spring Security tenant authorization 설계
 
-## Context
+## 배경
 
-Issue #54 closes the production trust gap left by the Chapter 10 routing
-examples. The existing Spring MVC examples show tenant propagation and
-isolation, but `X-Tenant-ID` is still the final trust source. This example must
-authenticate the caller first, derive the caller's tenant from security
-material, then authorize the requested tenant before any Exposed JDBC
-transaction can select a tenant database.
+Issue #54는 10장 routing example이 남긴 production trust gap을 닫는다. 기존 Spring MVC 예제는
+tenant propagation과 isolation을 보여 주지만, `X-Tenant-ID`가 여전히 final trust source다. 이
+예제는 어떤 Exposed JDBC transaction도 tenant database를 선택하기 전에 caller를 먼저
+authenticate하고, security material에서 caller tenant를 도출한 뒤 requested tenant를 authorize해야
+한다.
 
-This is a Type A Full Design change because it adds a security-sensitive
-example module, public README material, CI wiring, and review-gated
-authorization behavior.
+이는 security-sensitive example module, public README material, CI wiring, review-gated
+authorization behavior를 추가하므로 Type A Full Design change다.
 
-## External Evidence
+## 외부 근거
 
-- Spring Security 6.5 servlet resource server documentation shows Kotlin
-  `SecurityFilterChain` configuration with OAuth2 Resource Server JWT and a
-  custom `jwtAuthenticationConverter`.
+- Spring Security 6.5 servlet resource server documentation은 OAuth2 Resource Server JWT와
+  custom `jwtAuthenticationConverter`를 사용하는 Kotlin `SecurityFilterChain` configuration을
+  보여 준다.
   Source: Context7 `/websites/spring_io_spring-security_reference_6_5`,
   servlet OAuth2 resource server JWT.
-- Spring Security test support provides MockMvc request post processors,
-  including JWT/OAuth2 helpers through `spring-security-test`.
+- Spring Security test support는 `spring-security-test`를 통해 JWT/OAuth2 helper를 포함한
+  MockMvc request post processor를 제공한다.
   Source: Context7 `/websites/spring_io_spring-security_reference_6_5`,
   servlet test API docs.
-- Existing repository pattern:
+- 기존 repository pattern:
   `12-production-integration/05-spring-auth-session` uses servlet
   `SecurityFilterChain`, stateless JSON security, and `spring-security-test`.
-- Existing tenant routing pattern:
+- 기존 tenant routing pattern:
   `10-multi-tenant/05-database-per-tenant-spring-web` owns one Hikari pool and
   Exposed `Database` per tenant, with no default datasource fallback.
-- Prior R2DBC sibling design:
+- 이전 R2DBC sibling design:
   `exposed-r2dbc-workshop` issue #40 requires tenant claim failures to remain
   authorization failures and requires the routing context to be written only
   after tenant authorization succeeds.
-- Module `05` normalizes tenant headers with `trim().lowercase()`. This module
-  keeps that policy so `X-Tenant-ID: ACME` maps to `acme`.
+- Module `05`는 tenant header를 `trim().lowercase()`로 normalize한다. 이 모듈도
+  `X-Tenant-ID: ACME`가 `acme`로 mapping되도록 해당 policy를 유지한다.
 
-## Scope
+## 범위
 
-- Add `10-multi-tenant/06-spring-security-tenant-authorization-spring-web`.
-- Use Spring MVC, Spring Security, Exposed JDBC, and two H2 tenant databases:
-  `acme` and `globex`.
-- Support three self-contained authentication paths for the workshop:
-  - JWT bearer token with a `tenant_id` claim.
-  - API key header mapped to a tenant.
-  - Demo session header mapped to a tenant.
-- Keep the inventory API and database-per-tenant routing shape comparable to
-  module `05`.
-- Add English/Korean READMEs with committed Architecture Diagram PNG and an
-  additional sequence/request-flow PNG.
-- Wire the module into Chapter 10 docs, root README docs where module lists are
-  maintained, and selected examples CI.
+- `10-multi-tenant/06-spring-security-tenant-authorization-spring-web`를 추가한다.
+- Spring MVC, Spring Security, Exposed JDBC, 두 H2 tenant database를 사용한다:
+  `acme`와 `globex`.
+- Workshop을 위해 self-contained authentication path 세 가지를 지원한다:
+  - `tenant_id` claim이 있는 JWT bearer token.
+  - Tenant에 mapping되는 API key header.
+  - Tenant에 mapping되는 demo session header.
+- Inventory API와 database-per-tenant routing shape를 module `05`와 비교 가능하게 유지한다.
+- Committed architecture diagram PNG와 추가 sequence/request-flow PNG가 있는 English/Korean
+  README를 추가한다.
+- 모듈을 Chapter 10 docs, module list를 유지하는 root README docs, selected examples CI에
+  연결한다.
 
-Out of scope:
+범위 제외:
 
-- Production identity provider or authorization server setup.
-- Dynamic tenant onboarding/provisioning. Issue #55 owns that.
-- A shared bluetape4k security abstraction.
-- Testcontainers database matrix coverage. This module remains H2-only and the
-  CI decision is documented.
+- Production identity provider 또는 authorization server setup.
+- Dynamic tenant onboarding/provisioning. Issue #55가 이를 소유한다.
+- Shared bluetape4k security abstraction.
+- Testcontainers database matrix coverage. 이 모듈은 H2-only로 유지되며 CI decision을
+  문서화한다.
 
-## Design
+## 설계
 
-### Security Boundary
+### Security boundary
 
-The example must prove this invariant:
+예제는 다음 invariant를 증명해야 한다.
 
-1. Authentication establishes a tenant identity.
-2. `X-Tenant-ID` selects the target tenant.
-3. Tenant authorization succeeds only when the authenticated tenant equals the
-   requested tenant.
-4. `TenantContext` is written only after tenant authorization succeeds.
-5. Repositories select an Exposed `Database` only through `TenantTransaction`.
+1. Authentication은 tenant identity를 수립한다.
+2. `X-Tenant-ID`는 target tenant를 선택한다.
+3. Tenant authorization은 authenticated tenant가 requested tenant와 같을 때만 성공한다.
+4. `TenantContext`는 tenant authorization이 성공한 뒤에만 기록된다.
+5. Repository는 `TenantTransaction`을 통해서만 Exposed `Database`를 선택한다.
 
-No request path may write `TenantContext` from the raw tenant header alone. If
-header-only trust can reach Exposed, the module fails its primary purpose.
+어떤 request path도 raw tenant header만으로 `TenantContext`를 쓰면 안 된다. Header-only trust가
+Exposed까지 도달할 수 있다면 모듈은 primary purpose에 실패한 것이다.
 
-### Authentication Sources
+### Authentication source
 
-The module supports fixed demo credentials so tests and README snippets remain
-self-contained:
+Test와 README snippet이 self-contained 상태로 남도록 모듈은 fixed demo credential을 지원한다.
 
 | Source | Request shape | Tenant source |
 |---|---|---|
@@ -88,119 +83,103 @@ self-contained:
 | API key | `X-API-Key: demo-acme-key` | configured API key map |
 | Demo session | `X-Demo-Session: acme-session` | configured demo session map |
 
-The demo JWT decoder accepts only fixed token strings. It returns Spring
-Security `Jwt` instances with predictable claims and does not implement signing
-or issuer discovery. That keeps the example focused on tenant authorization,
-not identity-provider infrastructure.
+Demo JWT decoder는 fixed token string만 허용한다. Predictable claim을 가진 Spring Security
+`Jwt` instance를 반환하며 signing이나 issuer discovery를 구현하지 않는다. 이렇게 해서 예제는
+identity-provider infrastructure가 아니라 tenant authorization에 집중한다.
 
-JWT authentication must still succeed when a bearer token is syntactically
-valid but lacks a tenant claim. The tenant claim problem is an authorization
-failure and should return `403 Forbidden`, not `401 Unauthorized`.
+Bearer token이 syntactically valid하지만 tenant claim이 없어도 JWT authentication은 성공해야
+한다. Tenant claim 문제는 authentication failure가 아니라 authorization failure이므로
+`401 Unauthorized`가 아니라 `403 Forbidden`을 반환해야 한다.
 
-Invalid bearer tokens, invalid API keys, and invalid demo sessions remain
-authentication failures and return `401 Unauthorized`.
+Invalid bearer token, invalid API key, invalid demo session은 authentication failure로 남으며
+`401 Unauthorized`를 반환한다.
 
-### Credential Precedence
+### Credential precedence
 
-Multiple credential sources in one request are rejected before authentication.
-A request may send exactly one of:
+하나의 request에 여러 credential source가 있으면 authentication 전에 거부한다. Request는 다음 중
+정확히 하나만 보낼 수 있다.
 
 - `Authorization: Bearer ...`
 - `X-API-Key`
 - `X-Demo-Session`
 
-Header presence means at least one header value exists and at least one value
-is non-blank after trim. Empty API-key or demo-session headers do not count as
-credential sources and do not authenticate.
+Header presence는 header value가 최소 하나 존재하고 trim 후 non-blank value가 최소 하나 있음을
+뜻한다. Empty API-key 또는 demo-session header는 credential source로 세지 않으며 authenticate하지
+않는다.
 
-The `Authorization` header is counted as a bearer credential source only when
-any non-blank header value uses the `Bearer` scheme with case-insensitive
-scheme matching. Non-bearer authorization schemes and authorization values
-without a scheme are ignored by this example because the module does not
-support Basic, Digest, or form login authentication. Multiple `Authorization`
-header values are scanned together; if any value is bearer and another
-supported credential source is present, the request is conflicting.
+`Authorization` header는 non-blank header value 중 하나가 case-insensitive scheme matching으로
+`Bearer` scheme을 사용할 때만 bearer credential source로 센다. 이 모듈은 Basic, Digest, form
+login authentication을 지원하지 않으므로 non-bearer authorization scheme과 scheme 없는
+authorization value는 무시한다. 여러 `Authorization` header value는 함께 scan한다. Bearer value가
+있고 다른 supported credential source도 있으면 request는 conflicting 상태다.
 
-If two or more credential sources are present, the request returns
-`400 Bad Request` with `CONFLICTING_CREDENTIALS`. The module deliberately avoids
-"first credential wins" behavior because it can hide cross-tenant escalation
-attempts such as bearer token `acme` plus API key `globex`.
+Credential source가 둘 이상 있으면 request는 `CONFLICTING_CREDENTIALS`와 함께
+`400 Bad Request`를 반환한다. Bearer token `acme`와 API key `globex` 조합 같은 cross-tenant
+escalation attempt를 숨길 수 있으므로 이 모듈은 "first credential wins" behavior를 의도적으로
+피한다.
 
-Public health checks bypass credential conflict checks and tenant
-authorization. `/actuator/health` returns the health response even when a proxy
-or caller sends unrelated credential headers.
+Public health check는 credential conflict check와 tenant authorization을 bypass한다. Proxy 또는
+caller가 unrelated credential header를 보내도 `/actuator/health`는 health response를 반환한다.
 
-### Authorization Filter
+### Authorization filter
 
-Custom filters are plain classes instantiated inside `SecurityConfiguration`;
-they are not `@Component` classes and are not exposed as `Filter` beans. This
-prevents Spring Boot from registering them as independent servlet filters
-outside `SecurityFilterChain`.
+Custom filter는 `SecurityConfiguration` 안에서 instantiate되는 plain class다. `@Component`
+class가 아니며 `Filter` bean으로 노출하지 않는다. 이는 Spring Boot가 이들을
+`SecurityFilterChain` 밖의 independent servlet filter로 등록하는 것을 막는다.
 
-`CredentialConflictFilter` is registered inside `SecurityFilterChain` before
-authentication filters. It checks only credential-source presence and writes
-`400 CONFLICTING_CREDENTIALS` for mixed credential sources.
+`CredentialConflictFilter`는 authentication filter 앞의 `SecurityFilterChain` 안에 등록된다.
+이 filter는 credential-source presence만 확인하고 mixed credential source에는
+`400 CONFLICTING_CREDENTIALS`를 쓴다.
 
-`TenantAuthorizationFilter` is registered inside `SecurityFilterChain`. It runs
-after Spring Security authentication and request authentication authorization
-have had a chance to populate and validate `SecurityContextHolder`, but before
-MVC handler invocation. It:
+`TenantAuthorizationFilter`는 `SecurityFilterChain` 안에 등록된다. Spring Security
+authentication과 request authentication authorization이 `SecurityContextHolder`를 populate/validate할
+기회를 가진 뒤, MVC handler invocation 전에 실행된다. 이 filter는 다음을 수행한다.
 
-- skips public actuator health requests;
-- resolves the authenticated tenant from JWT/API-key/demo-session
-  authentication;
-- returns `403` for missing, malformed, unknown, or mismatched authenticated
-  tenant identity;
-- validates exactly one `X-Tenant-ID` header only after the authenticated
-  tenant is valid;
-- rejects blank, comma-containing, too-long, or unknown tenant selectors;
-- sets `TenantContext` only for an authorized tenant and clears it in
-  `finally`.
+- public actuator health request를 skip한다.
+- JWT/API-key/demo-session authentication에서 authenticated tenant를 resolve한다.
+- Missing, malformed, unknown, mismatched authenticated tenant identity에는 `403`을 반환한다.
+- Authenticated tenant가 valid한 뒤에만 정확히 하나의 `X-Tenant-ID` header를 검증한다.
+- Blank, comma-containing, too-long, unknown tenant selector를 거부한다.
+- Authorized tenant에 대해서만 `TenantContext`를 설정하고 `finally`에서 clear한다.
 
-The check order is fixed:
+Check order는 고정이다.
 
-1. `CredentialConflictFilter` skips public health, then rejects mixed supported
-   credential sources.
-2. Spring Security authenticates the one supported credential source.
-3. Spring Security `AuthorizationFilter` enforces authentication for inventory
-   requests.
-4. `TenantAuthorizationFilter` resolves the authenticated tenant and returns
-   `403` for missing, malformed, or unknown tenant identity.
-5. Only after a valid authenticated tenant exists, the filter validates
-   `X-Tenant-ID` and returns `400`/`404` for selector errors.
-6. Tenant mismatch returns `403`; match sets `TenantContext` and continues.
+1. `CredentialConflictFilter`는 public health를 skip한 뒤 mixed supported credential source를
+   거부한다.
+2. Spring Security는 하나의 supported credential source를 authenticate한다.
+3. Spring Security `AuthorizationFilter`는 inventory request에 authentication을 강제한다.
+4. `TenantAuthorizationFilter`는 authenticated tenant를 resolve하고 missing, malformed, unknown
+   tenant identity에는 `403`을 반환한다.
+5. Valid authenticated tenant가 존재한 뒤에만 filter는 `X-Tenant-ID`를 검증하고 selector error에
+   `400`/`404`를 반환한다.
+6. Tenant mismatch는 `403`을 반환한다. Match는 `TenantContext`를 설정하고 계속 진행한다.
 
-Spring Security owns `401` and `403` for authentication and authorization
-failures. Tenant selector validation returns stable JSON errors before the
-request reaches the controller.
+Spring Security는 authentication/authorization failure의 `401` 및 `403`을 소유한다. Tenant
+selector validation은 request가 controller에 도달하기 전에 stable JSON error를 반환한다.
 
-`DemoApiKeyAuthenticationFilter` and `DemoSessionAuthenticationFilter` are also
-registered inside the Spring Security chain, before bearer-token authentication.
-They must not be plain `@Component` servlet filters because they create
-`Authentication` objects and must participate in Spring Security exception
-translation.
+`DemoApiKeyAuthenticationFilter`와 `DemoSessionAuthenticationFilter`도 bearer-token authentication
+앞의 Spring Security chain 안에 등록된다. 이 filter들은 `Authentication` object를 만들고 Spring
+Security exception translation에 참여해야 하므로 plain `@Component` servlet filter가 되면 안 된다.
 
-Security logs must not record raw `Authorization`, `X-API-Key`, or
-`X-Demo-Session` values. When a credential-related failure is logged, log only
-the credential source and outcome, not the secret-bearing header value.
+Security log는 raw `Authorization`, `X-API-Key`, `X-Demo-Session` 값을 기록하면 안 된다.
+Credential-related failure를 log할 때는 secret-bearing header value가 아니라 credential source와
+outcome만 기록한다.
 
-### Tenant Routing
+### Tenant routing
 
-The database-per-tenant infrastructure is intentionally similar to module `05`:
+Database-per-tenant infrastructure는 의도적으로 module `05`와 비슷하게 유지한다.
 
-- `TenantDataSourceProperties` configures all known tenant datasources under
-  `app.tenants`.
-- `TenantDatabaseRegistry` builds and owns one Hikari pool and one Exposed
-  `Database` per `TenantId`.
-- `TenantTransaction.execute { ... }` reads `TenantContext.current()` by
-  default and runs `transaction(registry.databaseFor(tenant))`.
-- The registry fails startup if a known tenant is missing or an unknown tenant
-  is configured.
-- There is no default datasource fallback.
+- `TenantDataSourceProperties`는 `app.tenants` 아래 모든 known tenant datasource를 설정한다.
+- `TenantDatabaseRegistry`는 `TenantId`마다 하나의 Hikari pool과 하나의 Exposed `Database`를
+  만들고 소유한다.
+- `TenantTransaction.execute { ... }`는 기본적으로 `TenantContext.current()`를 읽고
+  `transaction(registry.databaseFor(tenant))`를 실행한다.
+- Known tenant가 없거나 unknown tenant가 설정되면 registry는 startup을 실패시킨다.
+- Default datasource fallback은 없다.
 
 ### Domain
 
-The module reuses the inventory API shape from module `05`:
+모듈은 module `05`의 inventory API shape를 재사용한다.
 
 - `InventoryItems`
 - `InventoryItemRecord`
@@ -210,10 +189,10 @@ The module reuses the inventory API shape from module `05`:
 - `InventoryController`
 - `InventorySeeder`
 
-Tenant seed data must be visibly different for `acme` and `globex` so tests and
-README examples can prove isolation.
+Tenant seed data는 test와 README example이 isolation을 증명할 수 있도록 `acme`와 `globex`에서
+눈에 띄게 달라야 한다.
 
-### Error Contract
+### Error contract
 
 | Case | Result |
 |---|---|
@@ -228,31 +207,27 @@ README examples can prove isolation.
 | authenticated tenant malformed | `403 Forbidden` |
 | authenticated tenant differs from `X-Tenant-ID` | `403 Forbidden` |
 
-The 400/404 tenant-selector behavior stays aligned with module `05`; the new
-403 cases are the security boundary added by this issue.
-Tenant selector and tenant claim values are normalized with trim/lowercase
-before matching, so `ACME`, ` acme `, and `acme` are treated as the same tenant.
-The tenant selector length cap is 64 characters, matching module `05`. Blank,
-comma-containing, and too-long values remain malformed.
-For request tenant selectors, blank, duplicated, comma-containing, and too-long
-values intentionally reuse module `05`'s `MISSING_TENANT` code. For
-authenticated tenant identity, malformed means a non-string claim, blank claim,
-comma-containing claim, mid-value whitespace, or a value longer than 64
-characters. Malformed authenticated identity returns `403` because the caller
-is authenticated but not authorized for a valid tenant.
+400/404 tenant-selector behavior는 module `05`와 정렬된 상태를 유지한다. 새로운 403 case는 이
+issue가 추가하는 security boundary다. Tenant selector와 tenant claim value는 matching 전에
+trim/lowercase로 normalize되므로 `ACME`, ` acme `, `acme`는 같은 tenant로 취급된다. Tenant
+selector length cap은 module `05`와 같은 64자다. Blank, comma-containing, too-long value는
+malformed 상태로 남는다. Request tenant selector에서는 blank, duplicated, comma-containing,
+too-long value가 의도적으로 module `05`의 `MISSING_TENANT` code를 재사용한다. Authenticated
+tenant identity에서 malformed는 non-string claim, blank claim, comma-containing claim,
+mid-value whitespace, 64자를 넘는 value를 뜻한다. Malformed authenticated identity는 caller가
+authenticated 상태지만 valid tenant에 authorized되지 않았으므로 `403`을 반환한다.
 
-### README Diagrams
+### README diagram
 
-Both README files link the same committed PNG files under
-`docs/images/readme-diagrams/`:
+두 README file은 `docs/images/readme-diagrams/` 아래 같은 committed PNG file을 link한다.
 
 - `10-multi-tenant-06-spring-security-tenant-authorization-spring-web-architecture-01.png`
 - `10-multi-tenant-06-spring-security-tenant-authorization-spring-web-sequence-02.png`
 
-SVG sources are committed next to the PNGs. Diagram text is English. README
-files must not contain Mermaid blocks.
+SVG source는 PNG 옆에 commit한다. Diagram text는 English다. README file은 Mermaid block을
+포함하면 안 된다.
 
-## Verification
+## 검증
 
 Local verification:
 
@@ -260,38 +235,38 @@ Local verification:
 - `./gradlew :06-spring-security-tenant-authorization-spring-web:build --stacktrace --continue`
 - `./gradlew projects --quiet | rg '06-spring-security-tenant-authorization-spring-web'`
 - `actionlint .github/workflows/examples.yml`
-- README diagram scan for Architecture Diagram PNG links, existing PNG files,
-  and no Mermaid blocks.
-- Visual inspection of generated PNGs for readable contrast.
+- Architecture Diagram PNG link, existing PNG file, Mermaid block 없음 상태를 확인하는 README
+  diagram scan.
+- Generated PNG의 readable contrast에 대한 visual inspection.
 
 Required test coverage:
 
-- JWT tenant claim can access the matching tenant.
-- JWT/header mismatch returns 403.
-- JWT without `tenant_id` returns 403.
-- Missing authentication returns 401.
-- API key can access the matching tenant.
-- Invalid API key returns 401.
-- Demo session can access the matching tenant.
-- Demo session/header mismatch returns 403.
-- Missing, malformed, and unknown tenant selectors keep the module's stable
-  400/404 error contract for authenticated callers.
-- Parallel authorized `acme`/`globex` requests cannot leak `TenantContext`.
-- A failing downstream request clears `TenantContext` on the servlet thread.
-- Architecture scan proves only `TenantAuthorizationFilter` writes
-  `TenantContext` on HTTP request paths.
-- Multi-credential requests are rejected with `CONFLICTING_CREDENTIALS`.
-- Uppercase tenant selector and tenant claim variants follow the explicit
-  trim/lowercase normalization policy.
+- JWT tenant claim은 matching tenant에 접근할 수 있다.
+- JWT/header mismatch는 403을 반환한다.
+- `tenant_id` 없는 JWT는 403을 반환한다.
+- Missing authentication은 401을 반환한다.
+- API key는 matching tenant에 접근할 수 있다.
+- Invalid API key는 401을 반환한다.
+- Demo session은 matching tenant에 접근할 수 있다.
+- Demo session/header mismatch는 403을 반환한다.
+- Missing, malformed, unknown tenant selector는 authenticated caller에 대해 module의 stable
+  400/404 error contract를 유지한다.
+- Parallel authorized `acme`/`globex` request는 `TenantContext`를 leak할 수 없다.
+- Failing downstream request는 servlet thread에서 `TenantContext`를 clear한다.
+- Architecture scan은 HTTP request path에서 `TenantContext`를 쓰는 주체가
+  `TenantAuthorizationFilter`뿐임을 증명한다.
+- Multi-credential request는 `CONFLICTING_CREDENTIALS`로 거부된다.
+- Uppercase tenant selector와 tenant claim variant는 명시적 trim/lowercase normalization
+  policy를 따른다.
 
-Review gates:
+Review gate:
 
-- Step 2-R/3-R advisor review on this spec and plan using Claude Code CLI via
-  stdin with timeout >= 5 minutes.
-- Step 6-R code review after implementation using the 6-Tier frame plus Claude
-  Code CLI via stdin with timeout >= 5 minutes.
+- 이 spec/plan에 대해 stdin과 timeout >= 5 minutes를 사용하는 Claude Code CLI로 Step 2-R/3-R
+  advisor review를 수행한다.
+- 구현 후 6-Tier frame과 stdin 및 timeout >= 5 minutes를 사용하는 Claude Code CLI로 Step 6-R
+  code review를 수행한다.
 
-## Advisor Gate
+## Advisor gate
 
 | Artifact | Result | Notes |
 |---|---|---|
@@ -299,9 +274,8 @@ Review gates:
 | `.omx/artifacts/claude-issue-54-spec-plan-advisor-rerun-stdin-6min-20260523010057.md` | FAIL, P0=0/P1=3 | Accepted edits for bearer detection, authorization/selector check order, and malformed authenticated tenant semantics. |
 | `.omx/artifacts/claude-issue-54-spec-plan-advisor-rerun2-stdin-6min-20260523010327.md` | PASS, P0=0/P1=0 | Applied P2 clarifications for concrete filter anchors, blank credential presence, multiple authorization headers, selector length, and whitespace normalization tests. |
 
-## CI Decision
+## CI 결정
 
-This module is H2-only, so it belongs in selected Examples CI and does not need
-a Nightly Testcontainers shard. The selected Examples workflow must include the
-module path filters and the `:06-spring-security-tenant-authorization-spring-web:build`
-task.
+이 모듈은 H2-only이므로 selected Examples CI에 속하며 Nightly Testcontainers shard가 필요하지
+않다. Selected Examples workflow는 module path filter와
+`:06-spring-security-tenant-authorization-spring-web:build` task를 포함해야 한다.

--- a/docs/superpowers/specs/2026-06-28-issue-137-ecosystem-integrations-design.md
+++ b/docs/superpowers/specs/2026-06-28-issue-137-ecosystem-integrations-design.md
@@ -1,69 +1,59 @@
-# Issue #137 Ecosystem Integrations Chapter Design
+# Issue #137 Ecosystem integrations chapter 설계
 
-## Context
+## 배경
 
-Issue #137 is the parent epic for `bluetape4k-exposed 1.11.0` and adjacent
-DDD/Modulith workshop examples. Its child issues (#138-#145) cover database
-platform integrations, explicit Ktor integration, Spring Modulith publication
-storage, and DDD aggregate/module-boundary examples.
+Issue #137은 `bluetape4k-exposed 1.11.0` 및 인접 DDD/Modulith workshop example의 parent
+epic이다. Child issue #138-#145는 database platform integration, explicit Ktor integration,
+Spring Modulith publication storage, DDD aggregate/module-boundary example을 다룬다.
 
-The current repository already has `12-production-integration` for
-production-style Spring Boot 4 and Ktor service patterns. That chapter is about
-HTTP entrypoints, service boundaries, outbox/auth/realtime/observability, and
-small production-facing applications. Putting BigQuery, Trino, StarRocks,
-CockroachDB, DDD, and Modulith examples into chapter 12 would make the chapter
-mix runtime production concerns with ecosystem/dialect/framework integration
-concerns.
+현재 repository에는 production-style Spring Boot 4/Ktor service pattern을 위한
+`12-production-integration`이 이미 있다. 그 장은 HTTP entrypoint, service boundary,
+outbox/auth/realtime/observability, 작은 production-facing application을 다룬다. BigQuery,
+Trino, StarRocks, CockroachDB, DDD, Modulith 예제를 12장에 넣으면 runtime production concern과
+ecosystem/dialect/framework integration concern이 한 장에 섞인다.
 
-The accepted chapter name is `13-ecosystem-integrations`.
+채택된 chapter name은 `13-ecosystem-integrations`다.
 
-## Goals
+## 목표
 
-- Add a new chapter boundary for ecosystem-level Exposed examples.
-- Keep issue #137 as the parent epic and leave #138-#145 as implementable child
-  examples.
-- Make the future module order explicit before the child issues are
-  implemented.
-- Wire the new chapter into root documentation and workflow path filters so
-  future module work triggers the existing Examples gate when child PRs touch
-  the chapter.
-- Avoid pretending that the child example implementations exist before they are
-  built.
+- Ecosystem-level Exposed example을 위한 새 chapter boundary를 추가한다.
+- Issue #137은 parent epic으로 유지하고 #138-#145는 implementable child example로 둔다.
+- Child issue 구현 전에 future module order를 명시한다.
+- 새 chapter를 root documentation 및 workflow path filter에 연결해 향후 child PR이 chapter를
+  수정할 때 기존 Examples gate가 trigger되게 한다.
+- Child example implementation이 build되기 전에 이미 존재하는 것처럼 보이지 않게 한다.
 
-## Non-Goals
+## 비목표
 
-- Do not implement the BigQuery, Trino, CockroachDB, StarRocks, Ktor,
-  Modulith, or DDD child examples in this foundation PR.
-- Do not close #137 until the child issue chain is complete or the user
-  explicitly chooses to treat the scaffold as the epic closeout.
-- Do not add ad hoc dependency versions. Future child modules must continue to
-  use the existing catalog/BOM conventions.
-- Do not move current chapter 12 modules.
+- 이 foundation PR에서 BigQuery, Trino, CockroachDB, StarRocks, Ktor, Modulith, DDD child
+  example을 구현하지 않는다.
+- Child issue chain이 완료되거나 사용자가 scaffold를 epic closeout으로 취급하겠다고 명시하기
+  전까지 #137을 닫지 않는다.
+- Ad hoc dependency version을 추가하지 않는다. Future child module은 기존 catalog/BOM
+  convention을 계속 사용해야 한다.
+- 현재 12장 모듈을 이동하지 않는다.
 
-## Current Evidence
+## 현재 근거
 
-- `settings.gradle.kts` includes chapter directories through
-  `includeModules("<chapter>", false, false)`.
-- `12-production-integration/README.md` defines chapter 12 as Spring/Ktor
-  production service pattern coverage.
-- `docs/lessons/2026-05-22-issue-63-chapter-12-wiring.md` records that chapter
-  wiring must update root README pairs, chapter README pairs, workflow coverage,
-  and diagram assets.
-- `docs/lessons/2026-06-06-issue-118-examples-weekly.md` records that downstream
-  examples should extend the weekly Examples workflow scope.
-- GitHub issue #137 lists #138-#145 as child example issues under milestone
-  `exposed-1.11.0`.
+- `settings.gradle.kts`는 `includeModules("<chapter>", false, false)`를 통해 chapter
+  directory를 포함한다.
+- `12-production-integration/README.md`는 12장을 Spring/Ktor production service pattern
+  coverage로 정의한다.
+- `docs/lessons/2026-05-22-issue-63-chapter-12-wiring.md`는 chapter wiring이 root README pair,
+  chapter README pair, workflow coverage, diagram asset을 갱신해야 한다고 기록한다.
+- `docs/lessons/2026-06-06-issue-118-examples-weekly.md`는 downstream example이 weekly Examples
+  workflow scope를 확장해야 한다고 기록한다.
+- GitHub issue #137은 milestone `exposed-1.11.0` 아래 child example issue로 #138-#145를
+  나열한다.
 
-## Design
+## 설계
 
-Create `13-ecosystem-integrations/` as a chapter-level directory with
-`README.md` and `README.ko.md`. The chapter README describes the integration
-map and lists the planned child modules as issue-backed placeholders, not as
-implemented examples.
+`README.md`와 `README.ko.md`가 있는 chapter-level directory
+`13-ecosystem-integrations/`를 만든다. Chapter README는 integration map을 설명하고, planned
+child module을 implemented example이 아니라 issue-backed placeholder로 나열한다.
 
-The root README pair should link only the chapter overview until child modules
-exist. Planned child examples belong in the chapter README pair with explicit
-`Planned` status and GitHub issue links.
+Child module이 존재하기 전까지 root README pair는 chapter overview만 link해야 한다. Planned
+child example은 명시적 `Planned` status 및 GitHub issue link와 함께 chapter README pair에 둔다.
 
 Planned child module order:
 
@@ -78,112 +68,102 @@ Planned child module order:
 | #144 | Planned | `13-ecosystem-integrations/07-ddd-aggregate-repository` | `:07-ddd-aggregate-repository:build` | DDD Aggregate Lifecycle with Exposed Repository | Domain architecture |
 | #145 | Planned | `13-ecosystem-integrations/08-ddd-modulith-boundaries` | `:08-ddd-modulith-boundaries:build` | DDD Bounded Context and Modulith Boundary Verification | Domain architecture |
 
-Register the chapter in:
+Chapter를 다음 위치에 등록한다.
 
 - `settings.gradle.kts` with `includeModules("13-ecosystem-integrations", false, false)`.
-  This adds a base-directory scan hook. It does not create a Gradle project
-  until a child module directory with `build.gradle.kts` exists.
-- Root `README.md` and `README.ko.md` with a new module-list section.
+  이는 base-directory scan hook을 추가한다. `build.gradle.kts`가 있는 child module directory가
+  생기기 전까지 Gradle project는 만들지 않는다.
+- 새 module-list section이 있는 root `README.md`와 `README.ko.md`.
 - Repo-local `AGENTS.md` layout table.
-- `.github/workflows/examples.yml` path filters, so future chapter 13 module
-  PRs trigger the selected Examples gate. This foundation PR should not add
-  non-existent Gradle tasks to the hard-coded Examples build list. Each child
-  module PR must add its own Gradle task to that selected build list when it
-  creates a runnable module.
+- `.github/workflows/examples.yml` path filter. 이를 통해 향후 chapter 13 module PR이 selected
+  Examples gate를 trigger한다. 이 foundation PR은 hard-coded Examples build list에 존재하지 않는
+  Gradle task를 추가하면 안 된다. 각 child module PR은 runnable module을 만들 때 해당 selected
+  build list에 자체 Gradle task를 추가해야 한다.
 
-Add one chapter-level architecture diagram:
+Chapter-level architecture diagram 하나를 추가한다.
 
 - `docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.svg`
 - `docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.png`
 
-The diagram should show three lanes:
+Diagram은 세 lane을 보여 줘야 한다.
 
 1. Database platform adapters: BigQuery, Trino, CockroachDB, StarRocks.
 2. Runtime/framework integration: explicit Ktor and Spring Modulith.
-3. Domain architecture: DDD aggregate lifecycle and Modulith boundary
-   verification.
+3. Domain architecture: DDD aggregate lifecycle 및 Modulith boundary verification.
 
-## External Service And Credential Policy
+## External service 및 credential 정책
 
-Future child modules must be safe by default:
+Future child module은 default safe 상태여야 한다.
 
-- No checked-in credentials, tokens, service-account files, project IDs, or
-  endpoint secrets.
-- No automatic use of real cloud credentials such as ADC or local credential
-  files in default tests.
-- Default tests must use fake/local/Testcontainers/emulator-style paths or be
-  deterministic documentation-only checks.
-- Real external-service execution must be opt-in through explicit environment
-  variables, Gradle properties, or test tags, and skipped by default in CI.
-- Child module PRs must document whether their selected workflow coverage
-  belongs in the weekly Examples gate, the full Nightly matrix, or an explicit
-  opt-in/manual lane. The default path must remain local and deterministic.
-- README files for cloud or external-service examples must include cost,
-  network, and credential warnings before any real-service command.
+- Checked-in credential, token, service-account file, project ID, endpoint secret 없음.
+- Default test에서 ADC나 local credential file 같은 real cloud credential을 자동으로 사용하지
+  않는다.
+- Default test는 fake/local/Testcontainers/emulator-style path 또는 deterministic
+  documentation-only check를 사용해야 한다.
+- Real external-service execution은 explicit environment variable, Gradle property, test tag를
+  통한 opt-in이어야 하며 CI default에서는 skip해야 한다.
+- Child module PR은 selected workflow coverage가 weekly Examples gate, full Nightly matrix,
+  explicit opt-in/manual lane 중 어디에 속하는지 문서화해야 한다. Default path는 local 및
+  deterministic 상태로 남아야 한다.
+- Cloud 또는 external-service example의 README file은 real-service command 전에 cost, network,
+  credential warning을 포함해야 한다.
 
-## Rejected Approaches
+## 기각한 접근
 
 ### Extend `12-production-integration`
 
-Rejected because chapter 12 already has a clear production-service purpose.
-Adding cloud warehouse, OLAP, dialect, DDD, and Modulith examples there would
-make the chapter too broad and would hide the new Exposed 1.11 ecosystem theme.
+12장은 이미 명확한 production-service purpose를 가지므로 기각한다. Cloud warehouse, OLAP,
+dialect, DDD, Modulith 예제를 거기에 추가하면 장이 너무 넓어지고 새로운 Exposed 1.11 ecosystem
+theme가 숨겨진다.
 
 ### Name the chapter `13-exposed-1-11`
 
-Rejected because version-named chapters age quickly. The milestone and issue
-metadata already preserve the release context. The chapter name should describe
-the durable learning theme.
+Version-named chapter는 빠르게 낡으므로 기각한다. Milestone과 issue metadata가 release context를
+이미 보존한다. Chapter name은 durable learning theme를 설명해야 한다.
 
 ### Create empty child modules for #138-#145 now
 
-Rejected because empty Gradle projects would imply runnable examples exist.
-The child issues should create their modules with tests and README pairs when
-each example is implemented.
+Empty Gradle project는 runnable example이 존재한다고 암시하므로 기각한다. Child issue는 각
+example을 구현할 때 test와 README pair가 있는 module을 만들어야 한다.
 
-## Risks And Mitigations
+## 위험 및 완화
 
-- Risk: documentation claims future examples are implemented. Mitigation: mark
-  them as planned issue-backed examples and link to issue numbers.
-- Risk: future chapter changes do not run Examples workflow. Mitigation: add
-  `13-ecosystem-integrations/**` to Examples workflow path filters, and require
-  child PRs to add hard-coded Gradle task entries only when their runnable
-  modules exist.
-- Risk: future cloud examples accidentally depend on real credentials or
-  billable services. Mitigation: make local/fake execution the default and
-  require real-service tests to be opt-in and skipped by default in CI.
-- Risk: Gradle discovery is not proven. Mitigation: run `./gradlew projects`
-  after adding `settings.gradle.kts` registration and record that the
-  foundation PR creates no new Gradle project yet because no child module
-  directory exists.
-- Risk: diagram assets fail README quality expectations. Mitigation: render SVG
-  to PNG with CairoSVG, validate the SVG as XML, inspect the PNG, and verify
-  README references point to committed SVG/PNG siblings.
+- Risk: documentation이 future example이 이미 구현됐다고 주장할 수 있다. 완화: 이를
+  planned issue-backed example로 표시하고 issue number를 link한다.
+- Risk: future chapter change가 Examples workflow를 실행하지 않을 수 있다. 완화:
+  `13-ecosystem-integrations/**`를 Examples workflow path filter에 추가하고, child PR은 runnable
+  module이 존재할 때만 hard-coded Gradle task entry를 추가하도록 요구한다.
+- Risk: future cloud example이 real credential이나 billable service에 우발적으로 의존할 수 있다.
+  완화: local/fake execution을 default로 만들고 real-service test는 opt-in 및 CI default
+  skip을 요구한다.
+- Risk: Gradle discovery가 증명되지 않을 수 있다. 완화: `settings.gradle.kts` registration
+  추가 후 `./gradlew projects`를 실행하고, child module directory가 없으므로 foundation PR이 아직
+  새 Gradle project를 만들지 않는다는 점을 기록한다.
+- Risk: diagram asset이 README quality expectation을 만족하지 못할 수 있다. 완화: SVG를
+  CairoSVG로 PNG rendering하고, SVG를 XML로 validate하며, PNG를 inspect하고, README reference가
+  committed SVG/PNG sibling을 가리키는지 검증한다.
 
-## Acceptance Criteria
+## 수용 기준
 
-- `13-ecosystem-integrations/README.md` and `README.ko.md` exist and explain the
-  chapter purpose.
-- Root `README.md` and `README.ko.md` list the new chapter.
-- Root README entries link only the chapter overview until child modules exist.
-- Chapter README pairs include the same planned issue table, language switch,
-  and diagram reference in both locales.
-- `AGENTS.md` lists the chapter in the repo layout table.
-- `settings.gradle.kts` adds the chapter base-directory scan hook.
-- `.github/workflows/examples.yml` includes chapter 13 path filters.
-- `.github/workflows/examples.yml` does not reference missing chapter 13 Gradle
-  tasks before child modules exist.
-- Future child modules are documented as credential-free by default with
-  opt-in real-service execution only.
-- Chapter diagram SVG and PNG are committed and referenced from both README
-  locales.
-- SVG XML validation passes for the chapter diagram.
-- README references to the chapter diagram resolve to committed files.
-- Chapter diagram dimensions/viewBox are sane for README rendering and the PNG
-  is visually inspected.
-- `./gradlew projects` runs successfully; the expected foundation result is no
-  new chapter 13 Gradle project until a child module exists.
-- `git diff --check` and `actionlint .github/workflows/examples.yml` pass.
-- README link/reference checks cover the new root and chapter links.
-- The PR references #137 but does not close it unless child issues are also
-  complete.
+- `13-ecosystem-integrations/README.md`와 `README.ko.md`가 존재하고 chapter purpose를
+  설명한다.
+- Root `README.md`와 `README.ko.md`가 새 chapter를 나열한다.
+- Root README entry는 child module이 존재하기 전까지 chapter overview만 link한다.
+- Chapter README pair는 두 locale 모두에서 같은 planned issue table, language switch, diagram
+  reference를 포함한다.
+- `AGENTS.md`가 repo layout table에 chapter를 나열한다.
+- `settings.gradle.kts`가 chapter base-directory scan hook을 추가한다.
+- `.github/workflows/examples.yml`이 chapter 13 path filter를 포함한다.
+- `.github/workflows/examples.yml`은 child module이 존재하기 전 missing chapter 13 Gradle task를
+  참조하지 않는다.
+- Future child module은 default credential-free 및 opt-in real-service execution only로
+  문서화된다.
+- Chapter diagram SVG/PNG가 commit되고 두 README locale에서 참조된다.
+- Chapter diagram의 SVG XML validation이 통과한다.
+- Chapter diagram에 대한 README reference가 committed file로 resolve된다.
+- Chapter diagram dimension/viewBox는 README rendering에 적절하고 PNG는 시각적으로 검사된다.
+- `./gradlew projects`가 성공한다. Expected foundation result는 child module이 생기기 전까지
+  새 chapter 13 Gradle project가 없다는 것이다.
+- `git diff --check`와 `actionlint .github/workflows/examples.yml`가 통과한다.
+- README link/reference check는 새 root/chapter link를 다룬다.
+- PR은 #137을 reference하지만 child issue도 완료되지 않는 한 close하지 않는다.

--- a/docs/superpowers/specs/2026-06-29-issue-138-bigquery-dry-run-design.md
+++ b/docs/superpowers/specs/2026-06-29-issue-138-bigquery-dry-run-design.md
@@ -1,112 +1,106 @@
-# Issue #138 BigQuery Dry-Run Workshop Design
+# Issue #138 BigQuery dry-run workshop 설계
 
-## Context
+## 배경
 
-Issue #138 is the first runnable child example under chapter 13,
-`13-ecosystem-integrations`. The parent epic #137 created the chapter boundary
-for Exposed 1.11 ecosystem examples and reserved
-`13-ecosystem-integrations/01-bigquery-dry-run` for this module.
+Issue #138은 13장 `13-ecosystem-integrations` 아래 첫 runnable child example이다. Parent epic
+#137은 Exposed 1.11 ecosystem example을 위한 chapter boundary를 만들고 이 모듈을 위해
+`13-ecosystem-integrations/01-bigquery-dry-run`을 예약했다.
 
 `bluetape4k-exposed` issue #228 already added the product feature:
 `BigQueryContext`, `BigQueryQueryOptions`, dry-run validation for raw/generated
 SQL, and query-job options such as billed-byte limits, labels, priority,
-location, destination table, timeout, and query cache flags. That repository
-also has a compact `examples-exposed-bigquery-dry-run` example. This workshop
-module should not simply copy that example. It should make the learning path
-clearer for `exposed-workshop` readers by showing how an Exposed analytical
-read model becomes generated SQL and then a credential-free BigQuery dry-run
-request.
+location, destination table, timeout, query cache flag. 해당 repository에는 compact
+`examples-exposed-bigquery-dry-run` example도 있다. 이 workshop module은 그 예제를 단순 복사하면
+안 된다. Exposed analytical read model이 generated SQL이 되고 다시 credential-free BigQuery
+dry-run request가 되는 흐름을 보여 줘 `exposed-workshop` reader의 learning path를 더 명확히
+해야 한다.
 
-## Goals
+## 목표
 
-- Add the first runnable chapter 13 module:
+- 첫 runnable chapter 13 module을 추가한다:
   `13-ecosystem-integrations/01-bigquery-dry-run`.
-- Demonstrate generated SQL validation through
-  `BigQueryContext.validateQuery`, not only raw SQL validation.
-- Keep the default path credential-free, deterministic, network-free, and
-  cost-free by using a mocked BigQuery REST client.
-- Verify generated SQL, query-job option mapping, success handling, and failure
-  handling in tests.
-- Add English and Korean module README files with a clear distinction between
-  dry-run validation and query execution.
-- Add a README diagram as both editable SVG and rendered PNG.
-- Promote issue #138 from `Planned` to `Ready` in the chapter README pair and
-  add the module task to the weekly Examples workflow.
+- Raw SQL validation뿐 아니라 `BigQueryContext.validateQuery`를 통한 generated SQL validation을
+  보여 준다.
+- Mocked BigQuery REST client를 사용해 default path를 credential-free, deterministic,
+  network-free, cost-free 상태로 유지한다.
+- Test에서 generated SQL, query-job option mapping, success handling, failure handling을
+  검증한다.
+- Dry-run validation과 query execution의 차이를 명확히 설명하는 English/Korean module README를
+  추가한다.
+- README diagram을 editable SVG와 rendered PNG로 추가한다.
+- Chapter README pair에서 issue #138을 `Planned`에서 `Ready`로 승격하고 weekly Examples
+  workflow에 module task를 추가한다.
 
-## Non-Goals
+## 비목표
 
-- Do not contact real Google Cloud BigQuery in default tests.
-- Do not use Application Default Credentials, local credential files, service
-  accounts, project secrets, or user-provided cloud endpoints by default.
-- Do not add a BigQuery emulator or Testcontainers dependency for this example.
-  The acceptance criteria are about dry-run request construction and error
-  mapping, which can be tested deterministically with a mocked REST client.
-- Do not implement #139-#145.
-- Do not close parent epic #137.
+- Default test에서 real Google Cloud BigQuery에 접속하지 않는다.
+- Application Default Credentials, local credential file, service account, project secret,
+  user-provided cloud endpoint를 default로 사용하지 않는다.
+- 이 예제에 BigQuery emulator 또는 Testcontainers dependency를 추가하지 않는다. 수용 기준은
+  dry-run request construction과 error mapping이며, mocked REST client로 deterministic하게
+  테스트할 수 있다.
+- #139-#145를 구현하지 않는다.
+- Parent epic #137을 닫지 않는다.
 
-## Current Evidence
+## 현재 근거
 
-- `settings.gradle.kts` already scans `13-ecosystem-integrations` with
-  `includeModules("13-ecosystem-integrations", false, false)`, so adding a
-  child directory with `build.gradle.kts` creates Gradle project
-  `:01-bigquery-dry-run`.
-- `.github/workflows/examples.yml` already has chapter 13 path filters but no
-  chapter 13 Gradle task. The child module PR must add
-  `:01-bigquery-dry-run:build` to the selected Examples build list.
-- `.github/workflows/ci.yml` and `.github/workflows/nightly.yml` already run
-  broad `test` or matrix coverage tasks and do not need child-module-specific
-  path additions for this mock-only module. The implementation must still
-  record explicit N/A evidence for CI, Nightly, summary `needs`, and coverage
-  artifact changes during the registration audit.
-- `gradle/libs.versions.toml` imports `bluetape4k-dependencies` 1.3.1 and
-  already has aliases for common bluetape4k and Exposed modules, but it does
-  not yet expose `bluetape4k-exposed-bigquery`.
-- `bluetape4k-dependencies/gradle/libs.versions.toml` defines
-  `bluetape4k-exposed-bigquery`, so this repo can add the same catalog alias
-  without pinning an extra local version.
-- `bluetape4k-exposed` has the source APIs:
+- `settings.gradle.kts`는 이미 `includeModules("13-ecosystem-integrations", false, false)`로
+  `13-ecosystem-integrations`를 scan하므로, `build.gradle.kts`가 있는 child directory를 추가하면
+  Gradle project `:01-bigquery-dry-run`이 만들어진다.
+- `.github/workflows/examples.yml`에는 이미 chapter 13 path filter가 있지만 chapter 13 Gradle
+  task는 없다. Child module PR은 selected Examples build list에 `:01-bigquery-dry-run:build`를
+  추가해야 한다.
+- `.github/workflows/ci.yml`과 `.github/workflows/nightly.yml`은 이미 broad `test` 또는 matrix
+  coverage task를 실행하며, 이 mock-only module에는 child-module-specific path addition이
+  필요하지 않다. 구현은 registration audit 중 CI, Nightly, summary `needs`, coverage artifact
+  change에 대한 명시적 N/A evidence를 그래도 기록해야 한다.
+- `gradle/libs.versions.toml`은 `bluetape4k-dependencies` 1.3.1을 import하고 common bluetape4k
+  및 Exposed module alias를 이미 갖고 있지만, 아직 `bluetape4k-exposed-bigquery`를 노출하지
+  않는다.
+- `bluetape4k-dependencies/gradle/libs.versions.toml`은 `bluetape4k-exposed-bigquery`를
+  정의하므로 이 repo도 extra local version을 pin하지 않고 같은 catalog alias를 추가할 수 있다.
+- `bluetape4k-exposed`에는 다음 source API가 있다:
   `BigQueryContext`, `BigQueryQueryOptions`, `BigQueryQueryPriority`,
   `BigQueryQueryException`, and `BigQueryResultRow`.
-- The sibling example uses `MockK` to capture a `QueryRequest`, which is the
-  right credential-free testing strategy for this workshop module.
+- Sibling example은 `MockK`로 `QueryRequest`를 capture하며, 이는 이 workshop module에 맞는
+  credential-free testing strategy다.
 
-## Design
+## 설계
 
-Create a small module focused on one scenario: validating a dashboard read model
-before a potentially billable warehouse query is executed.
+Potentially billable warehouse query가 실행되기 전에 dashboard read model을 검증하는 하나의
+scenario에 집중한 작은 모듈을 만든다.
 
-The module will contain:
+모듈은 다음을 포함한다.
 
 - `build.gradle.kts`
-  - depends on `libs.exposed.bigquery`, JetBrains Exposed core/JDBC, H2,
-    MockK, and `bluetape4k-junit5`
-  - keeps the dependency version governed by the imported bluetape4k BOM
-- `README.md` and `README.ko.md`
-  - explain dry run vs execution
-  - document the credential-free default command
-  - describe what is verified by the tests
-  - warn that real-service execution is intentionally out of this issue's scope
+  - `libs.exposed.bigquery`, JetBrains Exposed core/JDBC, H2, MockK, `bluetape4k-junit5`에
+    의존한다.
+  - Dependency version은 imported bluetape4k BOM이 관리하게 유지한다.
+- `README.md`와 `README.ko.md`
+  - dry run vs execution을 설명한다.
+  - credential-free default command를 문서화한다.
+  - test가 무엇을 검증하는지 설명한다.
+  - real-service execution이 의도적으로 이 issue scope 밖임을 경고한다.
 - one small production source package:
   `exposed.examples.bigquery.dryrun`
   - `BigQueryDryRunWorkshop.kt`
-  - local `Events` table object for generated SQL
-  - helper functions that build the read-model query, create default dry-run
-    options, and call `BigQueryContext.validateQuery`
+  - generated SQL을 위한 local `Events` table object.
+  - read-model query를 만들고 default dry-run option을 생성하며
+    `BigQueryContext.validateQuery`를 호출하는 helper function.
 - one test source package:
   `exposed.examples.bigquery.dryrun`
   - `BigQueryDryRunWorkshopTest.kt`
-  - MockK stubs for the real Google API service chain:
-    `Bigquery`, `Bigquery.Jobs`, and `Bigquery.Jobs.Query`
-  - capture of the real `QueryRequest` passed to `Jobs.query(projectId, request)`
-  - tests for success, option mapping, generated SQL shape, and BigQuery error
-    conversion
+  - Real Google API service chain에 대한 MockK stub:
+    `Bigquery`, `Bigquery.Jobs`, `Bigquery.Jobs.Query`
+  - `Jobs.query(projectId, request)`에 전달되는 실제 `QueryRequest` capture.
+  - success, option mapping, generated SQL shape, BigQuery error conversion test.
 - test resources:
   `junit-platform.properties` and `logback-test.xml`
 - diagram assets:
   `docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.svg`
   `docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.png`
 
-The main test should generate a query like:
+Main test는 다음과 같은 query를 생성해야 한다.
 
 ```kotlin
 Events
@@ -116,7 +110,7 @@ Events
     .orderBy(Events.region)
 ```
 
-Then call:
+그런 다음 다음을 호출한다.
 
 ```kotlin
 context.validateQuery(
@@ -131,99 +125,86 @@ context.validateQuery(
 )
 ```
 
-Assertions should verify:
+Assertion은 다음을 검증해야 한다.
 
 - `QueryRequest.dryRun == true`
 - `useLegacySql == false`
-- `defaultDataset` contains the explicit project and dataset IDs
-- generated SQL includes `SELECT`, `FROM EVENTS`, `GROUP BY`, and `ORDER BY`
-- `maximumBytesBilled`, labels, priority, location, and timeout are mapped
-- a successful dry run returns a complete response
-- a BigQuery error response is surfaced as `BigQueryQueryException` with a
-  clear message
+- `defaultDataset`은 explicit project/dataset ID를 포함한다.
+- Generated SQL이 `SELECT`, `FROM EVENTS`, `GROUP BY`, `ORDER BY`를 포함한다.
+- `maximumBytesBilled`, labels, priority, location, timeout이 mapping된다.
+- Successful dry run은 complete response를 반환한다.
+- BigQuery error response는 clear message가 있는 `BigQueryQueryException`으로 노출된다.
 
-## Approach Comparison
+## 접근 비교
 
 ### A. Mocked REST dry-run with generated SQL
 
-Recommended. It proves the Exposed-to-BigQuery boundary without credentials or
-network access. It also keeps the module fast enough for weekly Examples CI.
+권장한다. Credential이나 network access 없이 Exposed-to-BigQuery boundary를 증명한다. 또한
+weekly Examples CI에 충분히 빠른 module 상태를 유지한다.
 
 ### B. BigQuery emulator
 
-Rejected for this issue. It is useful for broader execution semantics but adds
-container lifecycle complexity and does not improve confidence in query-job
-option mapping for this dry-run example.
+이 issue에서는 기각한다. 더 넓은 execution semantics에는 유용하지만 container lifecycle
+complexity를 추가하며 이 dry-run example의 query-job option mapping 신뢰도를 높이지 않는다.
 
 ### C. Real BigQuery opt-in test
 
-Rejected for the default module. It would require credentials, project
-configuration, network access, and cost guardrails. A future manual opt-in
-example can be opened separately if needed.
+Default module에서는 기각한다. Credential, project configuration, network access, cost
+guardrail이 필요하기 때문이다. 필요하면 향후 manual opt-in example을 별도로 열 수 있다.
 
-For issue #138, do not add any executable opt-in path for real BigQuery. The
-module must not read `GOOGLE_APPLICATION_CREDENTIALS`, Application Default
-Credentials, service-account files, `GOOGLE_CLOUD_PROJECT`, endpoint overrides,
-tokens, API keys, system properties, or environment variables, and must not
-construct a real Google Cloud BigQuery client. Only mocked REST client wiring is
-allowed.
+Issue #138에서는 real BigQuery용 executable opt-in path를 추가하지 않는다. 모듈은
+`GOOGLE_APPLICATION_CREDENTIALS`, Application Default Credentials, service-account file,
+`GOOGLE_CLOUD_PROJECT`, endpoint override, token, API key, system property, environment
+variable을 읽으면 안 되고, real Google Cloud BigQuery client를 만들면 안 된다. Mocked REST
+client wiring만 허용한다.
 
-## Risks And Mitigations
+## 위험 및 완화
 
-- Risk: generated SQL assertions become brittle across Exposed formatting
-  changes. Mitigation: assert durable SQL fragments instead of one full
-  whitespace-exact SQL string.
-- Risk: README accidentally implies a real BigQuery query is executed.
-  Mitigation: use explicit dry-run vs execution wording in both locales.
-- Risk: credentials leak into tests through ADC or local environment. Mitigation:
-  construct only a mocked BigQuery REST client in tests, keep placeholder
-  project and dataset IDs as test constants only, and scan executable code for
-  real-client or environment/property access.
-- Risk: Exposed/H2 global state leaks across tests. Mitigation: create a
-  deterministic H2 SQL-generation database in test setup, keep each validation
-  inside `BigQueryContext.validateQuery` transaction boundaries, and avoid
-  shared mutable mock state by recreating the mocked client per test.
-- Risk: workflow turns green without building the new module. Mitigation: add
-  `:01-bigquery-dry-run:build` to `.github/workflows/examples.yml` in the same
-  PR that creates the runnable module.
-- Risk: dependency drift from local catalog edits. Mitigation: add only the
-  centrally governed `exposed-bigquery` alias and rely on the imported
-  `bluetape4k-dependencies` BOM for the version.
+- Risk: generated SQL assertion이 Exposed formatting change에 brittle해질 수 있다.
+  완화: 전체 whitespace-exact SQL string 대신 durable SQL fragment를 assert한다.
+- Risk: README가 real BigQuery query가 실행된다고 우발적으로 암시할 수 있다. 완화: 두
+  locale 모두에서 dry-run vs execution wording을 명시적으로 사용한다.
+- Risk: ADC 또는 local environment를 통해 credential이 test로 leak될 수 있다. 완화:
+  test에서는 mocked BigQuery REST client만 만들고 placeholder project/dataset ID는 test constant로만
+  유지하며, executable code에서 real-client 또는 environment/property access를 scan한다.
+- Risk: Exposed/H2 global state가 test 사이에 leak될 수 있다. 완화: test setup에서
+  deterministic H2 SQL-generation database를 만들고 각 validation을
+  `BigQueryContext.validateQuery` transaction boundary 안에 유지하며, test마다 mocked client를 다시
+  만들어 shared mutable mock state를 피한다.
+- Risk: 새 모듈을 build하지 않아도 workflow가 green이 될 수 있다. 완화: runnable module을
+  만드는 같은 PR에서 `.github/workflows/examples.yml`에 `:01-bigquery-dry-run:build`를 추가한다.
+- Risk: local catalog edit로 dependency drift가 생길 수 있다. 완화: centrally governed
+  `exposed-bigquery` alias만 추가하고 version은 imported `bluetape4k-dependencies` BOM에 의존한다.
 
-## Acceptance Criteria
+## 수용 기준
 
-- `13-ecosystem-integrations/01-bigquery-dry-run/build.gradle.kts` exists and
-  Gradle discovers project `:01-bigquery-dry-run`.
-- Default tests run without Google Cloud credentials, ADC, network access, or
-  billable BigQuery execution.
-- No production, test, README command, or example path reads Google credential
-  environment variables, system properties, service-account files, project
-  secrets, endpoint overrides, tokens, API keys, or constructs a real BigQuery
-  service/client.
-- Tests construct `BigQueryContext` with deterministic placeholder constants for
-  project ID, dataset ID, and location, then MockK-capture the actual
-  `QueryRequest` sent through `Bigquery.Jobs.query`.
-- Tests verify generated SQL fragments, dry-run flag, default dataset,
-  billed-byte cap, labels, priority, location, timeout, success response, and
-  failure response handling.
-- New tests use JUnit 5, MockK, and `bluetape4k-assertions`.
-- `README.md` and `README.ko.md` exist for the module and include a language
-  switch.
-- README files explain dry-run validation vs query execution and document the
-  credential-free test command.
-- Diagram SVG and PNG are committed under `docs/images/readme-diagrams/` and
-  referenced from both README locales.
-- Chapter README pair marks #138 as runnable and links the module README pair.
-- Root README pair lists the first runnable chapter 13 module.
-- `.github/workflows/examples.yml` runs `:01-bigquery-dry-run:build`.
-- New-module registration audit records `settings.gradle.kts`,
-  repo-local module lists, CI, Nightly, Examples workflow path filters/jobs,
-  summary `needs`, coverage artifacts, and explicit N/A rationale where no
-  change is required.
-- `actionlint .github/workflows/examples.yml` passes.
-- `./gradlew :01-bigquery-dry-run:test` and
-  `./gradlew :01-bigquery-dry-run:build` pass.
-- `./gradlew projects --quiet` includes `:01-bigquery-dry-run`.
-- `git diff --check` passes.
-- PR metadata is derived from live issue #138 metadata, closes #138, references
-  parent #137, and verifies #137 remains open.
+- `13-ecosystem-integrations/01-bigquery-dry-run/build.gradle.kts`가 존재하고 Gradle이 project
+  `:01-bigquery-dry-run`을 발견한다.
+- Default test는 Google Cloud credential, ADC, network access, billable BigQuery execution
+  없이 실행된다.
+- Production, test, README command, example path 중 어느 것도 Google credential environment
+  variable, system property, service-account file, project secret, endpoint override, token,
+  API key를 읽거나 real BigQuery service/client를 만들지 않는다.
+- Test는 project ID, dataset ID, location에 deterministic placeholder constant를 사용해
+  `BigQueryContext`를 만들고, `Bigquery.Jobs.query`를 통해 전달된 실제 `QueryRequest`를
+  MockK-capture한다.
+- Test는 generated SQL fragment, dry-run flag, default dataset, billed-byte cap, label,
+  priority, location, timeout, success response, failure response handling을 검증한다.
+- 새 test는 JUnit 5, MockK, `bluetape4k-assertions`를 사용한다.
+- 모듈에 `README.md`와 `README.ko.md`가 존재하고 language switch를 포함한다.
+- README file은 dry-run validation vs query execution을 설명하고 credential-free test command를
+  문서화한다.
+- Diagram SVG/PNG는 `docs/images/readme-diagrams/` 아래 commit되고 두 README locale에서
+  참조된다.
+- Chapter README pair는 #138을 runnable로 표시하고 module README pair를 link한다.
+- Root README pair는 첫 runnable chapter 13 module을 나열한다.
+- `.github/workflows/examples.yml`은 `:01-bigquery-dry-run:build`를 실행한다.
+- New-module registration audit는 `settings.gradle.kts`, repo-local module list, CI, Nightly,
+  Examples workflow path filter/job, summary `needs`, coverage artifact, 변경이 필요 없는 곳의
+  explicit N/A rationale를 기록한다.
+- `actionlint .github/workflows/examples.yml` 통과.
+- `./gradlew :01-bigquery-dry-run:test`와 `./gradlew :01-bigquery-dry-run:build` 통과.
+- `./gradlew projects --quiet`는 `:01-bigquery-dry-run`을 포함한다.
+- `git diff --check` 통과.
+- PR metadata는 live issue #138 metadata에서 파생되고, #138을 close하며, parent #137을
+  reference하고, #137이 계속 open임을 검증한다.

--- a/docs/superpowers/specs/2026-06-29-issue-139-trino-session-options-design.md
+++ b/docs/superpowers/specs/2026-06-29-issue-139-trino-session-options-design.md
@@ -1,77 +1,74 @@
-# Issue #139 Trino Session Options Workshop Design
+# Issue #139 Trino session option workshop 설계
 
-## Context
+## 배경
 
-Issue #139 is the second child of epic #137 for chapter 13 ecosystem
-integrations. The previous child, #138, added a credential-free BigQuery
-dry-run example as `13-ecosystem-integrations/01-bigquery-dry-run`.
+Issue #139는 13장 ecosystem integration을 위한 epic #137의 두 번째 child다. 이전 child #138은
+credential-free BigQuery dry-run 예제 `13-ecosystem-integrations/01-bigquery-dry-run`을
+추가했다.
 
-The next planned module is `13-ecosystem-integrations/02-trino-session-options`.
-It should demonstrate the `bluetape4k-exposed` Trino option surface without
-requiring a live Trino cluster in default CI.
+다음 planned module은 `13-ecosystem-integrations/02-trino-session-options`다. 이 모듈은
+default CI에서 live Trino cluster를 요구하지 않고 `bluetape4k-exposed` Trino option surface를
+보여 줘야 한다.
 
-## Current Evidence
+## 현재 근거
 
-- `13-ecosystem-integrations/README.md` already lists #139 as
-  `02-trino-session-options` and planned Gradle task `:02-trino-session-options:build`.
-- `bluetape4k-exposed` issue #229 delivered `TrinoConnectionOptions` and
-  documented connector-specific pushdown verification.
+- `13-ecosystem-integrations/README.md`는 이미 #139를 `02-trino-session-options` 및 planned
+  Gradle task `:02-trino-session-options:build`로 나열한다.
+- `bluetape4k-exposed` issue #229는 `TrinoConnectionOptions`를 제공하고
+  connector-specific pushdown verification을 문서화했다.
 - `TrinoConnectionOptions` supports `explicitPrepare`, `encoding`,
   `validateConnection`, `source`, `clientTags`, `sessionProperties`,
   `extraCredentials`, and `extraHeaders`.
-- JetBrains Exposed 1.3.0 documents `Query.prepareSQL(prepared = false)` for
-  generating a non-parameterized SQL string.
-- Trino documentation treats pushdown as connector-specific; stable checks
-  should use `EXPLAIN` signals instead of brittle full-plan snapshots.
+- JetBrains Exposed 1.3.0은 non-parameterized SQL string 생성을 위한
+  `Query.prepareSQL(prepared = false)`를 문서화한다.
+- Trino documentation은 pushdown을 connector-specific으로 취급한다. Stable check는 brittle
+  full-plan snapshot 대신 `EXPLAIN` signal을 사용해야 한다.
 
-## Design Decision
+## 설계 결정
 
-Build a local-only workshop module that models a Trino analytical connection
-profile and a pushdown-friendly query plan request:
+Trino analytical connection profile과 pushdown-friendly query plan request를 model하는
+local-only workshop module을 만든다.
 
-1. Use `TrinoConnectionOptions` as the public typed options API.
-2. Keep an application-facing `TrinoWorkshopConnectionProfile` so example code
-   can validate catalog, schema, source, tags, and session properties before
-   constructing `TrinoConnectionOptions`.
-3. Generate analytical SQL with Exposed against an H2 SQL-generation database.
-4. Build an `EXPLAIN` request string around the generated SQL so tests can
-   verify the predicate/top-N/projection shape without a live Trino cluster.
-5. Document that actual pushdown support must be checked against the target
-   Trino catalog or connector.
+1. Public typed option API로 `TrinoConnectionOptions`를 사용한다.
+2. Example code가 `TrinoConnectionOptions`를 만들기 전에 catalog, schema, source, tag,
+   session property를 검증할 수 있도록 application-facing `TrinoWorkshopConnectionProfile`을
+   둔다.
+3. H2 SQL-generation database를 대상으로 Exposed analytical SQL을 생성한다.
+4. Generated SQL을 감싸는 `EXPLAIN` request string을 만들어 test가 live Trino cluster 없이
+   predicate/top-N/projection shape를 검증할 수 있게 한다.
+5. 실제 pushdown support는 target Trino catalog 또는 connector를 대상으로 확인해야 함을
+   문서화한다.
 
-## Rejected Alternatives
+## 기각한 대안
 
-- Live Trino Testcontainers as the default test path: rejected because #139
-  requires default tests to avoid a live cluster unless the local container path
-  is stable. The workshop can add an opt-in real-service lane later.
-- Snapshot full `EXPLAIN` output: rejected because Trino plan text is
-  connector- and version-sensitive. The module should assert stable request
-  shape only.
-- Build raw JDBC property strings in user code: rejected because the feature
-  being taught is typed `TrinoConnectionOptions`; raw string fragments should
-  stay behind a narrow preview for README/debugging.
+- Default test path로 Live Trino Testcontainers 사용: #139는 local container path가 안정적이지
+  않다면 default test가 live cluster를 피해야 하므로 기각한다. Workshop은 나중에 opt-in
+  real-service lane을 추가할 수 있다.
+- Full `EXPLAIN` output snapshot: Trino plan text는 connector와 version에 민감하므로
+  기각한다. 모듈은 stable request shape만 assert해야 한다.
+- User code에서 raw JDBC property string 생성: 가르치려는 기능은 typed
+  `TrinoConnectionOptions`이므로 기각한다. Raw string fragment는 README/debugging을 위한 좁은
+  preview 뒤에 머물러야 한다.
 
-## Acceptance Criteria
+## 수용 기준
 
-- `:02-trino-session-options:test` passes without a live Trino cluster.
-- Tests verify typed option construction, unsafe value rejection, and expected
-  SQL/`EXPLAIN` request shape.
-- `README.md` and `README.ko.md` explain local validation versus real Trino
-  connector validation.
-- The chapter README pair marks #139 Ready and links the new module.
-- Root README pair links the new child module.
-- A rendered PNG sequence diagram and adjacent SVG source are added under
+- `:02-trino-session-options:test`는 live Trino cluster 없이 통과한다.
+- Test는 typed option construction, unsafe value rejection, expected SQL/`EXPLAIN` request
+  shape를 검증한다.
+- `README.md`와 `README.ko.md`는 local validation과 real Trino connector validation의 차이를
+  설명한다.
+- Chapter README pair는 #139를 Ready로 표시하고 새 모듈을 link한다.
+- Root README pair는 새 child module을 link한다.
+- Rendered PNG sequence diagram과 adjacent SVG source를 다음 위치에 추가한다.
   `docs/images/readme-diagrams/`.
-- `.github/workflows/examples.yml` includes `:02-trino-session-options:build`.
-- Catalog dependency wiring uses existing BOM conventions and avoids ad hoc
-  version pins.
+- `.github/workflows/examples.yml`은 `:02-trino-session-options:build`를 포함한다.
+- Catalog dependency wiring은 기존 BOM convention을 사용하고 ad hoc version pin을 피한다.
 
-## Risks
+## 위험
 
-- The workshop could overclaim real pushdown. Mitigation: all prose must state
-  that local tests verify request shape only.
-- `TrinoConnectionOptions.toProperties` is internal to the library module.
-  Mitigation: inspect public data class fields and provide a workshop preview
-  map for educational assertions.
-- Generated SQL may vary by dialect. Mitigation: assert stable clauses
-  (`SELECT`, `FROM`, `WHERE`, `ORDER BY`, `LIMIT`) rather than exact SQL text.
+- Workshop이 real pushdown을 과장할 수 있다. 완화: 모든 prose는 local test가 request shape만
+  검증한다고 명시해야 한다.
+- `TrinoConnectionOptions.toProperties`는 library module 내부 API다. 완화: public data class
+  field를 검사하고 educational assertion을 위한 workshop preview map을 제공한다.
+- Generated SQL은 dialect별로 달라질 수 있다. 완화: exact SQL text가 아니라 stable clause
+  (`SELECT`, `FROM`, `WHERE`, `ORDER BY`, `LIMIT`)를 assert한다.

--- a/docs/superpowers/specs/2026-06-29-issue-140-cockroachdb-retry-design.md
+++ b/docs/superpowers/specs/2026-06-29-issue-140-cockroachdb-retry-design.md
@@ -1,54 +1,54 @@
-# Issue #140 CockroachDB Serializable Retry Workshop Design
+# Issue #140 CockroachDB serializable retry workshop 설계
 
 Date: 2026-06-29
 Issue: https://github.com/bluetape4k/exposed-workshop/issues/140
 Parent epic: https://github.com/bluetape4k/exposed-workshop/issues/137
 
-## Goal
+## 목표
 
-Add a chapter 13 workshop module that teaches how to use the
-`bluetape4k-exposed-cockroachdb` helper surface for CockroachDB connection
-setup and serializable transaction retry.
+CockroachDB connection setup과 serializable transaction retry를 위한
+`bluetape4k-exposed-cockroachdb` helper surface 사용법을 가르치는 13장 workshop module을
+추가한다.
 
-## Current Evidence
+## 현재 근거
 
 - `bluetape4k-exposed` exposes `CockroachDatabase.connect`,
   `CockroachTransactionRetryOptions`, `Throwable.isCockroachRetryableTransactionError()`,
   and `withCockroachTransaction`.
-- The library deliberately keeps CockroachDB as a PostgreSQL-wire helper module,
-  not a custom Exposed dialect.
-- CockroachDB serializable retry handling must restart the whole transaction;
-  Exposed generic `maxAttempts` is too broad because it retries `SQLException`
-  without CockroachDB-specific classification.
-- `exposed-workshop` chapter 13 already reserves
-  `13-ecosystem-integrations/03-cockroachdb-retry` for issue #140.
+- Library는 CockroachDB를 custom Exposed dialect가 아니라 PostgreSQL-wire helper module로
+  의도적으로 유지한다.
+- CockroachDB serializable retry handling은 전체 transaction을 다시 시작해야 한다. Exposed
+  generic `maxAttempts`는 CockroachDB-specific classification 없이 `SQLException`을 retry하므로
+  너무 넓다.
+- `exposed-workshop` 13장은 이미 issue #140을 위해
+  `13-ecosystem-integrations/03-cockroachdb-retry`를 예약했다.
 
-## Scope
+## 범위
 
-- Create `13-ecosystem-integrations/03-cockroachdb-retry`.
-- Demonstrate a small inventory reservation transaction that writes both an
-  inventory row and a ledger row in one retryable transaction.
-- Use `CockroachDatabase.connect` with `CockroachServer.Launcher.cockroach` in
-  tests.
-- Use deterministic SQLSTATE `40001` retry injection instead of timing-sensitive
-  concurrent write races.
-- Add README locale pair and one SVG+PNG sequence diagram under
+- `13-ecosystem-integrations/03-cockroachdb-retry`를 만든다.
+- 하나의 retryable transaction 안에서 inventory row와 ledger row를 모두 쓰는 작은 inventory
+  reservation transaction을 보여 준다.
+- Test에서는 `CockroachServer.Launcher.cockroach`와 함께 `CockroachDatabase.connect`를
+  사용한다.
+- Timing-sensitive concurrent write race 대신 deterministic SQLSTATE `40001` retry injection을
+  사용한다.
+- README locale pair와 하나의 SVG+PNG sequence diagram을 다음 위치에 추가한다.
   `docs/images/readme-diagrams/`.
 
-## Non-Goals
+## 비목표
 
 - Custom CockroachDB dialect support.
 - R2DBC retry support.
 - Savepoint-based advanced retry protocol.
 - Real multi-node CockroachDB cluster testing.
-- Generic retry wrappers outside the public bluetape4k-exposed helper API.
+- Public bluetape4k-exposed helper API 밖의 generic retry wrapper.
 
-## Acceptance Criteria
+## 수용 기준
 
-- Tests cover schema bootstrap, successful transaction, retryable serialization
-  conflict, and non-retryable SQL failure.
-- README.md and README.ko.md explain CockroachDB's serializable default and why
-  whole-transaction retry is a correctness requirement.
-- Diagram follows the bluetape4k diagram style and is validated as SVG and PNG.
-- The Examples workflow includes `:03-cockroachdb-retry:build`.
-- PR body final `##` section is `## DoD Status`.
+- Test는 schema bootstrap, successful transaction, retryable serialization conflict,
+  non-retryable SQL failure를 다룬다.
+- README.md와 README.ko.md는 CockroachDB의 serializable default와 whole-transaction retry가
+  correctness requirement인 이유를 설명한다.
+- Diagram은 bluetape4k diagram style을 따르고 SVG/PNG로 검증된다.
+- Examples workflow는 `:03-cockroachdb-retry:build`를 포함한다.
+- PR body의 마지막 `##` section은 `## DoD Status`다.

--- a/docs/superpowers/specs/2026-06-29-issue-141-starrocks-olap-local-design.md
+++ b/docs/superpowers/specs/2026-06-29-issue-141-starrocks-olap-local-design.md
@@ -1,37 +1,35 @@
-# Issue 141 - StarRocks Local-First OLAP Design
+# Issue 141 - StarRocks local-first OLAP 설계
 
-## Context
+## 배경
 
-Issue #141 asks for a workshop example that teaches the local-testability
-boundary for the `bluetape4k-exposed-starrocks` helper. The example must avoid
-making StarRocks a default CI dependency while still showing StarRocks-oriented
-DDL and analytical projection shape.
+Issue #141은 `bluetape4k-exposed-starrocks` helper의 local-testability boundary를 가르치는
+workshop example을 요구한다. 이 예제는 StarRocks를 default CI dependency로 만들지 않으면서
+StarRocks-oriented DDL과 analytical projection shape를 보여 줘야 한다.
 
-## Decision
+## 결정
 
-Create `13-ecosystem-integrations/04-starrocks-olap-local`.
+`13-ecosystem-integrations/04-starrocks-olap-local`을 만든다.
 
-- Use `StarRocksAnalyticsProfile` to validate the Connector/J boundary and
-  render the expected `jdbc:starrocks://host:port/catalog.database` URL.
-- Use `StarRocksTable` for the target rollup table so local DDL rendering keeps
-  `ENGINE=OLAP` and `replication_num = 1` visible.
-- Use H2 only as a transaction context and fixture store for local deterministic
-  projection tests.
-- Keep real StarRocks behavior out of the default test path and document it as
-  explicit opt-in.
+- Connector/J boundary를 검증하고 예상 `jdbc:starrocks://host:port/catalog.database` URL을
+  rendering하기 위해 `StarRocksAnalyticsProfile`을 사용한다.
+- Local DDL rendering에서 `ENGINE=OLAP`와 `replication_num = 1`이 보이도록 target rollup
+  table에는 `StarRocksTable`을 사용한다.
+- H2는 local deterministic projection test를 위한 transaction context와 fixture store로만
+  사용한다.
+- Real StarRocks behavior는 default test path 밖에 두고 explicit opt-in으로 문서화한다.
 
-## Acceptance Mapping
+## 수용 기준 매핑
 
-- Default tests remain local and deterministic: H2-only tests, no Docker.
-- README locale pair documents local and real StarRocks boundaries.
-- Tests verify DDL/query shape and a real local aggregation scenario.
-- Diagram asset ships as SVG plus rendered PNG under
+- Default test는 local/deterministic 상태를 유지한다: H2-only test, Docker 없음.
+- README locale pair는 local 및 real StarRocks boundary를 문서화한다.
+- Test는 DDL/query shape와 실제 local aggregation scenario를 검증한다.
+- Diagram asset은 SVG와 rendered PNG로 다음 위치에 제공된다.
   `docs/images/readme-diagrams/`.
-- Examples workflow includes `:04-starrocks-olap-local:build`.
+- Examples workflow는 `:04-starrocks-olap-local:build`를 포함한다.
 
-## Risks
+## 위험
 
-- DDL rendering is structural only; it is not proof of StarRocks storage or
-  distribution behavior.
-- Real StarRocks validation must remain a separate opt-in lane to avoid hiding
-  backend prerequisites inside fast CI.
+- DDL rendering은 structure만 검증한다. StarRocks storage나 distribution behavior의 증거가
+  아니다.
+- Real StarRocks validation은 fast CI 안에 backend prerequisite를 숨기지 않도록 별도 opt-in
+  lane으로 유지해야 한다.

--- a/docs/superpowers/specs/2026-06-29-issue-142-exposed-ktor-integration-design.md
+++ b/docs/superpowers/specs/2026-06-29-issue-142-exposed-ktor-integration-design.md
@@ -1,53 +1,45 @@
-# Issue #142 Design - Explicit Ktor Exposed Integration
+# Issue #142 설계 - 명시적 Ktor Exposed integration
 
-## Context
+## 배경
 
-Issue #142 asks for a workshop example that introduces the explicit
-`bluetape4k-exposed-ktor` integration added for the Exposed 1.11 line. Existing
-Ktor examples in chapter 12 intentionally own their transaction boundaries
-inside application repositories. This example must instead show the dedicated
-helper API so learners can compare the two styles without rewriting the older
-modules.
+Issue #142는 Exposed 1.11 line에 추가된 명시적 `bluetape4k-exposed-ktor` integration을
+소개하는 workshop example을 요구한다. 기존 12장 Ktor 예제는 transaction boundary를 의도적으로
+application repository 안에서 소유한다. 이 예제는 older module을 다시 작성하지 않고 학습자가
+두 style을 비교할 수 있도록 dedicated helper API를 보여 줘야 한다.
 
-## Target Module
+## 대상 모듈
 
 - Directory: `13-ecosystem-integrations/05-ktor-exposed-integration`
 - Gradle task: `:05-ktor-exposed-integration:build`
 - Default runtime: local in-memory H2 JDBC plus H2 R2DBC readiness probe
 - Public title: `Explicit Ktor Exposed Integration`
 
-## Learning Contract
+## 학습 계약
 
-The module demonstrates:
+모듈은 다음을 보여 준다.
 
-- caller-owned JDBC and R2DBC resources passed to
-  `installBluetape4kExposedKtor`;
-- helper-provided `/healthz/exposed` and `/readyz/exposed` routes;
-- `ApplicationCall.exposedJdbcTransaction` as the blocking JDBC boundary;
-- composed Ktor `StatusPages` with `bluetape4kErrorResponses()` and
-  `bluetape4kExposedErrors()`;
-- sanitized database error responses that do not leak SQL, JDBC URLs, or
-  credentials.
+- `installBluetape4kExposedKtor`에 전달되는 caller-owned JDBC/R2DBC resource.
+- Helper-provided `/healthz/exposed`, `/readyz/exposed` route.
+- Blocking JDBC boundary로서의 `ApplicationCall.exposedJdbcTransaction`.
+- `bluetape4kErrorResponses()`와 `bluetape4kExposedErrors()`를 조합한 Ktor `StatusPages`.
+- SQL, JDBC URL, credential을 leak하지 않는 sanitized database error response.
 
-## Non-Goals
+## 비목표
 
-- Do not replace chapter 10, 11, or 12 Ktor examples.
-- Do not introduce real external services, cloud credentials, or network
-  prerequisites.
-- Do not build a full production service template. Keep the example small and
-  focused on the integration helper surface.
+- 10장, 11장, 12장 Ktor 예제를 대체하지 않는다.
+- Real external service, cloud credential, network prerequisite를 도입하지 않는다.
+- Full production service template를 만들지 않는다. 예제는 작고 integration helper surface에
+  집중한다.
 
-## Acceptance Evidence
+## 수용 근거
 
-- Ktor `testApplication` verifies note CRUD through JDBC helper transactions.
-- Ktor `testApplication` verifies readiness success for JDBC and R2DBC probes.
-- Ktor `testApplication` verifies readiness failure returns `503 Service
-  Unavailable` when the caller-owned JDBC resource is unavailable.
-- Ktor `testApplication` verifies exposed database errors are structured and
-  sanitized.
-- `README.md` and `README.ko.md` compare the helper-based approach with older
-  hand-owned Ktor examples.
-- README diagram assets exist as editable SVG plus rendered PNG under
+- Ktor `testApplication`은 JDBC helper transaction을 통한 note CRUD를 검증한다.
+- Ktor `testApplication`은 JDBC/R2DBC probe의 readiness success를 검증한다.
+- Caller-owned JDBC resource를 사용할 수 없을 때 Ktor `testApplication`은 readiness failure가
+  `503 Service Unavailable`을 반환함을 검증한다.
+- Ktor `testApplication`은 exposed database error가 structured/sanitized 상태임을 검증한다.
+- `README.md`와 `README.ko.md`는 helper-based approach와 older hand-owned Ktor example을
+  비교한다.
+- README diagram asset은 editable SVG와 rendered PNG로 다음 위치에 존재한다.
   `docs/images/readme-diagrams/`.
-- Examples workflow includes `:05-ktor-exposed-integration:build`.
-
+- Examples workflow는 `:05-ktor-exposed-integration:build`를 포함한다.

--- a/docs/superpowers/specs/2026-06-30-issue-145-ddd-modulith-boundaries-design.md
+++ b/docs/superpowers/specs/2026-06-30-issue-145-ddd-modulith-boundaries-design.md
@@ -1,59 +1,57 @@
-# Issue #145 DDD Modulith Boundary Design
+# Issue #145 DDD Modulith boundary 설계
 
-## Context
+## 배경
 
-Issue #145 adds a runnable workshop example for combining DDD bounded contexts,
-Spring Modulith boundary verification, and Exposed persistence. The example
-belongs to `13-ecosystem-integrations/08-ddd-modulith-boundaries`.
+Issue #145는 DDD bounded context, Spring Modulith boundary verification, Exposed
+persistence를 조합하는 runnable workshop example을 추가한다. 이 예제는
+`13-ecosystem-integrations/08-ddd-modulith-boundaries`에 속한다.
 
-## Requirements
+## 요구사항
 
-- Model at least two bounded contexts with separate packages, Exposed tables,
-  repositories, and transaction scopes.
-- Publish domain events from the order context instead of allowing direct
-  repository access from another context.
-- Mark the exported event package as a Spring Modulith named interface.
-- Configure the consuming context with `allowedDependencies` so it can depend
-  only on that named interface.
-- Include a positive verifier test using `ApplicationModules.verify()`.
-- Include a negative test fixture that proves a direct dependency on another
-  context's internal repository fails boundary verification.
-- Keep the example local-first with H2 and no external credentials.
-- Provide bilingual README files and a generated diagram asset that passes the
-  `bluetape4k-diagram` checklist and visual inspection.
-- Register the module in Chapter 13 docs and the examples workflow.
+- 별도 package, Exposed table, repository, transaction scope를 가진 bounded context를 최소 두
+  개 model한다.
+- 다른 context의 direct repository access를 허용하지 않고 order context에서 domain event를
+  publish한다.
+- Exported event package를 Spring Modulith named interface로 표시한다.
+- Consuming context는 해당 named interface에만 의존할 수 있도록 `allowedDependencies`로
+  설정한다.
+- `ApplicationModules.verify()`를 사용하는 positive verifier test를 포함한다.
+- 다른 context의 internal repository에 대한 direct dependency가 boundary verification에
+  실패함을 증명하는 negative test fixture를 포함한다.
+- 예제는 H2와 no external credential 기반 local-first로 유지한다.
+- `bluetape4k-diagram` checklist와 visual inspection을 통과하는 bilingual README file 및
+  generated diagram asset을 제공한다.
+- 모듈을 Chapter 13 docs와 examples workflow에 등록한다.
 
-## Design
+## 설계
 
-The module has two Spring Modulith modules:
+모듈은 두 Spring Modulith module을 갖는다.
 
-- `orders`: accepts an order, persists it with Exposed, and publishes
-  `OrderAcceptedEvent`.
-- `shipping`: listens to `OrderAcceptedEvent` and persists a shipment
-  reservation with its own Exposed table and repository.
+- `orders`: order를 받고 Exposed로 저장하며 `OrderAcceptedEvent`를 publish한다.
+- `shipping`: `OrderAcceptedEvent`를 listen하고 자체 Exposed table/repository로 shipment
+  reservation을 저장한다.
 
-The `orders.events` package is the only exported named interface. The
-`shipping` module metadata declares `allowedDependencies = ["orders :: events"]`.
-The negative test fixture imports an `orders.internal` repository from
-`shipping`, which must fail verification.
+`orders.events` package는 유일한 exported named interface다. `shipping` module metadata는
+`allowedDependencies = ["orders :: events"]`를 선언한다. Negative test fixture는
+`shipping`에서 `orders.internal` repository를 import하며, 이는 verification에 실패해야 한다.
 
-## Non-goals
+## 비목표
 
-- No distributed event broker or external database.
-- No REST API; the tests and README are the workshop interface.
-- No new production dependency beyond the Spring Modulith and Exposed
-  dependencies already used by Chapter 13 Modulith examples.
+- Distributed event broker나 external database 없음.
+- REST API 없음. Test와 README가 workshop interface다.
+- Chapter 13 Modulith 예제가 이미 사용하는 Spring Modulith 및 Exposed dependency 외에 새
+  production dependency 없음.
 
-## Verification
+## 검증
 
-- Red test run before production code exists:
+- Production code가 존재하기 전 red test run:
   `./gradlew :08-ddd-modulith-boundaries:test --no-daemon --no-configuration-cache --rerun-tasks`
-- Targeted test and build:
+- Targeted test 및 build:
   `./gradlew :08-ddd-modulith-boundaries:test --no-daemon --no-configuration-cache --rerun-tasks`
   `./gradlew :08-ddd-modulith-boundaries:build --no-daemon --no-configuration-cache --rerun-tasks --warning-mode all`
-- Registration and docs:
+- Registration 및 docs:
   `./gradlew projects --no-daemon --no-configuration-cache`
   `actionlint .github/workflows/examples.yml`
   `git diff --check`
 - Diagram:
-  run the `bluetape4k-diagram` audits and inspect the generated PNG at full size.
+  `bluetape4k-diagram` audit를 실행하고 generated PNG를 full size로 검사한다.


### PR DESCRIPTION
## Summary
- Localizes single-language superpowers design specifications to Korean.
- Preserves code identifiers, commands, URLs, issue metadata, and README/manual bilingual boundaries.
- Keeps LLM-facing operating documents out of scope.

## Scope
- Updates `docs/superpowers/specs/*.md` only.
- Leaves bilingual README/manual parity as validation-only scope.

## Validation
- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-177-korean-review-docs --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `git diff --check`

Closes #178

## DoD Status
- [x] Korean rewrite completed for the issue scope.
- [x] Scope guard passed against the stacked base branch.
- [x] Whitespace validation passed.
- [x] No Gradle build required; Markdown prose only.
