### PR TITLE
Localize superpowers implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-04-10-memory-hybrid-enforcement.md
+++ b/docs/superpowers/plans/2026-04-10-memory-hybrid-enforcement.md
@@ -1,36 +1,36 @@
-# Memory Hybrid Enforcement Implementation Plan
+# Memory hybrid enforcement 구현 계획
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Agentic worker용:** REQUIRED SUB-SKILL: 이 계획은 task-by-task로 구현하기 위해 superpowers:subagent-driven-development(권장) 또는 superpowers:executing-plans를 사용한다. 단계 추적에는 checkbox(`- [ ]`) syntax를 사용한다.
 
-**Goal:** 테스트 누락을 우선적으로 줄이고, 코딩 스타일 forgetting을 보조적으로 줄이기 위해 hook + memory + mempalace/wiki/obsidian 분류 체계를 구현한다.
+**목표:** 테스트 누락을 우선적으로 줄이고, 코딩 스타일 forgetting을 보조적으로 줄이기 위해 hook + memory + mempalace/wiki/obsidian 분류 체계를 구현한다.
 
-**Architecture:** 기존 `~/.claude/settings.json`의 hook 체인을 유지한 채, `post-edit-dispatcher.sh`에서 테스트 강제 체크를 추가하고 `SessionStart`/`UserPromptSubmit`에 짧은 priority reminder를 주입한다. 저장 계층은 auto-memory를 행동 규칙의 단일 원천으로 두고, mempalace/wiki/obsidian은 검색·아카이브 용도로 분리한다.
+**아키텍처:** 기존 `~/.claude/settings.json`의 hook 체인을 유지한 채, `post-edit-dispatcher.sh`에서 테스트 강제 체크를 추가하고 `SessionStart`/`UserPromptSubmit`에 짧은 priority reminder를 주입한다. 저장 계층은 auto-memory를 행동 규칙의 단일 원천으로 두고, mempalace/wiki/obsidian은 검색·아카이브 용도로 분리한다.
 
-**Tech Stack:** Claude Code hooks, Bash, jq, Python 3, auto-memory files, mempalace ChromaDB, project docs markdown
+**기술 스택:** Claude Code hooks, Bash, jq, Python 3, auto-memory files, mempalace ChromaDB, project docs markdown
 
 ---
 
-## File Structure
+## 파일 구조
 
-- Modify: `/Users/debop/.claude/hooks/post-edit-dispatcher.sh` — Edit/Write 후 파일 유형별 검사를 라우팅하는 entrypoint
-- Create: `/Users/debop/.claude/hooks/test-enforcement-check.sh` — 코드 변경 시 테스트/실행/testlog 누락을 판정
-- Modify: `/Users/debop/.claude/settings.json` — SessionStart/UserPromptSubmit/Stop hooks에 reminder 및 classifier 연결
-- Create: `/Users/debop/.claude/hooks/session-priority-reminder.sh` — 짧은 협업 규칙 상기 메시지 출력
-- Create: `/Users/debop/.claude/hooks/knowledge-routing-reminder.sh` — Stop 시 mempalace/wiki/obsidian 저장 기준 안내
-- Modify: `/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/MEMORY.md` — 핵심 행동 규칙 인덱스 유지
-- Create or Modify: `/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/feedback_test_enforcement.md` — 테스트 우선 규칙 저장
-- Create or Modify: `/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/feedback_response_verification.md` — 확인 후 응답 규칙 저장
-- Create: `/Users/debop/work/bluetape4k/exposed-workshop/docs/testlogs/2026-04.md` — 테스트 로그 월간 파일
-- Create: `/Users/debop/work/bluetape4k/exposed-workshop/.omc/wiki/memory-hybrid-enforcement.md` — 재사용 가치 있는 운영 패턴 정리
-- Create: `/Users/debop/Library/Mobile Documents/com~apple~CloudDocs/Obsidian/<vault>/claude-memory-hybrid-enforcement.md` 또는 기존 적절한 노트 수정 — 사람 중심 허브 노트
+- 수정: `/Users/debop/.claude/hooks/post-edit-dispatcher.sh` — Edit/Write 후 파일 유형별 검사를 라우팅하는 entrypoint
+- 생성: `/Users/debop/.claude/hooks/test-enforcement-check.sh` — 코드 변경 시 테스트/실행/testlog 누락을 판정
+- 수정: `/Users/debop/.claude/settings.json` — SessionStart/UserPromptSubmit/Stop hooks에 reminder 및 classifier 연결
+- 생성: `/Users/debop/.claude/hooks/session-priority-reminder.sh` — 짧은 협업 규칙 상기 메시지 출력
+- 생성: `/Users/debop/.claude/hooks/knowledge-routing-reminder.sh` — Stop 시 mempalace/wiki/obsidian 저장 기준 안내
+- 수정: `/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/MEMORY.md` — 핵심 행동 규칙 인덱스 유지
+- 생성 또는 수정: `/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/feedback_test_enforcement.md` — 테스트 우선 규칙 저장
+- 생성 또는 수정: `/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/feedback_response_verification.md` — 확인 후 응답 규칙 저장
+- 생성: `/Users/debop/work/bluetape4k/exposed-workshop/docs/testlogs/2026-04.md` — 테스트 로그 월간 파일
+- 생성: `/Users/debop/work/bluetape4k/exposed-workshop/.omc/wiki/memory-hybrid-enforcement.md` — 재사용 가치 있는 운영 패턴 정리
+- 생성: `/Users/debop/Library/Mobile Documents/com~apple~CloudDocs/Obsidian/<vault>/claude-memory-hybrid-enforcement.md` 또는 기존 적절한 노트 수정 — 사람 중심 허브 노트
 
-### Task 1: 테스트 강제 훅 스크립트 추가
+### 작업 1: 테스트 강제 훅 스크립트 추가
 
-**Files:**
-- Create: `/Users/debop/.claude/hooks/test-enforcement-check.sh`
-- Test: `/private/tmp/test-enforcement-input.json`
+**파일:**
+- 생성: `/Users/debop/.claude/hooks/test-enforcement-check.sh`
+- 테스트: `/private/tmp/test-enforcement-input.json`
 
-- [ ] **Step 1: failing path를 정의하는 테스트 입력 JSON 작성**
+- [ ] **단계 1: 실패 경로를 정의하는 테스트 입력 JSON 작성**
 
 ```json
 {
@@ -44,12 +44,12 @@
 }
 ```
 
-- [ ] **Step 2: 입력 파일 생성 후 스크립트 없이 실패 조건을 문서화**
+- [ ] **단계 2: 입력 파일 생성 후 스크립트 없이 실패 조건을 문서화**
 
-Run: `printf '%s\n' '<JSON above>' > /private/tmp/test-enforcement-input.json`
-Expected: `/private/tmp/test-enforcement-input.json` 파일 생성
+실행: `printf '%s\n' '<JSON above>' > /private/tmp/test-enforcement-input.json`
+예상: `/private/tmp/test-enforcement-input.json` 파일 생성
 
-- [ ] **Step 3: 최소 구현으로 스크립트 초안 작성**
+- [ ] **단계 3: 최소 구현으로 스크립트 초안 작성**
 
 ```bash
 #!/usr/bin/env bash
@@ -86,12 +86,12 @@ echo "────────────────────────�
 exit 0
 ```
 
-- [ ] **Step 4: 스크립트 실행으로 기본 경고 출력 확인**
+- [ ] **단계 4: 스크립트 실행으로 기본 경고 출력 확인**
 
-Run: `bash /Users/debop/.claude/hooks/test-enforcement-check.sh < /private/tmp/test-enforcement-input.json`
-Expected: stderr에 `⚠️ 테스트 강제 체크` 포함
+실행: `bash /Users/debop/.claude/hooks/test-enforcement-check.sh < /private/tmp/test-enforcement-input.json`
+예상: stderr에 `⚠️ 테스트 강제 체크` 포함
 
-- [ ] **Step 5: 테스트 파일 변경은 통과하도록 필터 추가**
+- [ ] **단계 5: 테스트 파일 변경은 통과하도록 필터 추가**
 
 ```bash
 if printf '%s' "$FILE_PATH" | grep -qE '/src/test/|/src/testFixtures/'; then
@@ -99,35 +99,35 @@ if printf '%s' "$FILE_PATH" | grep -qE '/src/test/|/src/testFixtures/'; then
 fi
 ```
 
-- [ ] **Step 6: 문서 파일 변경은 통과하도록 필터 확인**
+- [ ] **단계 6: 문서 파일 변경은 통과하도록 필터 확인**
 
-Run: `printf '%s\n' '{"tool_input":{"file_path":"/Users/debop/work/bluetape4k/exposed-workshop/README.md"}}' | bash /Users/debop/.claude/hooks/test-enforcement-check.sh`
-Expected: 출력 없음, exit 0
+실행: `printf '%s\n' '{"tool_input":{"file_path":"/Users/debop/work/bluetape4k/exposed-workshop/README.md"}}' | bash /Users/debop/.claude/hooks/test-enforcement-check.sh`
+예상: 출력 없음, exit 0
 
-- [ ] **Step 7: 실행 권한 부여**
+- [ ] **단계 7: 실행 권한 부여**
 
-Run: `chmod +x /Users/debop/.claude/hooks/test-enforcement-check.sh`
-Expected: 권한 부여 성공
+실행: `chmod +x /Users/debop/.claude/hooks/test-enforcement-check.sh`
+예상: 권한 부여 성공
 
-- [ ] **Step 8: Commit**
+- [ ] **단계 8: 커밋**
 
 ```bash
 git add /Users/debop/.claude/hooks/test-enforcement-check.sh
 git commit -m "feat: add test enforcement hook"
 ```
 
-### Task 2: post-edit-dispatcher에 테스트 강제 체크 연결
+### 작업 2: post-edit-dispatcher에 테스트 강제 체크 연결
 
-**Files:**
-- Modify: `/Users/debop/.claude/hooks/post-edit-dispatcher.sh:11-28`
-- Test: `/private/tmp/test-enforcement-input.json`
+**파일:**
+- 수정: `/Users/debop/.claude/hooks/post-edit-dispatcher.sh:11-28`
+- 테스트: `/private/tmp/test-enforcement-input.json`
 
-- [ ] **Step 1: 연결 전 failing expectation 명시**
+- [ ] **단계 1: 연결 전 실패 기대값 명시**
 
-Run: `bash /Users/debop/.claude/hooks/post-edit-dispatcher.sh < /private/tmp/test-enforcement-input.json`
-Expected: 아직 `⚠️ 테스트 강제 체크`가 없거나 라우팅되지 않음
+실행: `bash /Users/debop/.claude/hooks/post-edit-dispatcher.sh < /private/tmp/test-enforcement-input.json`
+예상: 아직 `⚠️ 테스트 강제 체크`가 없거나 라우팅되지 않음
 
-- [ ] **Step 2: kt 분기에서 새 스크립트 호출 추가**
+- [ ] **단계 2: kt 분기에서 새 스크립트 호출 추가**
 
 ```bash
   kt)
@@ -136,49 +136,49 @@ Expected: 아직 `⚠️ 테스트 강제 체크`가 없거나 라우팅되지 �
     bash /Users/debop/.claude/hooks/kotlin-detekt.sh <<< "$INPUT"
 ```
 
-- [ ] **Step 3: kts/java도 검사 대상에 포함하도록 case 확장**
+- [ ] **단계 3: kts/java도 검사 대상에 포함하도록 case 확장**
 
 ```bash
   kt|kts|java)
     bash /Users/debop/.claude/hooks/test-enforcement-check.sh <<< "$INPUT"
 ```
 
-- [ ] **Step 4: dispatcher를 직접 실행해 경고가 라우팅되는지 확인**
+- [ ] **단계 4: dispatcher를 직접 실행해 경고가 라우팅되는지 확인**
 
-Run: `bash /Users/debop/.claude/hooks/post-edit-dispatcher.sh < /private/tmp/test-enforcement-input.json`
-Expected: stderr에 `⚠️ 테스트 강제 체크` 포함
+실행: `bash /Users/debop/.claude/hooks/post-edit-dispatcher.sh < /private/tmp/test-enforcement-input.json`
+예상: stderr에 `⚠️ 테스트 강제 체크` 포함
 
-- [ ] **Step 5: shell, markdown 기존 동작이 깨지지 않는지 확인**
+- [ ] **단계 5: shell, markdown 기존 동작이 깨지지 않는지 확인**
 
-Run: `printf '%s\n' '{"tool_input":{"file_path":"/Users/debop/.claude/hooks/testlog-reminder.sh"}}' | bash /Users/debop/.claude/hooks/post-edit-dispatcher.sh`
-Expected: shell validator만 실행, fatal error 없음
+실행: `printf '%s\n' '{"tool_input":{"file_path":"/Users/debop/.claude/hooks/testlog-reminder.sh"}}' | bash /Users/debop/.claude/hooks/post-edit-dispatcher.sh`
+예상: shell validator만 실행, fatal error 없음
 
-- [ ] **Step 6: Commit**
+- [ ] **단계 6: 커밋**
 
 ```bash
 git add /Users/debop/.claude/hooks/post-edit-dispatcher.sh
 git commit -m "feat: route test enforcement in post edit dispatcher"
 ```
 
-### Task 3: SessionStart/UserPromptSubmit reminder 추가
+### 작업 3: SessionStart/UserPromptSubmit reminder 추가
 
-**Files:**
-- Create: `/Users/debop/.claude/hooks/session-priority-reminder.sh`
-- Modify: `/Users/debop/.claude/settings.json`
-- Test: `/private/tmp/empty-hook-input.json`
+**파일:**
+- 생성: `/Users/debop/.claude/hooks/session-priority-reminder.sh`
+- 수정: `/Users/debop/.claude/settings.json`
+- 테스트: `/private/tmp/empty-hook-input.json`
 
-- [ ] **Step 1: 빈 hook 입력 파일 작성**
+- [ ] **단계 1: 빈 hook 입력 파일 작성**
 
 ```json
 {}
 ```
 
-- [ ] **Step 2: 입력 파일 생성**
+- [ ] **단계 2: 입력 파일 생성**
 
-Run: `printf '{}\n' > /private/tmp/empty-hook-input.json`
-Expected: `/private/tmp/empty-hook-input.json` 생성
+실행: `printf '{}\n' > /private/tmp/empty-hook-input.json`
+예상: `/private/tmp/empty-hook-input.json` 생성
 
-- [ ] **Step 3: reminder 스크립트 최소 구현 작성**
+- [ ] **단계 3: reminder 스크립트 최소 구현 작성**
 
 ```bash
 #!/usr/bin/env bash
@@ -193,21 +193,12 @@ cat <<'EOF'
 EOF
 ```
 
-- [ ] **Step 4: reminder 스크립트 단독 실행 확인**
+- [ ] **단계 4: reminder 스크립트 단독 실행 확인**
 
-Run: `bash /Users/debop/.claude/hooks/session-priority-reminder.sh < /private/tmp/empty-hook-input.json`
-Expected: stdout에 `<priority_reminder>` 블록 출력
+실행: `bash /Users/debop/.claude/hooks/session-priority-reminder.sh < /private/tmp/empty-hook-input.json`
+예상: stdout에 `<priority_reminder>` 블록 출력
 
-- [ ] **Step 5: settings.json의 SessionStart hooks에 command hook 추가**
-
-```json
-{
-  "type": "command",
-  "command": "bash /Users/debop/.claude/hooks/session-priority-reminder.sh"
-}
-```
-
-- [ ] **Step 6: settings.json의 UserPromptSubmit hooks에도 동일 hook 추가**
+- [ ] **단계 5: settings.json의 SessionStart hooks에 command hook 추가**
 
 ```json
 {
@@ -216,26 +207,35 @@ Expected: stdout에 `<priority_reminder>` 블록 출력
 }
 ```
 
-- [ ] **Step 7: jq로 설정 JSON 유효성 검증**
+- [ ] **단계 6: settings.json의 UserPromptSubmit hooks에도 동일 hook 추가**
 
-Run: `jq -e '.hooks.SessionStart, .hooks.UserPromptSubmit' /Users/debop/.claude/settings.json >/dev/null`
-Expected: exit 0
+```json
+{
+  "type": "command",
+  "command": "bash /Users/debop/.claude/hooks/session-priority-reminder.sh"
+}
+```
 
-- [ ] **Step 8: Commit**
+- [ ] **단계 7: jq로 설정 JSON 유효성 검증**
+
+실행: `jq -e '.hooks.SessionStart, .hooks.UserPromptSubmit' /Users/debop/.claude/settings.json >/dev/null`
+예상: exit 0
+
+- [ ] **단계 8: 커밋**
 
 ```bash
 git add /Users/debop/.claude/hooks/session-priority-reminder.sh /Users/debop/.claude/settings.json
 git commit -m "feat: add session priority reminders"
 ```
 
-### Task 4: auto-memory 규칙 압축 정리
+### 작업 4: auto-memory 규칙 압축 정리
 
-**Files:**
-- Modify: `/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/MEMORY.md`
-- Create: `/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/feedback_test_enforcement.md`
-- Create: `/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/feedback_response_verification.md`
+**파일:**
+- 수정: `/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/MEMORY.md`
+- 생성: `/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/feedback_test_enforcement.md`
+- 생성: `/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/feedback_response_verification.md`
 
-- [ ] **Step 1: 테스트 우선 규칙 memory 파일 작성**
+- [ ] **단계 1: 테스트 우선 규칙 memory 파일 작성**
 
 ```markdown
 ---
@@ -249,7 +249,7 @@ type: feedback
 **How to apply:** 코드 파일을 수정하면 테스트 작성/실행/testlog 기록 여부를 먼저 점검하고, 누락 시 즉시 보완을 유도한다.
 ```
 
-- [ ] **Step 2: 확인 후 응답 규칙 memory 파일 작성**
+- [ ] **단계 2: 확인 후 응답 규칙 memory 파일 작성**
 
 ```markdown
 ---
@@ -263,16 +263,16 @@ type: feedback
 **How to apply:** 설정, 저장, 동작 여부 질문에는 먼저 파일이나 현재 상태를 확인하고, 확인 결과를 근거로 대답한다.
 ```
 
-- [ ] **Step 3: MEMORY.md 인덱스에 두 파일 포인터 추가**
+- [ ] **단계 3: MEMORY.md 인덱스에 두 파일 포인터 추가**
 
 ```markdown
 - [feedback_test_enforcement.md](feedback_test_enforcement.md) — 테스트 코드/실행/testlog 누락 방지를 최우선으로 다룬다
 - [feedback_response_verification.md](feedback_response_verification.md) — 일반론보다 실제 확인 결과를 근거로 답한다
 ```
 
-- [ ] **Step 4: memory 파일 형식 검토**
+- [ ] **단계 4: memory 파일 형식 검토**
 
-Run: `python3 - <<'PY'
+실행: `python3 - <<'PY'
 from pathlib import Path
 for p in [
 Path('/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/feedback_test_enforcement.md'),
@@ -281,9 +281,9 @@ Path('/Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-worksho
     assert '---' in txt and 'Why:' in txt and 'How to apply:' in txt
 print('OK')
 PY`
-Expected: `OK`
+예상: `OK`
 
-- [ ] **Step 5: Commit**
+- [ ] **단계 5: 커밋**
 
 ```bash
 git add /Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-workshop/memory/MEMORY.md \
@@ -292,18 +292,18 @@ git add /Users/debop/.claude/projects/-Users-debop-work-bluetape4k-exposed-works
 git commit -m "docs: tighten memory rules for test enforcement"
 ```
 
-### Task 5: testlog 기본 파일 준비 및 검사 경로 명확화
+### 작업 5: testlog 기본 파일 준비 및 검사 경로 명확화
 
-**Files:**
-- Create: `/Users/debop/work/bluetape4k/exposed-workshop/docs/testlogs/2026-04.md`
-- Modify: `/Users/debop/.claude/hooks/test-enforcement-check.sh`
+**파일:**
+- 생성: `/Users/debop/work/bluetape4k/exposed-workshop/docs/testlogs/2026-04.md`
+- 수정: `/Users/debop/.claude/hooks/test-enforcement-check.sh`
 
-- [ ] **Step 1: testlogs 디렉터리 생성**
+- [ ] **단계 1: testlogs 디렉터리 생성**
 
-Run: `mkdir -p /Users/debop/work/bluetape4k/exposed-workshop/docs/testlogs`
-Expected: 디렉터리 생성
+실행: `mkdir -p /Users/debop/work/bluetape4k/exposed-workshop/docs/testlogs`
+예상: 디렉터리 생성
 
-- [ ] **Step 2: 월간 testlog 파일 기본 템플릿 작성**
+- [ ] **단계 2: 월간 testlog 파일 기본 템플릿 작성**
 
 ```markdown
 # 2026-04 Test Logs
@@ -312,7 +312,7 @@ Expected: 디렉터리 생성
 |------|------|------|-------------|------|------|------|
 ```
 
-- [ ] **Step 3: test-enforcement-check에 testlog 존재 확인 추가**
+- [ ] **단계 3: test-enforcement-check에 testlog 존재 확인 추가**
 
 ```bash
 TESTLOG_FILE="/Users/debop/work/bluetape4k/exposed-workshop/docs/testlogs/$(date +%Y-%m).md"
@@ -321,12 +321,12 @@ if [[ ! -f "$TESTLOG_FILE" ]]; then
 fi
 ```
 
-- [ ] **Step 4: 직접 실행으로 testlog 경고가 보이는지 확인**
+- [ ] **단계 4: 직접 실행으로 testlog 경고가 보이는지 확인**
 
-Run: `bash /Users/debop/.claude/hooks/test-enforcement-check.sh < /private/tmp/test-enforcement-input.json`
-Expected: testlog 파일이 없던 경우 경고, 파일 생성 후에는 해당 줄 사라짐
+실행: `bash /Users/debop/.claude/hooks/test-enforcement-check.sh < /private/tmp/test-enforcement-input.json`
+예상: testlog 파일이 없던 경우 경고, 파일 생성 후에는 해당 줄 사라짐
 
-- [ ] **Step 5: Commit**
+- [ ] **단계 5: 커밋**
 
 ```bash
 git add /Users/debop/work/bluetape4k/exposed-workshop/docs/testlogs/2026-04.md \
@@ -334,15 +334,15 @@ git add /Users/debop/work/bluetape4k/exposed-workshop/docs/testlogs/2026-04.md \
 git commit -m "test: add monthly testlog template"
 ```
 
-### Task 6: mempalace/wiki/obsidian 분류 가이드 구현
+### 작업 6: mempalace/wiki/obsidian 분류 가이드 구현
 
-**Files:**
-- Create: `/Users/debop/.claude/hooks/knowledge-routing-reminder.sh`
-- Modify: `/Users/debop/.claude/hooks/mempalace-save-hook.sh`
-- Create: `/Users/debop/work/bluetape4k/exposed-workshop/.omc/wiki/memory-hybrid-enforcement.md`
-- Create or Modify: `/Users/debop/Library/Mobile Documents/com~apple~CloudDocs/Obsidian/<vault>/claude-memory-hybrid-enforcement.md`
+**파일:**
+- 생성: `/Users/debop/.claude/hooks/knowledge-routing-reminder.sh`
+- 수정: `/Users/debop/.claude/hooks/mempalace-save-hook.sh`
+- 생성: `/Users/debop/work/bluetape4k/exposed-workshop/.omc/wiki/memory-hybrid-enforcement.md`
+- 생성 또는 수정: `/Users/debop/Library/Mobile Documents/com~apple~CloudDocs/Obsidian/<vault>/claude-memory-hybrid-enforcement.md`
 
-- [ ] **Step 1: 분류 reminder 스크립트 작성**
+- [ ] **단계 1: 분류 reminder 스크립트 작성**
 
 ```bash
 #!/usr/bin/env bash
@@ -358,7 +358,7 @@ cat <<'EOF'
 EOF
 ```
 
-- [ ] **Step 2: mempalace-save-hook 출력문에 분류 기준 한 줄 추가**
+- [ ] **단계 2: mempalace-save-hook 출력문에 분류 기준 한 줄 추가**
 
 ```bash
 저장 전 분류 기준:
@@ -368,7 +368,7 @@ EOF
 - 장문 연결은 obsidian
 ```
 
-- [ ] **Step 3: wiki 문서 작성**
+- [ ] **단계 3: wiki 문서 작성**
 
 ```markdown
 ---
@@ -390,7 +390,7 @@ created: 2026-04-10
 - obsidian: 사람 중심 허브
 ```
 
-- [ ] **Step 4: obsidian 노트 초안 작성 또는 기존 허브에 링크 추가**
+- [ ] **단계 4: obsidian 노트 초안 작성 또는 기존 허브에 링크 추가**
 
 ```markdown
 # Claude Memory Hybrid Enforcement
@@ -406,7 +406,7 @@ created: 2026-04-10
 - 문서 자산은 wiki/obsidian
 ```
 
-- [ ] **Step 5: Commit**
+- [ ] **단계 5: 커밋**
 
 ```bash
 git add /Users/debop/.claude/hooks/knowledge-routing-reminder.sh \
@@ -415,49 +415,49 @@ git add /Users/debop/.claude/hooks/knowledge-routing-reminder.sh \
 git commit -m "docs: add knowledge routing guidance"
 ```
 
-### Task 7: Hook 실제 동작 검증
+### 작업 7: Hook 실제 동작 검증
 
-**Files:**
-- Modify: `/private/tmp/test-enforcement-input.json`
-- Test: `/Users/debop/.claude/settings.json`
+**파일:**
+- 수정: `/private/tmp/test-enforcement-input.json`
+- 테스트: `/Users/debop/.claude/settings.json`
 
-- [ ] **Step 1: 테스트 강제 훅 단독 검증**
+- [ ] **단계 1: 테스트 강제 훅 단독 검증**
 
-Run: `bash /Users/debop/.claude/hooks/test-enforcement-check.sh < /private/tmp/test-enforcement-input.json 2>&1 | tee /private/tmp/test-enforcement-check.log`
-Expected: 경고 메시지와 testlog 항목 출력
+실행: `bash /Users/debop/.claude/hooks/test-enforcement-check.sh < /private/tmp/test-enforcement-input.json 2>&1 | tee /private/tmp/test-enforcement-check.log`
+예상: 경고 메시지와 testlog 항목 출력
 
-- [ ] **Step 2: dispatcher 경유 검증**
+- [ ] **단계 2: dispatcher 경유 검증**
 
-Run: `bash /Users/debop/.claude/hooks/post-edit-dispatcher.sh < /private/tmp/test-enforcement-input.json 2>&1 | tee /private/tmp/post-edit-dispatcher.log`
-Expected: dispatcher를 통해 동일 경고 출력
+실행: `bash /Users/debop/.claude/hooks/post-edit-dispatcher.sh < /private/tmp/test-enforcement-input.json 2>&1 | tee /private/tmp/post-edit-dispatcher.log`
+예상: dispatcher를 통해 동일 경고 출력
 
-- [ ] **Step 3: session reminder 단독 검증**
+- [ ] **단계 3: session reminder 단독 검증**
 
-Run: `bash /Users/debop/.claude/hooks/session-priority-reminder.sh < /private/tmp/empty-hook-input.json`
-Expected: `<priority_reminder>` 출력
+실행: `bash /Users/debop/.claude/hooks/session-priority-reminder.sh < /private/tmp/empty-hook-input.json`
+예상: `<priority_reminder>` 출력
 
-- [ ] **Step 4: knowledge routing reminder 단독 검증**
+- [ ] **단계 4: knowledge routing reminder 단독 검증**
 
-Run: `bash /Users/debop/.claude/hooks/knowledge-routing-reminder.sh < /private/tmp/empty-hook-input.json`
-Expected: `<knowledge_routing>` 출력
+실행: `bash /Users/debop/.claude/hooks/knowledge-routing-reminder.sh < /private/tmp/empty-hook-input.json`
+예상: `<knowledge_routing>` 출력
 
-- [ ] **Step 5: settings.json hook schema 검증**
+- [ ] **단계 5: settings.json hook schema 검증**
 
-Run: `jq -e '.hooks.PostToolUse[]?.hooks, .hooks.SessionStart[]?.hooks, .hooks.UserPromptSubmit[]?.hooks, .hooks.Stop[]?.hooks' /Users/debop/.claude/settings.json >/dev/null`
-Expected: exit 0
+실행: `jq -e '.hooks.PostToolUse[]?.hooks, .hooks.SessionStart[]?.hooks, .hooks.UserPromptSubmit[]?.hooks, .hooks.Stop[]?.hooks' /Users/debop/.claude/settings.json >/dev/null`
+예상: exit 0
 
-- [ ] **Step 6: exposed-workshop 관련 테스트 실행**
+- [ ] **단계 6: exposed-workshop 관련 테스트 실행**
 
-Run: `./bin/repo-test-summary -- ./gradlew :01-spring-boot:test`
-Expected: 테스트 요약 성공 또는 현재 상태 기준 의미 있는 실패 원인 출력
+실행: `./bin/repo-test-summary -- ./gradlew :01-spring-boot:test`
+예상: 테스트 요약 성공 또는 현재 상태 기준 의미 있는 실패 원인 출력
 
-- [ ] **Step 7: testlog 기록**
+- [ ] **단계 7: testlog 기록**
 
 ```markdown
 | 2026-04-10 | memory hybrid enforcement hook 검증 | hooks/settings | session-priority-reminder, test-enforcement-check | PASS 또는 실제 결과 | 수동기록 | initial verification |
 ```
 
-- [ ] **Step 8: Commit**
+- [ ] **단계 8: 커밋**
 
 ```bash
 git add /Users/debop/.claude/settings.json \
@@ -465,7 +465,7 @@ git add /Users/debop/.claude/settings.json \
 git commit -m "test: verify memory hybrid enforcement hooks"
 ```
 
-## Self-Review
+## 자체 검토
 
 - Spec coverage: 테스트 강제, memory 규칙 압축, mempalace/wiki/obsidian 역할 분리가 모두 Task 1~7에 매핑되어 있다.
 - Placeholder scan: TODO/TBD/implement later 없음. 각 코드/명령/파일 경로를 명시했다.

--- a/docs/superpowers/plans/2026-05-17-issue-58-ktor-architecture-plan.md
+++ b/docs/superpowers/plans/2026-05-17-issue-58-ktor-architecture-plan.md
@@ -1,78 +1,75 @@
-# Issue 58 - Ktor Application Architecture Plan
+# Issue 58 - Ktor application architecture 계획
 
-## Scope
+## 범위
 
-Implement the first chapter 12 Ktor module in `exposed-workshop`.
+`exposed-workshop`의 첫 12장 Ktor module을 구현한다.
 
-## Tasks
+## 작업
 
-1. Add design and advisor artifacts.
+1. 설계와 advisor artifact를 추가한다.
    - Complexity: S
-   - Apply `bluetape4k-design` review gates and Claude Code CLI advisor review.
+   - `bluetape4k-design` review gate와 Claude Code CLI advisor review를 적용한다.
 
-2. Add Gradle/catalog wiring.
+2. Gradle/catalog wiring을 추가한다.
    - Complexity: S
-   - Add `ktor = "3.4.3"` and aliases:
+   - `ktor = "3.4.3"` 및 다음 alias를 추가한다:
      `ktor-server-core`, `ktor-server-cio`,
      `ktor-server-content-negotiation`, `ktor-server-status-pages`,
      `ktor-server-call-logging`, `ktor-server-call-id`,
      `ktor-server-test-host`, and `ktor-serialization-kotlinx-json`.
-   - Register `12-production-integration`.
-   - Add module `build.gradle.kts`.
+   - `12-production-integration`을 등록한다.
+   - Module `build.gradle.kts`를 추가한다.
 
-3. Implement Ktor + Exposed baseline.
+3. Ktor + Exposed baseline을 구현한다.
    - Complexity: M
-   - Add table, repository, service, DTOs, routes, application module, and main.
-   - Repository API is `suspend`; repository owns the
-     `withContext(Dispatchers.IO) { transaction {} }` boundary.
-   - Use deterministic Hikari/H2 settings for tests, including
-     `maximumPoolSize = 4`.
-   - Add explicit `StatusPages` mappings for validation, not-found, malformed
-     request, and sanitized fallback errors. Do not echo exception messages or
-     stack traces from unexpected exceptions.
-   - Configure request body limit at `64 KiB`.
-   - Configure CallId logging with MDC-friendly logback test output.
-   - Apply `bluetape4k-patterns`: no `!!`, validate caller input with
-     `require*`/explicit exceptions, keep state immutable.
-   - Do not use `runCatching` around suspend calls.
+   - Table, repository, service, DTO, route, application module, main을 추가한다.
+   - Repository API는 `suspend`다. Repository가 `withContext(Dispatchers.IO) { transaction {} }`
+     boundary를 소유한다.
+   - Test에는 `maximumPoolSize = 4`를 포함한 deterministic Hikari/H2 setting을 사용한다.
+   - Validation, not-found, malformed request, sanitized fallback error를 위한 명시적
+     `StatusPages` mapping을 추가한다. Unexpected exception의 message나 stack trace를 echo하지
+     않는다.
+   - Request body limit을 `64 KiB`로 설정한다.
+   - MDC-friendly logback test output과 함께 CallId logging을 설정한다.
+   - `bluetape4k-patterns`를 적용한다: `!!` 없음, caller input은 `require*`/explicit exception으로
+     검증, state는 immutable하게 유지한다.
+   - Suspend call 주변에는 `runCatching`을 사용하지 않는다.
 
-4. Add focused tests.
+4. 집중 test를 추가한다.
    - Complexity: M
-   - Use Ktor `testApplication`.
-   - Use bluetape4k assertions, not JUnit/kotlin.test assertions.
-   - Do not use `assertThrows`, `invoking { } shouldThrow`, or
-     `kotlin.test.assertFailsWith`.
-   - Use a unique H2 JDBC URL per test and assert empty table state at test
-     start.
-   - Add a parallel insert smoke test with 16 concurrent requests and verify
-     distinct primary keys plus total row count.
+   - Ktor `testApplication`을 사용한다.
+   - JUnit/kotlin.test assertion이 아니라 bluetape4k assertion을 사용한다.
+   - `assertThrows`, `invoking { } shouldThrow`, `kotlin.test.assertFailsWith`를 사용하지 않는다.
+   - Test마다 unique H2 JDBC URL을 사용하고 test 시작 시 table이 비어 있음을 assert한다.
+   - 16개 concurrent request를 사용하는 parallel insert smoke test를 추가하고 distinct primary key와
+     total row count를 검증한다.
 
-5. Add documentation.
+5. 문서를 추가한다.
    - Complexity: S
-   - Add `README.md` and `README.ko.md`.
-   - Include a small Mermaid architecture diagram.
-   - Document run/test commands, the suspend repository boundary, and why the
-     R2DBC workshop is the non-blocking persistence counterpart.
+   - `README.md`와 `README.ko.md`를 추가한다.
+   - 작은 Mermaid architecture diagram을 포함한다.
+   - 실행/test command, suspend repository boundary, R2DBC workshop이 non-blocking persistence
+     counterpart인 이유를 문서화한다.
 
-6. Verify.
+6. 검증한다.
    - Complexity: S
-   - Run `./gradlew projects`.
-   - Run `./gradlew :01-ktor-application-architecture:compileKotlin`.
-   - Run `./gradlew :01-ktor-application-architecture:test`.
-   - Run `./gradlew :01-ktor-application-architecture:detekt` if the task is
-     available for the module.
-   - Run `git diff --check`.
+   - `./gradlew projects`를 실행한다.
+   - `./gradlew :01-ktor-application-architecture:compileKotlin`을 실행한다.
+   - `./gradlew :01-ktor-application-architecture:test`를 실행한다.
+   - Module에서 task를 사용할 수 있으면 `./gradlew :01-ktor-application-architecture:detekt`를
+     실행한다.
+   - `git diff --check`를 실행한다.
 
-7. Capture lesson and commit.
+7. Lesson을 기록하고 commit한다.
    - Complexity: S
-   - Add `docs/lessons/2026-05-17-issue-58-ktor-architecture.md`.
-   - Commit with Lore trailers after verification.
+   - `docs/lessons/2026-05-17-issue-58-ktor-architecture.md`를 추가한다.
+   - 검증 후 Lore trailer를 포함해 commit한다.
 
-## Advisor Review Requirement
+## Advisor review 요구사항
 
 Claude Code CLI review artifacts:
 
 - `.omx/artifacts/claude-issue-58-spec-plan-2026-05-17.md`
 - `.omx/artifacts/claude-issue-58-spec-plan-rereview-2026-05-17.md`
 
-Summarize accepted/rejected findings in the research note.
+Research note에 accepted/rejected finding을 요약한다.

--- a/docs/superpowers/plans/2026-05-22-issue-52-schema-per-tenant-plan.md
+++ b/docs/superpowers/plans/2026-05-22-issue-52-schema-per-tenant-plan.md
@@ -1,56 +1,46 @@
-# Issue 52 Schema-Per-Tenant Plan
+# Issue 52 Schema-per-tenant 계획
 
-## Steps
+## 단계
 
-1. Add the Spring Boot module skeleton and dependencies.
-2. Implement tenant resolution, `tenantTransaction { }`, Exposed repository,
-   service, controller, and seed initializer. `tenantTransaction { }` must use
-   `SchemaUtils.setSchema(Schema(...))`, must not concatenate raw tenant strings
-   into SQL, must set the tenant schema at transaction start, and must reset to
-   `PUBLIC` before returning. If reset fails, it must invoke a Hikari connection
-   eviction hook before rethrowing the original reset failure. Add
-   `SchemaResetter`, `ConnectionEvictor`, and connection-probe seams for
-   reset-failure and same-connection reuse tests. The eviction target is the
-   Hikari-borrowed proxy connection from
-   `TransactionManager.current().connection.connection`, not an unwrapped driver
-   connection.
-3. Add focused Spring Boot tests for request errors, valid routing, and
-   cross-tenant isolation. Configure the test datasource with a small Hikari
-   pool (`maximumPoolSize=1`, `minimumIdle=1`) to force connection reuse across
-   tenant requests.
-4. Add English/Korean README files and a committed Architecture Diagram PNG/SVG.
-5. Wire the module into the Examples workflow and update chapter/root docs if
-   needed.
-6. Run local verification and 6-Tier review before opening the PR.
+1. Spring Boot module skeleton과 dependency를 추가한다.
+2. Tenant resolution, `tenantTransaction { }`, Exposed repository, service, controller, seed
+   initializer를 구현한다. `tenantTransaction { }`은 `SchemaUtils.setSchema(Schema(...))`를
+   사용해야 하며, raw tenant string을 SQL에 concatenate하면 안 된다. Transaction 시작 시 tenant
+   schema를 설정하고 반환 전에 `PUBLIC`으로 reset해야 한다. Reset이 실패하면 original reset
+   failure를 다시 던지기 전에 Hikari connection eviction hook을 호출해야 한다. Reset-failure 및
+   same-connection reuse test를 위해 `SchemaResetter`, `ConnectionEvictor`, connection-probe seam을
+   추가한다. Eviction target은 unwrapped driver connection이 아니라
+   `TransactionManager.current().connection.connection`에서 얻은 Hikari-borrowed proxy connection이다.
+3. Request error, valid routing, cross-tenant isolation을 위한 집중 Spring Boot test를 추가한다.
+   Tenant request 간 connection reuse를 강제하도록 test datasource는 작은 Hikari pool
+   (`maximumPoolSize=1`, `minimumIdle=1`)로 설정한다.
+4. English/Korean README file과 committed architecture diagram PNG/SVG를 추가한다.
+5. Module을 Examples workflow에 연결하고 필요하면 chapter/root docs를 갱신한다.
+6. PR을 열기 전에 local verification과 6-Tier review를 실행한다.
 
-## Acceptance Mapping
+## 수용 기준 매핑
 
-- Builds independently: targeted Gradle test/build task.
-- Tenant isolation: same SKU can exist with different values per tenant, and a
-  new tenant-local SKU is not visible in another schema.
-- Error handling: missing/unknown tenant headers return HTTP 400.
-- Context safety: `TenantContext` is always cleared even when downstream request
-  handling fails.
-- Reset safety: a tenant A request followed by tenant B on a reused connection
-  cannot read tenant A data, and the current schema is reset to `PUBLIC` after
-  a tenant transaction.
-- Reset failure: a test-only schema reset failure invokes the eviction hook and
-  the following tenant request remains isolated. The original reset exception
-  remains primary if Exposed raises a secondary rollback/close failure.
-- Reset failure after a successful business block throws
-  `TenantSchemaResetFailedException`, rolls back the business write, logs the
-  tenant/operation context at warn level, and evicts the connection.
-- Reset failure after a business block failure preserves the business exception
-  as primary and attaches the reset failure with `addSuppressed`.
-- Same-connection proof: the pool=1 isolation test records the physical
-  connection identity and verifies tenant A and tenant B operations used the
-  reused connection before asserting B cannot read A-only data.
-- Pool-state proof: reset-failure tests assert Hikari pool active connections
-  return to zero and a fresh borrow is used for the next tenant request.
-- Failure cleanup: a controller exception after tenant resolution still clears
-  `TenantContext`; the next missing-tenant request is rejected instead of using a
-  stale tenant.
-- Header hardening: blank, uppercase, path-like, SQL-like, and oversized tenant
-  values are rejected.
-- Documentation: README pairs explain when schema-per-tenant is preferable and
-  when database-per-tenant is a better next step.
+- 독립 build: targeted Gradle test/build task.
+- Tenant isolation: 같은 SKU가 tenant마다 다른 값으로 존재할 수 있고, 새 tenant-local SKU는 다른
+  schema에서 보이지 않는다.
+- Error handling: missing/unknown tenant header는 HTTP 400을 반환한다.
+- Context safety: downstream request handling이 실패해도 `TenantContext`는 항상 clear된다.
+- Reset safety: reused connection에서 tenant A request 다음 tenant B request가 실행돼도 tenant B는
+  tenant A data를 읽을 수 없고, tenant transaction 이후 current schema는 `PUBLIC`으로 reset된다.
+- Reset failure: test-only schema reset failure는 eviction hook을 호출하고 다음 tenant request의
+  isolation은 유지된다. Exposed가 secondary rollback/close failure를 발생시켜도 original reset
+  exception은 primary로 남는다.
+- Successful business block 이후 reset failure는 `TenantSchemaResetFailedException`을 던지고
+  business write를 rollback하며 tenant/operation context를 warn level로 log하고 connection을
+  evict한다.
+- Business block failure 이후 reset failure는 business exception을 primary로 보존하고 reset failure를
+  `addSuppressed`로 붙인다.
+- Same-connection proof: pool=1 isolation test는 physical connection identity를 기록하고 tenant A/B
+  operation이 reused connection을 사용했음을 검증한 뒤 B가 A-only data를 읽을 수 없음을 assert한다.
+- Pool-state proof: reset-failure test는 Hikari pool active connection이 0으로 돌아오고 다음 tenant
+  request에 fresh borrow가 사용됨을 assert한다.
+- Failure cleanup: tenant resolution 이후 controller exception이 발생해도 `TenantContext`가 clear된다.
+  다음 missing-tenant request는 stale tenant를 사용하지 않고 거부된다.
+- Header hardening: blank, uppercase, path-like, SQL-like, oversized tenant value를 거부한다.
+- Documentation: README pair는 schema-per-tenant가 적합한 경우와 database-per-tenant가 더 나은 다음
+  단계인 경우를 설명한다.

--- a/docs/superpowers/plans/2026-05-22-issue-53-database-per-tenant-plan.md
+++ b/docs/superpowers/plans/2026-05-22-issue-53-database-per-tenant-plan.md
@@ -1,91 +1,90 @@
-# Issue 53 Database-Per-Tenant Plan
+# Issue 53 Database-per-tenant 계획
 
-## Steps
+## 단계
 
-1. Confirm routing and docs requirements.
-   - Use issue #53 and epic #51 as scope.
-   - Compare issue #52 schema-per-tenant module for controller, domain,
-     README, CI, and test patterns.
-   - Keep fallback behavior explicit: missing tenant is 400, unknown tenant is
-     404, and no default datasource is used.
+1. Routing 및 docs requirement를 확인한다.
+   - Issue #53과 epic #51을 scope로 사용한다.
+   - Controller, domain, README, CI, test pattern에 대해 issue #52 schema-per-tenant module과
+     비교한다.
+   - Fallback behavior를 명시적으로 유지한다: missing tenant는 400, unknown tenant는 404이며 default
+     datasource는 사용하지 않는다.
 
-2. Create the new module.
-   - Add `10-multi-tenant/05-database-per-tenant-spring-web`.
-   - Add Gradle dependencies matching the issue #52 Spring MVC/H2 example.
-   - Add application YAML with `app.tenants.acme` and
-     `app.tenants.globex` H2 JDBC URLs.
+2. 새 module을 만든다.
+   - `10-multi-tenant/05-database-per-tenant-spring-web`를 추가한다.
+   - Issue #52 Spring MVC/H2 example과 맞는 Gradle dependency를 추가한다.
+   - `app.tenants.acme`와 `app.tenants.globex` H2 JDBC URL을 포함한 application YAML을
+     추가한다.
 
-3. Implement tenant routing.
-   - Add `TenantId`, `TenantContext`, and `TenantFilter`.
-   - Register `TenantFilter` at highest precedence and clear `TenantContext`
-     in `finally`.
-   - Add tenant datasource properties and `TenantDatabaseRegistry`.
-   - Pin safe Hikari defaults and require H2 URLs with `DB_CLOSE_DELAY=-1`.
-   - Add `TenantTransaction` as the only repository transaction boundary.
-   - Ensure registry validates known tenants and closes all owned datasources.
-   - Close owned datasources from a Spring lifecycle hook.
+3. Tenant routing을 구현한다.
+   - `TenantId`, `TenantContext`, `TenantFilter`를 추가한다.
+   - `TenantFilter`를 highest precedence로 등록하고 `finally`에서 `TenantContext`를 clear한다.
+   - Tenant datasource property와 `TenantDatabaseRegistry`를 추가한다.
+   - Safe Hikari default를 고정하고 H2 URL에는 `DB_CLOSE_DELAY=-1`을 요구한다.
+   - 유일한 repository transaction boundary로 `TenantTransaction`을 추가한다.
+   - Registry가 known tenant를 검증하고 모든 owned datasource를 닫는지 보장한다.
+   - Spring lifecycle hook에서 owned datasource를 닫는다.
 
-4. Implement inventory API.
-   - Add table/model/repository/service/controller/error-handler classes.
-   - Seed distinct inventory rows per tenant.
-   - Bootstrap DDL once per tenant database before seed writes.
-   - Keep seed writes idempotent for repeated application context starts.
-   - Keep repository code datasource-agnostic.
+4. Inventory API를 구현한다.
+   - Table/model/repository/service/controller/error-handler class를 추가한다.
+   - Tenant마다 구분되는 inventory row를 seed한다.
+   - Seed write 전에 tenant database마다 DDL을 한 번 bootstrap한다.
+   - 반복 application context start에서도 seed write를 idempotent하게 유지한다.
+   - Repository code는 datasource-agnostic하게 유지한다.
 
-5. Add focused tests.
-   - Valid tenants read isolated seed data.
-   - Writes for one tenant are not visible to another tenant.
-   - Parallel alternating tenant requests cannot leak `TenantContext`.
-   - Missing tenant returns 400.
-   - Unknown tenant returns 404.
-   - Error responses use stable `{code, message}` JSON.
-   - Registry rejects incomplete or unknown tenant configuration.
-   - Registry close closes all owned Hikari datasources.
-   - Failing writes roll back in the selected tenant database only.
-   - DDL bootstrap creates inventory tables in every configured database.
+5. 집중 test를 추가한다.
+   - Valid tenant는 isolated seed data를 읽는다.
+   - 한 tenant의 write는 다른 tenant에서 보이지 않는다.
+   - Parallel alternating tenant request는 `TenantContext`를 leak할 수 없다.
+   - Missing tenant는 400을 반환한다.
+   - Unknown tenant는 404를 반환한다.
+   - Error response는 stable `{code, message}` JSON을 사용한다.
+   - Registry는 incomplete 또는 unknown tenant configuration을 거부한다.
+   - Registry close는 모든 owned Hikari datasource를 닫는다.
+   - Failing write는 selected tenant database에서만 rollback된다.
+   - DDL bootstrap은 모든 configured database에 inventory table을 만든다.
 
-6. Add documentation and diagrams.
-   - Add English/Korean module READMEs.
-   - Document that header-based tenant routing is a workshop simplification;
-     production systems must bind tenant identity to authentication.
-   - Add architecture PNG/SVG and sequence PNG/SVG.
-   - Update `10-multi-tenant/README.md` and `README.ko.md`.
-   - Update root `README.md` and `README.ko.md`.
+6. 문서와 diagram을 추가한다.
+   - English/Korean module README를 추가한다.
+   - Header-based tenant routing은 workshop simplification이며 production system은 tenant identity를
+     authentication에 bind해야 함을 문서화한다.
+   - Architecture PNG/SVG와 sequence PNG/SVG를 추가한다.
+   - `10-multi-tenant/README.md`와 `README.ko.md`를 갱신한다.
+   - Root `README.md`와 `README.ko.md`를 갱신한다.
 
-7. Wire selected examples CI.
-   - Add module path to `.github/workflows/examples.yml` triggers.
-   - Add `:05-database-per-tenant-spring-web:build` to selected example build.
+7. Selected examples CI를 연결한다.
+   - `.github/workflows/examples.yml` trigger에 module path를 추가한다.
+   - Selected example build에 `:05-database-per-tenant-spring-web:build`를 추가한다.
 
-8. Verify and review.
-   - Run targeted module tests/build.
-   - Run `actionlint`.
-   - Run README diagram scan and visual PNG inspection.
-   - Run Step 6-R 6-Tier review plus Claude Code CLI review.
+8. 검증하고 review한다.
+   - Targeted module tests/build를 실행한다.
+   - `actionlint`를 실행한다.
+   - README diagram scan과 visual PNG inspection을 실행한다.
+   - Step 6-R 6-Tier review와 Claude Code CLI review를 실행한다.
 
-9. Publish.
-   - Commit with Lore protocol.
-   - Push branch and create PR against `develop`, assigned to `debop`.
-   - Add `examples` and `documentation` labels when available.
-   - Watch CI and address failures before handoff.
+9. 게시한다.
+   - Lore protocol로 commit한다.
+   - Branch를 push하고 `debop`에게 assign된 `develop` 대상 PR을 만든다.
+   - 사용할 수 있으면 `examples`와 `documentation` label을 추가한다.
+   - Handoff 전에 CI를 watch하고 failure를 처리한다.
 
-## Acceptance Mapping
+## 수용 기준 매핑
 
 - Tenant-specific datasource/database routing:
-  Steps 2-4 implement `TenantDatabaseRegistry` and `TenantTransaction`.
-- Focused tenant isolation and error tests:
-  Step 5 covers isolation, missing/unknown tenant, and no fallback.
-- README.md and README.ko.md strategy guidance:
-  Step 6 documents when database-per-tenant is appropriate.
-- CI/nightly coverage decision:
-  The spec records H2 selected-example CI coverage; Step 7 enforces it.
+  Steps 2-4는 `TenantDatabaseRegistry`와 `TenantTransaction`을 구현한다.
+- Tenant isolation과 error test 집중:
+  Step 5는 isolation, missing/unknown tenant, no fallback을 다룬다.
+- README.md 및 README.ko.md 전략 안내:
+  Step 6은 database-per-tenant가 적절한 경우를 문서화한다.
+- CI/nightly coverage 결정:
+  Spec은 H2 selected-example CI coverage를 기록하고 Step 7은 이를 강제한다.
 
-## Review Notes
+## 검토 메모
 
-Step 2-R/3-R advisor review is required before implementation proceeds.
-The gate passes only with latest normalized `P0=0` and `P1=0`.
+구현을 진행하기 전에 Step 2-R/3-R advisor review가 필요하다. Gate는 최신 normalized `P0=0`,
+`P1=0` 상태에서만 통과한다.
 
-Initial advisor artifact:
+초기 advisor artifact:
 `.omx/artifacts/claude-issue-53-spec-plan-advisor-stdin-6min-20260522235409.md`.
-It failed with P0=2/P1=6. The spec and plan now include the accepted fixes:
-ThreadLocal cleanup, H2 lifecycle, lifecycle close hook, filter ordering,
-parallel isolation, rollback, DDL bootstrap, and README auth-warning coverage.
+해당 review는 P0=2/P1=6으로 실패했다. Spec과 plan은 이제 accepted fix를 포함한다: ThreadLocal
+cleanup, H2 lifecycle, lifecycle close hook, filter ordering, parallel isolation, rollback, DDL
+bootstrap, README auth-warning coverage.

--- a/docs/superpowers/plans/2026-05-22-issue-61-http-outbox-idempotency-plan.md
+++ b/docs/superpowers/plans/2026-05-22-issue-61-http-outbox-idempotency-plan.md
@@ -1,35 +1,35 @@
-# Issue 61 HTTP Outbox Idempotency Plan
+# Issue 61 HTTP outbox idempotency 계획
 
-## Retrieval
+## 검색 근거
 
-- GNO similar work lookup: complete.
-- GNO caution lookup: complete.
-- Current issue body: verified from GitHub issue #61.
-- `$bluetape4k-patterns`: applied to all Kotlin tasks.
+- GNO similar work lookup: 완료.
+- GNO caution lookup: 완료.
+- Current issue body: GitHub issue #61에서 검증함.
+- `$bluetape4k-patterns`: 모든 Kotlin task에 적용함.
 
-## Tasks
+## 작업
 
-1. Create Spring Boot 4 module.
-   - Add Gradle build.
-   - Add Exposed persistence/repository.
-   - Add `RestClient` outbound client.
-   - Add service and MVC controller/advice.
-   - Add repository, service, and MockMvc tests.
+1. Spring Boot 4 module을 만든다.
+   - Gradle build를 추가한다.
+   - Exposed persistence/repository를 추가한다.
+   - `RestClient` outbound client를 추가한다.
+   - Service와 MVC controller/advice를 추가한다.
+   - Repository, service, MockMvc test를 추가한다.
 
-2. Create Ktor module.
-   - Add Gradle build.
-   - Add Exposed persistence/repository.
-   - Add Ktor `HttpClient` outbound client.
-   - Add service, plugins, and routes.
-   - Add repository, service, and route tests.
+2. Ktor module을 만든다.
+   - Gradle build를 추가한다.
+   - Exposed persistence/repository를 추가한다.
+   - Ktor `HttpClient` outbound client를 추가한다.
+   - Service, plugin, route를 추가한다.
+   - Repository, service, route test를 추가한다.
 
-3. Update docs and workflow.
-   - Add module README files in English and Korean.
-   - Update chapter README files.
-   - Update root README files.
-   - Add both modules to `.github/workflows/examples.yml`.
+3. Docs와 workflow를 갱신한다.
+   - English/Korean module README file을 추가한다.
+   - Chapter README file을 갱신한다.
+   - Root README file을 갱신한다.
+   - 두 module을 `.github/workflows/examples.yml`에 추가한다.
 
-4. Verify.
+4. 검증한다.
    - `./gradlew projects --no-daemon`
    - `./gradlew :03-spring-http-outbox-idempotency:test --no-daemon`
    - `./gradlew :04-ktor-http-outbox-idempotency:test --no-daemon`
@@ -37,9 +37,9 @@
    - `actionlint .github/workflows/examples.yml`
    - `git diff --check`
 
-5. Delivery.
-   - Record concise lesson.
-   - Commit with Lore trailers.
-   - Open PR assigned to `debop`.
-   - Wait for Examples success.
-   - Merge and sync local `develop`.
+5. 전달한다.
+   - 간결한 lesson을 기록한다.
+   - Lore trailer를 포함해 commit한다.
+   - `debop`에게 assign된 PR을 연다.
+   - Examples success를 기다린다.
+   - Merge하고 local `develop`을 sync한다.

--- a/docs/superpowers/plans/2026-05-23-issue-54-spring-security-tenant-authorization-plan.md
+++ b/docs/superpowers/plans/2026-05-23-issue-54-spring-security-tenant-authorization-plan.md
@@ -1,77 +1,72 @@
-# Issue 54 Spring Security Tenant Authorization Plan
+# Issue 54 Spring Security tenant authorization 계획
 
-## Scope
+## 범위
 
-Add `10-multi-tenant/06-spring-security-tenant-authorization-spring-web`, a
-Spring MVC + Spring Security + Exposed JDBC workshop module that authorizes a
-tenant before selecting the tenant database.
+Tenant database를 선택하기 전에 tenant를 authorize하는 Spring MVC + Spring Security + Exposed JDBC
+workshop module `10-multi-tenant/06-spring-security-tenant-authorization-spring-web`를 추가한다.
 
-Approved spec draft:
+승인된 spec draft:
 
 - `docs/superpowers/specs/2026-05-23-issue-54-spring-security-tenant-authorization-design.md`
 
-## Implementation Tasks
+## 구현 작업
 
-### 1. Scaffold the module
+### 1. Module scaffold
 
 Complexity: M
 
-- Copy the structure of `10-multi-tenant/05-database-per-tenant-spring-web`.
-- Rename package from `exposed.multitenant.database` to
+- `10-multi-tenant/05-database-per-tenant-spring-web`의 structure를 복사한다.
+- Package를 `exposed.multitenant.database`에서
   `exposed.multitenant.security`.
-- Rename the Spring Boot entrypoint to `TenantSecurityApplication.kt`.
-- Update `springBoot.mainClass`, README titles, and application metadata.
-- Confirm `settings.gradle.kts` auto-registers the module through
-  `includeModules("10-multi-tenant", false, false)` and update it only if
-  discovery fails.
-- Keep inventory domain, service, repository, and seed data comparable with
-  module `05`.
+- Spring Boot entrypoint를 `TenantSecurityApplication.kt`로 rename한다.
+- `springBoot.mainClass`, README title, application metadata를 갱신한다.
+- `settings.gradle.kts`가 `includeModules("10-multi-tenant", false, false)`를 통해 module을
+  auto-register하는지 확인하고, discovery가 실패할 때만 갱신한다.
+- Inventory domain, service, repository, seed data를 module `05`와 비교 가능하게 유지한다.
 
-### 2. Add Spring Security dependencies
+### 2. Spring Security dependency 추가
 
 Complexity: S
 
-- Add module dependencies:
+- Module dependency를 추가한다:
   - `org.springframework.boot:spring-boot-starter-security`
   - `org.springframework.boot:spring-boot-starter-oauth2-resource-server`
   - `org.springframework.security:spring-security-test`
-- Keep H2-only tenant database dependencies from module `05`.
-- Avoid new version catalog entries unless existing repo style requires them;
-  current examples use direct Spring Boot starter coordinates.
-- Do not add Konsist or ArchUnit. Use focused JUnit source-text architecture
-  tests with `java.nio.file.Files.walk` and `readText()` so the example stays
-  dependency-light.
-- Keep Exposed imports under `org.jetbrains.exposed.v1.*`.
+- Module `05`의 H2-only tenant database dependency를 유지한다.
+- 기존 repo style이 요구하지 않는 한 새 version catalog entry를 피한다. Current example은 direct
+  Spring Boot starter coordinate를 사용한다.
+- Konsist나 ArchUnit을 추가하지 않는다. Example이 dependency-light 상태를 유지하도록
+  `java.nio.file.Files.walk`와 `readText()`를 사용하는 focused JUnit source-text architecture test를
+  사용한다.
+- Exposed import는 `org.jetbrains.exposed.v1.*` 아래로 유지한다.
 
-### 3. Implement authentication and tenant authorization
+### 3. Authentication 및 tenant authorization 구현
 
 Complexity: L
 
-- Add `config/SecurityConfiguration.kt`.
-  - Disable CSRF for this stateless JSON workshop API.
-  - Use stateless session management.
-  - Permit `/actuator/health`.
-  - Require authentication for inventory endpoints.
-  - Enable OAuth2 Resource Server JWT with a converter that preserves JWT
-    authentication even when tenant claims are absent.
-  - Instantiate custom security filters directly inside this configuration;
-    do not annotate them with `@Component` and do not expose them as `Filter`
-    beans.
-  - Register `CredentialConflictFilter` before authentication filters to reject
-    requests that include more than one credential source.
-  - Register API-key and demo-session filters inside `SecurityFilterChain`
-    before bearer-token authentication.
-  - Register `TenantAuthorizationFilter` inside `SecurityFilterChain` after
-    `AuthorizationFilter`, so `.anyRequest().authenticated()` has already run
-    and MVC handlers still receive the authorized `TenantContext`.
-  - Disable independent servlet filter auto-registration for all custom
-    security filters if they are exposed as beans.
-- Add `security/AuthenticatedTenant.kt`.
-  - Any `data class` must implement `java.io.Serializable` and define
-    `serialVersionUID`.
-  - Public API/KDoc text must be English.
-- Add `security/DemoJwtDecoder.kt`.
-  - Fixed accepted token strings:
+- `config/SecurityConfiguration.kt`를 추가한다.
+  - 이 stateless JSON workshop API에서는 CSRF를 비활성화한다.
+  - Stateless session management를 사용한다.
+  - `/actuator/health`를 permit한다.
+  - Inventory endpoint에는 authentication을 요구한다.
+  - Tenant claim이 없어도 JWT authentication을 보존하는 converter와 함께 OAuth2 Resource Server
+    JWT를 활성화한다.
+  - Custom security filter는 이 configuration 안에서 직접 instantiate한다. `@Component`를 붙이거나
+    `Filter` bean으로 노출하지 않는다.
+  - Credential source를 둘 이상 포함한 request를 거부하도록 authentication filter 앞에
+    `CredentialConflictFilter`를 등록한다.
+  - Bearer-token authentication 앞의 `SecurityFilterChain` 안에 API-key filter와 demo-session
+    filter를 등록한다.
+  - `.anyRequest().authenticated()`가 이미 실행되고 MVC handler가 authorized `TenantContext`를 받을
+    수 있도록 `AuthorizationFilter` 뒤의 `SecurityFilterChain` 안에 `TenantAuthorizationFilter`를
+    등록한다.
+  - Custom security filter가 bean으로 노출된다면 independent servlet filter auto-registration을
+    비활성화한다.
+- `security/AuthenticatedTenant.kt`를 추가한다.
+  - 모든 `data class`는 `java.io.Serializable`을 구현하고 `serialVersionUID`를 정의해야 한다.
+  - Public API/KDoc text는 English여야 한다.
+- `security/DemoJwtDecoder.kt`를 추가한다.
+  - Fixed accepted token string:
     - `demo-acme-token` -> `tenant_id=acme`
     - `demo-globex-token` -> `tenant_id=globex`
     - `demo-no-tenant-token` -> no `tenant_id`
@@ -79,157 +74,143 @@ Complexity: L
     - `demo-acme-upper-token` -> `tenant_id=ACME`
     - `demo-malformed-tenant-token` -> `tenant_id=acme,globex`
     - `demo-non-string-tenant-token` -> numeric `tenant_id`
-  - Include English KDoc warning that this decoder is fixed-data workshop code,
-    not production token validation.
-- Add `security/CredentialConflictFilter.kt`.
-  - Counts credential source presence only: bearer authorization, API key, demo
-    session.
-  - Treat a header as present only when at least one value is non-blank after
-    trim.
-  - Count `Authorization` only when the scheme is `Bearer` with
-    case-insensitive scheme matching.
-  - Scan all `Authorization` header values; if any non-blank value is bearer,
-    bearer credentials are present.
-  - Ignore non-bearer authorization schemes because the example does not
-    support Basic, Digest, or form login.
-  - Skip `/actuator/health`.
-  - Returns `400 CONFLICTING_CREDENTIALS` when more than one source is present.
-  - Must not log raw secret-bearing header values.
-- Add `security/DemoApiKeyAuthenticationFilter.kt`.
+  - 이 decoder가 production token validation이 아니라 fixed-data workshop code라는 한국어 KDoc
+    warning을 포함한다.
+- `security/CredentialConflictFilter.kt`를 추가한다.
+  - Bearer authorization, API key, demo session의 credential source presence만 count한다.
+  - Trim 후 non-blank value가 최소 하나 있을 때만 header가 present라고 취급한다.
+  - `Authorization`은 case-insensitive scheme matching으로 scheme이 `Bearer`일 때만 count한다.
+  - 모든 `Authorization` header value를 scan한다. Non-blank bearer value가 있으면 bearer
+    credential이 present다.
+  - Example은 Basic, Digest, form login을 지원하지 않으므로 non-bearer authorization scheme은
+    무시한다.
+  - `/actuator/health`는 skip한다.
+  - Source가 둘 이상 present이면 `400 CONFLICTING_CREDENTIALS`를 반환한다.
+  - Raw secret-bearing header value를 log하면 안 된다.
+- `security/DemoApiKeyAuthenticationFilter.kt`를 추가한다.
   - `demo-acme-key` -> `acme`
   - `demo-globex-key` -> `globex`
-  - Invalid provided API keys fail authentication.
-  - Must participate in Spring Security exception translation and must not
-    write directly to the servlet response outside the security chain.
-  - Plain class, not `@Component`, not a `Filter` bean.
-- Add `security/DemoSessionAuthenticationFilter.kt`.
+  - Invalid provided API key는 authentication에 실패한다.
+  - Spring Security exception translation에 참여해야 하며 security chain 밖에서 servlet response에
+    직접 write하면 안 된다.
+  - Plain class이며 `@Component`나 `Filter` bean이 아니다.
+- `security/DemoSessionAuthenticationFilter.kt`를 추가한다.
   - `acme-session` -> `acme`
   - `globex-session` -> `globex`
-  - Invalid provided session headers fail authentication.
-  - Must participate in Spring Security exception translation and must not
-    create a persistent server session.
-  - Plain class, not `@Component`, not a `Filter` bean.
-- Add `security/TenantAuthenticationResolver.kt`.
-  - Reads tenant identity from JWT, API-key, or demo-session authentication.
-  - Distinguishes missing, malformed, unknown, and resolved states.
-  - Normalizes tenant claim values with trim/lowercase, matching
-    `TenantId.fromHeaderOrNull`.
-- Add `security/TenantAuthorizationFilter.kt`.
-  - Skip `/actuator/health`.
-  - Resolve authenticated tenant before validating `X-Tenant-ID`; missing,
-    malformed, or unknown authenticated tenant returns 403.
-  - Validates exactly one `X-Tenant-ID` header.
-  - Compares requested and authenticated tenants.
-  - Sets `TenantContext` only after authorization succeeds.
-  - Clears `TenantContext` in `finally`.
-  - Plain class, not `@Component`, not a `Filter` bean.
-  - Must not log raw `Authorization`, `X-API-Key`, or `X-Demo-Session` values.
-  - Use explicit servlet security anchors:
+  - Invalid provided session header는 authentication에 실패한다.
+  - Spring Security exception translation에 참여해야 하며 persistent server session을 만들면 안 된다.
+  - Plain class이며 `@Component`나 `Filter` bean이 아니다.
+- `security/TenantAuthenticationResolver.kt`를 추가한다.
+  - JWT, API-key, demo-session authentication에서 tenant identity를 읽는다.
+  - Missing, malformed, unknown, resolved state를 구분한다.
+  - `TenantId.fromHeaderOrNull`과 맞게 tenant claim value를 trim/lowercase로 normalize한다.
+- `security/TenantAuthorizationFilter.kt`를 추가한다.
+  - `/actuator/health`는 skip한다.
+  - `X-Tenant-ID`를 validate하기 전에 authenticated tenant를 resolve한다. Missing, malformed,
+    unknown authenticated tenant는 403을 반환한다.
+  - 정확히 하나의 `X-Tenant-ID` header를 validate한다.
+  - Requested tenant와 authenticated tenant를 비교한다.
+  - Authorization이 성공한 뒤에만 `TenantContext`를 설정한다.
+  - `finally`에서 `TenantContext`를 clear한다.
+  - Plain class이며 `@Component`나 `Filter` bean이 아니다.
+  - Raw `Authorization`, `X-API-Key`, `X-Demo-Session` value를 log하면 안 된다.
+  - 명시적 servlet security anchor를 사용한다:
     - `addFilterBefore(credentialConflictFilter, BearerTokenAuthenticationFilter::class.java)`
     - `addFilterBefore(apiKeyAuthenticationFilter, BearerTokenAuthenticationFilter::class.java)`
     - `addFilterBefore(demoSessionAuthenticationFilter, BearerTokenAuthenticationFilter::class.java)`
     - `addFilterAfter(tenantAuthorizationFilter, AuthorizationFilter::class.java)`
 
-### 4. Preserve database-per-tenant routing
+### 4. Database-per-tenant routing 보존
 
 Complexity: M
 
-- Keep `TenantDatabaseRegistry`, `TenantTransaction`, `TenantContext`, and
-  `TenantId` behavior aligned with module `05`.
-- Remove any request-path filter that writes `TenantContext` from a raw header.
-- Keep registry validation and datasource lifecycle tests.
-- Keep repositories datasource-agnostic; repositories call `TenantTransaction`
-  only.
+- `TenantDatabaseRegistry`, `TenantTransaction`, `TenantContext`, `TenantId` behavior를 module
+  `05`와 정렬된 상태로 유지한다.
+- Raw header에서 `TenantContext`를 쓰는 request-path filter는 제거한다.
+- Registry validation과 datasource lifecycle test를 유지한다.
+- Repository는 datasource-agnostic하게 유지한다. Repository는 `TenantTransaction`만 호출한다.
 
-### 5. Add tests
+### 5. Test 추가
 
 Complexity: L
 
-- Security request tests:
-  - valid JWT claim reads matching tenant seed data;
-  - JWT/header mismatch returns 403;
-  - JWT without tenant claim returns 403;
-  - JWT with unknown tenant claim returns 403;
-  - JWT with malformed tenant claim returns 403;
-  - JWT with non-string tenant claim returns 403;
-  - missing authentication returns 401;
-  - API key reads matching tenant seed data;
-  - invalid API key returns 401;
-  - demo session reads matching tenant seed data;
-  - demo session/header mismatch returns 403.
-- Tenant selector tests:
-  - missing header returns 400;
-  - blank, duplicate, comma-containing, and too-long headers return 400;
-  - unknown header returns 404 for authenticated callers.
-  - uppercase tenant selector and uppercase tenant claim normalize to the same
-    known tenant.
-  - leading/trailing whitespace around tenant selector and claim normalizes to
-    the same known tenant.
-  - authenticated JWT without tenant claim plus missing `X-Tenant-ID` returns
-    403 because authenticated tenant validation runs before selector
-    validation.
-- Credential conflict tests:
-  - bearer `acme` plus API key `globex` returns 400
-    `CONFLICTING_CREDENTIALS`;
-  - API key plus demo session returns 400 `CONFLICTING_CREDENTIALS`;
-  - `Authorization: Basic ...` plus API key is not a credential conflict and
-    authenticates through the API key;
-  - multi-credential `/actuator/health` still returns the health response;
-  - conflict responses do not set `TenantContext`.
-- Routing and cleanup tests:
-  - valid `acme` and `globex` requests return tenant-specific rows;
-  - cross-tenant data is not visible;
-  - parallel authorized requests cannot leak `TenantContext`;
-  - direct filter test proves same servlet-thread cleanup after downstream
-    failure.
-- Architecture tests:
-  - implement as JUnit source-text scans using `java.nio.file.Files.walk`; no
-    Konsist or ArchUnit dependency;
-  - only `TenantAuthorizationFilter` calls `TenantContext.set`;
-  - custom security filters are not annotated with `@Component`;
-  - no production code in this module imports from module `05`;
-  - repositories do not call bare `transaction(` except through
-    `TenantTransaction`.
+- Security request test:
+  - Valid JWT claim은 matching tenant seed data를 읽는다.
+  - JWT/header mismatch는 403을 반환한다.
+  - Tenant claim 없는 JWT는 403을 반환한다.
+  - Unknown tenant claim이 있는 JWT는 403을 반환한다.
+  - Malformed tenant claim이 있는 JWT는 403을 반환한다.
+  - Non-string tenant claim이 있는 JWT는 403을 반환한다.
+  - Missing authentication은 401을 반환한다.
+  - API key는 matching tenant seed data를 읽는다.
+  - Invalid API key는 401을 반환한다.
+  - Demo session은 matching tenant seed data를 읽는다.
+  - Demo session/header mismatch는 403을 반환한다.
+- Tenant selector test:
+  - Missing header는 400을 반환한다.
+  - Blank, duplicate, comma-containing, too-long header는 400을 반환한다.
+  - Unknown header는 authenticated caller에 대해 404를 반환한다.
+  - Uppercase tenant selector와 uppercase tenant claim은 같은 known tenant로 normalize된다.
+  - Tenant selector 및 claim 주변 leading/trailing whitespace는 같은 known tenant로 normalize된다.
+  - Tenant claim 없는 authenticated JWT와 missing `X-Tenant-ID` 조합은 403을 반환한다.
+    Authenticated tenant validation이 selector validation보다 먼저 실행되기 때문이다.
+- Credential conflict test:
+  - Bearer `acme`와 API key `globex` 조합은 `400 CONFLICTING_CREDENTIALS`를 반환한다.
+  - API key와 demo session 조합은 `400 CONFLICTING_CREDENTIALS`를 반환한다.
+  - `Authorization: Basic ...`과 API key 조합은 credential conflict가 아니며 API key로
+    authenticate된다.
+  - Multi-credential `/actuator/health`도 health response를 반환한다.
+  - Conflict response는 `TenantContext`를 설정하지 않는다.
+- Routing 및 cleanup test:
+  - Valid `acme`, `globex` request는 tenant-specific row를 반환한다.
+  - Cross-tenant data는 보이지 않는다.
+  - Parallel authorized request는 `TenantContext`를 leak할 수 없다.
+  - Direct filter test는 downstream failure 이후 same servlet-thread cleanup을 증명한다.
+- Architecture test:
+  - Konsist나 ArchUnit dependency 없이 `java.nio.file.Files.walk`를 사용하는 JUnit source-text
+    scan으로 구현한다.
+  - `TenantAuthorizationFilter`만 `TenantContext.set`을 호출한다.
+  - Custom security filter는 `@Component` annotation을 갖지 않는다.
+  - 이 module의 production code는 module `05`에서 import하지 않는다.
+  - Repository는 `TenantTransaction`을 통하지 않는 bare `transaction(`을 호출하지 않는다.
 
-### 6. Update documentation and diagrams
+### 6. Documentation 및 diagram 갱신
 
 Complexity: M
 
-- Add module `README.md` and `README.ko.md`.
-- Explain:
-  - tenant routing vs tenant authorization;
-  - JWT/API-key/demo-session identity sources;
-  - demo session header is not a production session cookie;
-  - CSRF is disabled because this example is stateless JSON;
-  - request and error contract;
-  - when to choose this strategy;
-  - CI coverage and why Nightly remains unchanged.
-  - top-level "Not for production" caveat for `DemoJwtDecoder`, fixed API key
-    maps, and demo session header.
-  - MVC `ThreadLocal` propagation does not transfer unchanged to coroutine,
-    WebFlux, or virtual-thread examples.
-- Add architecture PNG/SVG and sequence PNG/SVG under
-  `docs/images/readme-diagrams/`.
-- Visually inspect PNGs for readable contrast.
-- Update `10-multi-tenant/README.md` and `README.ko.md` to list module `06`.
-- Update root README files only if their module tables enumerate Chapter 10
-  examples directly.
+- Module `README.md`와 `README.ko.md`를 추가한다.
+- 다음을 설명한다:
+  - Tenant routing vs tenant authorization.
+  - JWT/API-key/demo-session identity source.
+  - Demo session header는 production session cookie가 아니다.
+  - 이 example은 stateless JSON이므로 CSRF가 비활성화된다.
+  - Request 및 error contract.
+  - 이 strategy를 선택할 시점.
+  - CI coverage와 Nightly가 unchanged인 이유.
+  - `DemoJwtDecoder`, fixed API key map, demo session header에 대한 top-level
+    "Not for production" caveat.
+  - MVC `ThreadLocal` propagation은 coroutine, WebFlux, virtual-thread example에 그대로
+    이전되지 않는다.
+- `docs/images/readme-diagrams/` 아래 architecture PNG/SVG와 sequence PNG/SVG를 추가한다.
+- Readable contrast를 위해 PNG를 visually inspect한다.
+- Module `06`을 나열하도록 `10-multi-tenant/README.md`와 `README.ko.md`를 갱신한다.
+- Root README file은 module table이 Chapter 10 example을 직접 enumerate할 때만 갱신한다.
 
-### 7. Wire selected Examples CI
+### 7. Selected Examples CI 연결
 
 Complexity: S
 
-- Add `10-multi-tenant/06-spring-security-tenant-authorization-spring-web/**`
-  to both `on.push.paths` and `on.pull_request.paths` in Examples workflow.
-- Add `:06-spring-security-tenant-authorization-spring-web:build` to the
-  selected examples Gradle command.
-- Run `actionlint .github/workflows/examples.yml`.
+- Examples workflow의 `on.push.paths`와 `on.pull_request.paths` 모두에
+  `10-multi-tenant/06-spring-security-tenant-authorization-spring-web/**`를 추가한다.
+- Selected examples Gradle command에 `:06-spring-security-tenant-authorization-spring-web:build`를
+  추가한다.
+- `actionlint .github/workflows/examples.yml`을 실행한다.
 
-### 8. Verify and review
+### 8. 검증 및 review
 
 Complexity: M
 
-Run in order:
+다음 순서로 실행한다:
 
 1. `./gradlew projects --quiet | rg '06-spring-security-tenant-authorization-spring-web'`
 2. `./gradlew :06-spring-security-tenant-authorization-spring-web:compileKotlin --warning-mode all --console=plain`
@@ -237,39 +218,37 @@ Run in order:
 4. `./gradlew :06-spring-security-tenant-authorization-spring-web:build --stacktrace --continue`
 5. `actionlint .github/workflows/examples.yml`
 6. `git diff --check`
-7. README diagram scan for required Architecture Diagram PNG links and no
-   Mermaid blocks.
-8. Visual PNG inspection through image viewer tooling.
-9. IDE diagnostics if available; otherwise record compile/test fallback.
-10. Step 6-R current-session 6-Tier review plus Claude Code CLI review with
-    `P0=0`, `P1=0`.
+7. Required architecture diagram PNG link와 Mermaid block 없음 상태에 대한 README diagram scan.
+8. Image viewer tooling을 통한 visual PNG inspection.
+9. 사용할 수 있으면 IDE diagnostics. 그렇지 않으면 compile/test fallback을 기록한다.
+10. Step 6-R current-session 6-Tier review와 Claude Code CLI review. 결과는 `P0=0`, `P1=0`.
 
-### 9. Publish
+### 9. 게시
 
 Complexity: M
 
-- Add `docs/lessons/2026-05-23-issue-54-spring-security-tenant-authorization.md`.
-- Commit with Lore protocol trailers.
-- Push branch and open a PR against `develop`, assigned to `debop`.
-- Add `examples`, `documentation`, and security-related labels if available.
-- Add Step 7-R PR comment and formal review entry.
-- Watch CI until required checks are `SUCCESS` or `SKIPPED`.
-- Do not merge unless the user requests merge after the DoD report.
+- `docs/lessons/2026-05-23-issue-54-spring-security-tenant-authorization.md`를 추가한다.
+- Lore protocol trailer를 포함해 commit한다.
+- Branch를 push하고 `debop`에게 assign된 `develop` 대상 PR을 연다.
+- 사용할 수 있으면 `examples`, `documentation`, security-related label을 추가한다.
+- Step 7-R PR comment와 formal review entry를 추가한다.
+- Required check가 `SUCCESS` 또는 `SKIPPED`가 될 때까지 CI를 watch한다.
+- DoD report 이후 사용자가 merge를 요청하기 전에는 merge하지 않는다.
 
-## Acceptance Mapping
+## 수용 기준 매핑
 
-- Tenant from authenticated requests:
-  Tasks 2 and 3 implement JWT/API-key/demo-session authentication and tenant
-  authorization before `TenantContext` is set.
-- Focused tests for isolation and error handling:
-  Task 5 covers valid access, missing auth, invalid tenant claims, mismatch,
-  and cross-tenant denial.
-- README strategy guidance:
-  Task 6 updates English/Korean docs and committed PNG diagrams.
-- CI/nightly coverage decision:
-  Task 7 wires Examples CI; the spec records why Nightly is unchanged.
+- Authenticated request에서 tenant 도출:
+  Task 2와 3은 `TenantContext`가 설정되기 전에 JWT/API-key/demo-session authentication 및 tenant
+  authorization을 구현한다.
+- Isolation 및 error handling용 focused test:
+  Task 5는 valid access, missing auth, invalid tenant claim, mismatch, cross-tenant denial을
+  다룬다.
+- README 전략 안내:
+  Task 6은 English/Korean docs와 committed PNG diagram을 갱신한다.
+- CI/nightly coverage 결정:
+  Task 7은 Examples CI를 연결한다. Spec은 Nightly가 unchanged인 이유를 기록한다.
 
-## Review Notes
+## 검토 메모
 
-Step 2-R/3-R advisor review is required before implementation proceeds. The
-gate passes only when the latest normalized table shows `P0=0` and `P1=0`.
+구현을 진행하기 전에 Step 2-R/3-R advisor review가 필요하다. Gate는 최신 normalized table이
+`P0=0` 및 `P1=0`을 보여 줄 때만 통과한다.

--- a/docs/superpowers/plans/2026-06-28-issue-137-ecosystem-integrations-plan.md
+++ b/docs/superpowers/plans/2026-06-28-issue-137-ecosystem-integrations-plan.md
@@ -1,157 +1,180 @@
-# Issue #137 Ecosystem Integrations Chapter Implementation Plan
+# Issue #137 Ecosystem integrations chapter 구현 계획
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Agentic worker용:** REQUIRED SUB-SKILL: 이 계획은 task-by-task로 구현하기 위해 superpowers:subagent-driven-development(권장) 또는 superpowers:executing-plans를 사용한다. 단계 추적에는 checkbox(`- [ ]`) syntax를 사용한다.
 
-**Goal:** Add the `13-ecosystem-integrations` chapter foundation for issue #137 without claiming the child examples are implemented.
+**목표:** Child example이 구현됐다고 주장하지 않으면서 issue #137을 위한
+`13-ecosystem-integrations` chapter foundation을 추가한다.
 
-**Architecture:** The PR creates a README-only chapter overview, registers the chapter scan hook, and wires root docs plus Examples workflow path triggers. Child issues #138-#145 will create runnable Gradle modules later and must add their own workflow build tasks.
+**아키텍처:** PR은 README-only chapter overview를 만들고 chapter scan hook을 등록하며 root docs와
+Examples workflow path trigger를 연결한다. Child issue #138-#145는 나중에 runnable Gradle module을
+만들며, 각자 workflow build task를 추가해야 한다.
 
-**Tech Stack:** Gradle Kotlin DSL, GitHub Actions, Markdown README pairs, committed SVG/PNG README diagram assets.
+**기술 스택:** Gradle Kotlin DSL, GitHub Actions, Markdown README pair, committed SVG/PNG README
+diagram asset.
 
 ---
 
-## File Structure
+## 파일 구조
 
-- Create: `13-ecosystem-integrations/README.md`
-- Create: `13-ecosystem-integrations/README.ko.md`
-- Create: `docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.svg`
-- Create: `docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.png`
-- Modify: `settings.gradle.kts`
-- Modify: `README.md`
-- Modify: `README.ko.md`
-- Modify: `AGENTS.md`
-- Modify: `.github/workflows/examples.yml`
-- Create: `docs/lessons/2026-06-28-issue-137-ecosystem-integrations.md`
+- 생성: `13-ecosystem-integrations/README.md`
+- 생성: `13-ecosystem-integrations/README.ko.md`
+- 생성: `docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.svg`
+- 생성: `docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.png`
+- 수정: `settings.gradle.kts`
+- 수정: `README.md`
+- 수정: `README.ko.md`
+- 수정: `AGENTS.md`
+- 수정: `.github/workflows/examples.yml`
+- 생성: `docs/lessons/2026-06-28-issue-137-ecosystem-integrations.md`
 
-## Task 0: Commit Design Artifacts
-
-**complexity:** low
-
-**Files:**
-- Create: `docs/superpowers/specs/2026-06-28-issue-137-ecosystem-integrations-design.md`
-- Create: `docs/superpowers/plans/2026-06-28-issue-137-ecosystem-integrations-plan.md`
-
-- [ ] Confirm Step 2-R and Step 3-R review gates have P0=0 and P1=0.
-- [ ] Commit the spec and plan before implementation edits.
-- [ ] Use a Lore-style commit message that records review evidence.
-
-## Task 1: Register Chapter Boundary
+## 작업 0: Design artifact commit
 
 **complexity:** low
 
-**Files:**
-- Modify: `settings.gradle.kts`
-- Modify: `AGENTS.md`
+**파일:**
+- 생성: `docs/superpowers/specs/2026-06-28-issue-137-ecosystem-integrations-design.md`
+- 생성: `docs/superpowers/plans/2026-06-28-issue-137-ecosystem-integrations-plan.md`
 
-- [ ] Add `includeModules("13-ecosystem-integrations", false, false)` immediately after chapter 12 in `settings.gradle.kts`.
-- [ ] Update the `AGENTS.md` layout table to include both `12-production-integration` and `13-ecosystem-integrations`.
-- [ ] Defer Gradle project verification until after Task 2 creates the base directory.
+- [ ] 확인: Step 2-R 및 Step 3-R review gate가 P0=0, P1=0이다.
+- [ ] commit: Implementation edit 전에 spec과 plan을 commit한다.
+- [ ] 검토 evidence를 기록하는 Lore-style commit message를 사용한다.
 
-## Task 2: Add Chapter README Pair
+## 작업 1: Chapter boundary 등록
 
 **complexity:** low
 
-**Files:**
-- Create: `13-ecosystem-integrations/README.md`
-- Create: `13-ecosystem-integrations/README.ko.md`
+**파일:**
+- 수정: `settings.gradle.kts`
+- 수정: `AGENTS.md`
 
-- [ ] Add the English README with `English | [한국어](README.ko.md)`.
-- [ ] Add the Korean README with `[English](README.md) | 한국어`.
-- [ ] Include the shared architecture PNG reference:
+- [ ] 추가: `settings.gradle.kts`의 chapter 12 바로 뒤에
+  `includeModules("13-ecosystem-integrations", false, false)`.
+- [ ] 갱신: `AGENTS.md` layout table에 `12-production-integration`과
+  `13-ecosystem-integrations`를 모두 포함한다.
+- [ ] Task 2가 base directory를 만든 뒤까지 Gradle project verification을 미룬다.
+
+## 작업 2: Chapter README pair 추가
+
+**complexity:** low
+
+**파일:**
+- 생성: `13-ecosystem-integrations/README.md`
+- 생성: `13-ecosystem-integrations/README.ko.md`
+
+- [ ] 추가: `English | [한국어](README.ko.md)`가 있는 English README.
+- [ ] 추가: `[English](README.md) | 한국어`가 있는 Korean README.
+- [ ] 포함: Shared architecture PNG reference:
   `![Chapter 13 ecosystem integrations architecture](../docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.png)`.
-- [ ] Include the planned issue table for #138-#145 with status `Planned`, full planned directory, Gradle task, README title, and lane.
-- [ ] Use explicit GitHub issue links in both README tables, for example `[#138](https://github.com/bluetape4k/exposed-workshop/issues/138)`.
-- [ ] Include the external service and credential policy with these five explicit bullets:
+- [ ] 포함: #138-#145의 planned issue table. Status `Planned`, full planned directory, Gradle
+  task, README title, lane을 포함한다.
+- [ ] 두 README table에서 예시처럼 explicit GitHub issue link를 사용한다:
+  `[#138](https://github.com/bluetape4k/exposed-workshop/issues/138)`.
+- [ ] 포함: 다음 다섯 explicit bullet이 있는 external service 및 credential policy:
   no checked-in credentials/tokens/service-account files/project IDs/endpoint secrets;
   no default ADC or local credential file use;
   fake/local/Testcontainers/emulator-style defaults;
   real-service execution is explicit opt-in and skipped by default in CI;
   README warnings for cost, network, and credentials before any real-service command.
-- [ ] Avoid links to non-existent child README files.
-- [ ] Add a short future child implementation order note: create the module and `build.gradle.kts`, verify Gradle project discovery, add chapter/root README links only after files exist, add the module build task to Examples or Nightly as appropriate, and record credential/coverage lane decisions.
-- [ ] Add a future child workflow-lane checklist with separate fields for default local/fake path, real-service opt-in property or tag, and selected workflow lane: weekly Examples, full Nightly, or manual opt-in.
+- [ ] 회피: 존재하지 않는 child README file link.
+- [ ] 추가: Future child implementation order note. Module과 `build.gradle.kts`를 만들고, Gradle
+  project discovery를 검증하며, file이 존재한 뒤에만 chapter/root README link를 추가하고,
+  적절한 Examples 또는 Nightly module build task를 추가하며, credential/coverage lane decision을
+  기록한다.
+- [ ] 추가: Future child workflow-lane checklist. Default local/fake path, real-service opt-in
+  property/tag, selected workflow lane(weekly Examples, full Nightly, manual opt-in)을 분리한다.
 
-## Task 3: Add Chapter Diagram Assets
+## 작업 3: Chapter diagram asset 추가
 
 **complexity:** medium
 
-**Files:**
-- Create: `docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.svg`
-- Create: `docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.png`
+**파일:**
+- 생성: `docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.svg`
+- 생성: `docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.png`
 
-- [ ] Create a source-backed SVG with three lanes: Database platform adapters, Runtime/framework integration, Domain architecture.
-- [ ] Use `Architects Daughter` and `Comic Mono` font families.
-- [ ] Keep final diagram text reader-facing only.
-- [ ] Validate XML with `xmllint --noout docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.svg`.
-- [ ] Check the SVG has a non-empty `viewBox`, explicit `width`, and explicit `height`.
-- [ ] Render PNG with `~/.local/bin/cairosvg docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.svg -o docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.png -s 2`.
-- [ ] Inspect the rendered PNG with `view_image`.
-- [ ] During PNG inspection, verify no text overflow, no card/connector overlap, no excessive whitespace, readable three-lane grouping, and all eight planned child examples represented.
+- [ ] 생성: Database platform adapters, Runtime/framework integration, Domain architecture 세 lane을
+  보여 주는 source-backed SVG.
+- [ ] `Architects Daughter`와 `Comic Mono` font family를 사용한다.
+- [ ] 유지: 최종 diagram text는 reader-facing text만 둔다.
+- [ ] validate: `xmllint --noout docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.svg`로 XML을 검증한다.
+- [ ] SVG가 non-empty `viewBox`, explicit `width`, explicit `height`를 갖는지 확인한다.
+- [ ] `~/.local/bin/cairosvg docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.svg -o docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.png -s 2`로 PNG를 render한다.
+- [ ] `view_image`로 rendered PNG를 검사한다.
+- [ ] PNG inspection 중 text overflow, card/connector overlap, excessive whitespace가 없고,
+  three-lane grouping이 readable하며 planned child example 여덟 개가 모두 표현됐는지 검증한다.
 
-## Task 4: Wire Root README Pair
-
-**complexity:** low
-
-**Files:**
-- Modify: `README.md`
-- Modify: `README.ko.md`
-
-- [ ] Add a root module-list entry for the chapter overview only.
-- [ ] English root README links to `13-ecosystem-integrations/README.md`.
-- [ ] Korean root README links to `13-ecosystem-integrations/README.ko.md`.
-- [ ] Do not add child module README links until those directories exist.
-- [ ] Mention that child examples are planned under `[#137](https://github.com/bluetape4k/exposed-workshop/issues/137)`.
-- [ ] Review existing root visuals (`root-readme-overview-01` and `root-readme-module-chart-01`) and either update them or record why a README-only zero-leaf chapter is intentionally excluded for this foundation PR.
-
-## Task 5: Wire Examples Workflow Trigger
+## 작업 4: Root README pair 연결
 
 **complexity:** low
 
-**Files:**
-- Modify: `.github/workflows/examples.yml`
+**파일:**
+- 수정: `README.md`
+- 수정: `README.ko.md`
 
-- [ ] Add `13-ecosystem-integrations/**` to both `push.paths` and `pull_request.paths`.
-- [ ] Do not add missing chapter 13 Gradle tasks to the selected build list in this foundation PR.
-- [ ] Keep the inline workflow comment clear that child module PRs must add their runnable Gradle tasks when modules exist.
-- [ ] Record in DoD that this foundation PR can trigger the existing selected Examples job, but it intentionally does not add a chapter 13 task until a runnable child module exists.
-- [ ] Record that Nightly remains unchanged because this foundation PR creates no runnable Testcontainers or external-service module.
-- [ ] Run `actionlint .github/workflows/examples.yml`.
-- [ ] Run `rg "\\\\'" .github/workflows`.
+- [ ] 추가: Chapter overview만 가리키는 root module-list entry.
+- [ ] English root README는 `13-ecosystem-integrations/README.md`로 link한다.
+- [ ] Korean root README는 `13-ecosystem-integrations/README.ko.md`로 link한다.
+- [ ] Child module directory가 존재하기 전에는 child module README link를 추가하지 않는다.
+- [ ] Child example이 `[#137](https://github.com/bluetape4k/exposed-workshop/issues/137)` 아래 planned 상태임을 언급한다.
+- [ ] 기존 root visual(`root-readme-overview-01`, `root-readme-module-chart-01`)을 review하고
+  update하거나, README-only zero-leaf chapter를 이 foundation PR에서 의도적으로 제외한 이유를
+  기록한다.
 
-## Task 6: Verification And Documentation Checks
+## 작업 5: Examples workflow trigger 연결
 
 **complexity:** low
 
-**Files:**
-- Check all changed files.
+**파일:**
+- 수정: `.github/workflows/examples.yml`
 
-- [ ] Run `git diff --check`.
-- [ ] Run `./gradlew projects --quiet`.
-- [ ] Confirm the `./gradlew projects --quiet` output does not contain planned chapter 13 child projects such as `:01-bigquery-dry-run`, because the foundation PR has no child `build.gradle.kts` yet.
-- [ ] Run `actionlint .github/workflows/examples.yml`.
-- [ ] Run README reference checks:
+- [ ] 추가: `push.paths`와 `pull_request.paths` 모두에 `13-ecosystem-integrations/**`.
+- [ ] 이 foundation PR에서는 아직 없는 chapter 13 Gradle task를 selected build list에 추가하지 않는다.
+- [ ] 유지: Child module PR은 module이 존재할 때 runnable Gradle task를 추가해야 한다는 inline workflow
+  comment를 명확하게 둔다.
+- [ ] 기록: 이 foundation PR은 기존 selected Examples job을 trigger할 수 있지만 runnable child module이
+  존재하기 전까지 chapter 13 task를 의도적으로 추가하지 않는다는 점을 DoD에 기록한다.
+- [ ] 기록: 이 foundation PR은 runnable Testcontainers 또는 external-service module을 만들지 않으므로
+  Nightly가 변경되지 않는다는 점.
+- [ ] 실행: `actionlint .github/workflows/examples.yml`.
+- [ ] 실행: `rg "\\\\'" .github/workflows`.
+
+## 작업 6: 검증과 문서 검사
+
+**complexity:** low
+
+**파일:**
+- 변경된 모든 file을 검사한다.
+
+- [ ] 실행: `git diff --check`.
+- [ ] 실행: `./gradlew projects --quiet`.
+- [ ] 확인: Foundation PR에는 아직 child `build.gradle.kts`가 없으므로 `./gradlew projects --quiet`
+  output에 `:01-bigquery-dry-run` 같은 planned chapter 13 child project가 없는지 확인한다.
+- [ ] 실행: `actionlint .github/workflows/examples.yml`.
+- [ ] 실행: README reference check:
   `rg -n "13-ecosystem-integrations|13-ecosystem-integrations-architecture-01" README.md README.ko.md 13-ecosystem-integrations/README.md 13-ecosystem-integrations/README.ko.md`.
-- [ ] Verify real Markdown link targets for the root and chapter README pair.
-- [ ] Verify the chapter README files exist:
+- [ ] 검증: Root 및 chapter README pair의 real Markdown link target.
+- [ ] 검증: Chapter README file 존재 여부:
   `test -f 13-ecosystem-integrations/README.md && test -f 13-ecosystem-integrations/README.ko.md`.
-- [ ] Verify both chapter README files contain eight explicit child issue links:
+- [ ] 검증: 두 chapter README file이 8개의 explicit child issue link를 포함하는지:
   `rg -c "https://github.com/bluetape4k/exposed-workshop/issues/13[8-9]|https://github.com/bluetape4k/exposed-workshop/issues/14[0-5]" 13-ecosystem-integrations/README.md 13-ecosystem-integrations/README.ko.md`.
-- [ ] Verify both chapter README files reference the same PNG path and contain the same five credential policy bullets.
-- [ ] Run a documentation secret/credential drift scan:
+- [ ] 검증: 두 chapter README file이 같은 PNG path를 reference하고 동일한 다섯 credential policy bullet을
+  포함하는지.
+- [ ] 실행: Documentation secret/credential drift scan:
   `rg -in "GOOGLE_APPLICATION_CREDENTIALS|application-default|Application Default Credentials|\bADC\b|service[-_ ]account|client_secret|password|token|api[_-]?key|project[-_ ]?ids?|projectId|endpoint secret" README.md README.ko.md 13-ecosystem-integrations docs/superpowers docs/lessons docs/images/readme-diagrams .github/workflows/examples.yml`.
-- [ ] Read any matches from the drift scan and classify them as policy text only or remove them before PR.
-- [ ] Verify diagram sibling existence:
+- [ ] 읽기: Drift scan match를 확인하고 policy text only로 분류하거나 PR 전에 제거한다.
+- [ ] 검증: Diagram sibling 존재 여부:
   `test -f docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.svg && test -f docs/images/readme-diagrams/13-ecosystem-integrations-architecture-01.png`.
 
-## Task 7: Lessons And PR Preparation
+## 작업 7: Lesson 및 PR 준비
 
 **complexity:** low
 
-**Files:**
-- Create: `docs/lessons/2026-06-28-issue-137-ecosystem-integrations.md`
+**파일:**
+- 생성: `docs/lessons/2026-06-28-issue-137-ecosystem-integrations.md`
 
-- [ ] Add a lesson recording the chapter boundary decision, workflow false-green guard, credential-free default guard, and future child implementation order.
-- [ ] Commit implementation and lesson with Lore trailers.
-- [ ] Create a PR that references #137 without `Closes #137`.
-- [ ] Set PR assignee `debop`, milestone `exposed-1.11.0`, and labels `enhancement`, `examples`.
-- [ ] Verify live PR body ends with `## DoD Status`.
+- [ ] 추가: Chapter boundary decision, workflow false-green guard, credential-free default guard,
+  future child implementation order를 기록하는 lesson.
+- [ ] commit: Implementation과 lesson을 Lore trailer로 commit한다.
+- [ ] 생성: `Closes #137` 없이 #137을 reference하는 PR.
+- [ ] PR assignee는 `debop`, milestone은 `exposed-1.11.0`, label은 `enhancement`, `examples`로
+  설정한다.
+- [ ] 검증: Live PR body는 `## DoD Status`로 끝난다.

--- a/docs/superpowers/plans/2026-06-29-issue-138-bigquery-dry-run-plan.md
+++ b/docs/superpowers/plans/2026-06-29-issue-138-bigquery-dry-run-plan.md
@@ -1,57 +1,55 @@
-# Issue #138 BigQuery Dry-Run Implementation Plan
+# Issue #138 BigQuery dry-run 구현 계획
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Agentic worker용:** REQUIRED SUB-SKILL: 이 계획은 task-by-task로 구현하기 위해 superpowers:subagent-driven-development(권장) 또는 superpowers:executing-plans를 사용한다. 단계 추적에는 checkbox(`- [ ]`) syntax를 사용한다.
 
-**Goal:** Add the runnable `13-ecosystem-integrations/01-bigquery-dry-run`
-workshop module for issue #138.
+**목표:** Issue #138을 위한 runnable `13-ecosystem-integrations/01-bigquery-dry-run` workshop
+module을 추가한다.
 
-**Architecture:** The module is a credential-free test-driven workshop example.
-It uses Exposed to build analytical SQL against an H2-backed SQL generation
-database, then validates the generated SQL through `BigQueryContext.validateQuery`
-against a mocked BigQuery REST client. Documentation and a flow diagram explain
-the boundary between dry-run validation and billable query execution.
+**아키텍처:** Module은 credential-free test-driven workshop example이다. H2-backed SQL generation
+database에서 Exposed로 analytical SQL을 만들고, mocked BigQuery REST client에 대해
+`BigQueryContext.validateQuery`로 generated SQL을 검증한다. Documentation과 flow diagram은
+dry-run validation과 billable query execution의 boundary를 설명한다.
 
-**Tech Stack:** Kotlin 2.3, Java 21, Gradle Kotlin DSL, JetBrains Exposed v1.x
+**기술 스택:** Kotlin 2.3, Java 21, Gradle Kotlin DSL, JetBrains Exposed v1.x
 from the catalog-backed dependency line,
 `bluetape4k-exposed-bigquery`, H2, JUnit 5, MockK, `bluetape4k-assertions`,
 CairoSVG, GitHub Actions.
 
 ---
 
-## File Map
+## 파일 지도
 
-- Modify: `gradle/libs.versions.toml`
-  - add `exposed-bigquery` alias using the centrally governed artifact.
-- Create: `13-ecosystem-integrations/01-bigquery-dry-run/build.gradle.kts`
-  - module dependencies and test classpath wiring.
-- Create: `13-ecosystem-integrations/01-bigquery-dry-run/src/main/kotlin/exposed/examples/bigquery/dryrun/BigQueryDryRunWorkshop.kt`
-  - public workshop helper API for building the read-model query, default
-    dry-run options, and validation call.
-- Create: `13-ecosystem-integrations/01-bigquery-dry-run/src/test/kotlin/exposed/examples/bigquery/dryrun/BigQueryDryRunWorkshopTest.kt`
-  - generated SQL, dry-run options, success, and failure tests.
-- Create: `13-ecosystem-integrations/01-bigquery-dry-run/src/test/resources/junit-platform.properties`
-- Create: `13-ecosystem-integrations/01-bigquery-dry-run/src/test/resources/logback-test.xml`
-- Create: `13-ecosystem-integrations/01-bigquery-dry-run/README.md`
-- Create: `13-ecosystem-integrations/01-bigquery-dry-run/README.ko.md`
-- Create: `docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.svg`
-- Create: `docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.png`
-- Modify: `13-ecosystem-integrations/README.md`
-- Modify: `13-ecosystem-integrations/README.ko.md`
-- Modify: `README.md`
-- Modify: `README.ko.md`
-- Modify: `.github/workflows/examples.yml`
-- Create: `docs/review/2026-06-29-issue-138-bigquery-dry-run-code-review.md`
-- Create: `docs/lessons/2026-06-29-issue-138-bigquery-dry-run.md`
+- 수정: `gradle/libs.versions.toml`
+  - Centrally governed artifact를 사용하는 `exposed-bigquery` alias를 추가한다.
+- 생성: `13-ecosystem-integrations/01-bigquery-dry-run/build.gradle.kts`
+  - Module dependency와 test classpath wiring.
+- 생성: `13-ecosystem-integrations/01-bigquery-dry-run/src/main/kotlin/exposed/examples/bigquery/dryrun/BigQueryDryRunWorkshop.kt`
+  - Read-model query, default dry-run option, validation call을 만드는 public workshop helper API.
+- 생성: `13-ecosystem-integrations/01-bigquery-dry-run/src/test/kotlin/exposed/examples/bigquery/dryrun/BigQueryDryRunWorkshopTest.kt`
+  - Generated SQL, dry-run option, success, failure test.
+- 생성: `13-ecosystem-integrations/01-bigquery-dry-run/src/test/resources/junit-platform.properties`
+- 생성: `13-ecosystem-integrations/01-bigquery-dry-run/src/test/resources/logback-test.xml`
+- 생성: `13-ecosystem-integrations/01-bigquery-dry-run/README.md`
+- 생성: `13-ecosystem-integrations/01-bigquery-dry-run/README.ko.md`
+- 생성: `docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.svg`
+- 생성: `docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.png`
+- 수정: `13-ecosystem-integrations/README.md`
+- 수정: `13-ecosystem-integrations/README.ko.md`
+- 수정: `README.md`
+- 수정: `README.ko.md`
+- 수정: `.github/workflows/examples.yml`
+- 생성: `docs/review/2026-06-29-issue-138-bigquery-dry-run-code-review.md`
+- 생성: `docs/lessons/2026-06-29-issue-138-bigquery-dry-run.md`
 
-## Task 1: Catalog And Module Skeleton
+## 작업 1: Catalog 및 module skeleton
 
 complexity: low
 
-Apply `$bluetape4k-code-patterns` for module registration and dependency
-governance.
+Module registration과 dependency governance에는 `$bluetape4k-code-patterns`를 적용한다.
 
-- [ ] Add `exposed-bigquery = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-bigquery" }` next to the other `exposed-*` aliases in `gradle/libs.versions.toml`.
-- [ ] Create `13-ecosystem-integrations/01-bigquery-dry-run/build.gradle.kts`:
+- [ ] 추가: `gradle/libs.versions.toml`의 다른 `exposed-*` alias 옆에
+  `exposed-bigquery = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-bigquery" }`.
+- [ ] 생성: `13-ecosystem-integrations/01-bigquery-dry-run/build.gradle.kts`:
 
 ```kotlin
 configurations {
@@ -70,281 +68,271 @@ dependencies {
 }
 ```
 
-- [ ] Create `src/test/resources/junit-platform.properties` with parallel
-  execution disabled for deterministic request capture.
-- [ ] Create `src/test/resources/logback-test.xml` using the repository's
-  existing compact test logging pattern.
-- [ ] Run:
+- [ ] 생성: Deterministic request capture를 위해 parallel execution을 비활성화한
+  `src/test/resources/junit-platform.properties`.
+- [ ] 생성: Repository의 기존 compact test logging pattern을 사용하는
+  `src/test/resources/logback-test.xml`.
+- [ ] 실행:
 
 ```bash
 ./gradlew projects --quiet
 ```
 
-Expected: exit 0 and output contains `:01-bigquery-dry-run`.
+예상: exit 0이고 output이 `:01-bigquery-dry-run`을 포함한다.
 
-## Task 2: RED Tests For Dry-Run Query Validation
+## 작업 2: Dry-run query validation용 RED test
 
 complexity: medium
 
-Apply `$bluetape4k-code-patterns`, `ecc-kotlin-exposed`, and
-`ecc-kotlin-testing`. Follow TDD: write the tests before adding
-`BigQueryDryRunWorkshop.kt`.
+`$bluetape4k-code-patterns`, `ecc-kotlin-exposed`, `ecc-kotlin-testing`을 적용한다. TDD를 따라
+`BigQueryDryRunWorkshop.kt`를 추가하기 전에 test를 작성한다.
 
-- [ ] Create
+- [ ] 생성:
   `13-ecosystem-integrations/01-bigquery-dry-run/src/test/kotlin/exposed/examples/bigquery/dryrun/BigQueryDryRunWorkshopTest.kt`.
-- [ ] Write tests that expect production API symbols from
-  `BigQueryDryRunWorkshop.kt`: `Events`, `buildRegionalRevenueQuery`,
+- [ ] 작성: `BigQueryDryRunWorkshop.kt`의 production API symbol을 기대하는 test:
+  `Events`, `buildRegionalRevenueQuery`,
   `defaultDryRunOptions`, and `validateRegionalRevenueDryRun`.
-- [ ] Add MockK stubs for the actual Google API service chain:
+- [ ] 추가: 실제 Google API service chain용 MockK stub:
   `Bigquery`, `Bigquery.Jobs`, and `Bigquery.Jobs.Query`.
-- [ ] Capture the real `QueryRequest` argument passed to
-  `Jobs.query(projectId, request)` and return a configured `QueryResponse` from
-  `Jobs.Query.execute()`.
-- [ ] Use named test constants for placeholder project ID, dataset ID, and
-  location, then construct `BigQueryContext` with those constants.
-- [ ] Add test `generated query dry run maps query job options without credentials`:
-  - builds an Exposed grouped query
-  - calls `BigQueryContext.validateQuery`
-  - asserts captured request fields with `bluetape4k-assertions`
-- [ ] Add test `dry run surfaces BigQuery validation errors without execution`:
-  - mocked response includes an error
-  - `validateQuery` throws `BigQueryQueryException`
-  - assertion uses `io.bluetape4k.assertions.assertFailsWith`
-- [ ] Run:
+- [ ] `Jobs.query(projectId, request)`에 전달되는 실제 `QueryRequest` argument를 capture하고
+  `Jobs.Query.execute()`에서 configured `QueryResponse`를 반환한다.
+- [ ] Placeholder project ID, dataset ID, location에는 named test constant를 사용하고, 해당
+  constant로 `BigQueryContext`를 구성한다.
+- [ ] 추가: test `generated query dry run maps query job options without credentials`:
+  - Exposed grouped query를 만든다.
+  - `BigQueryContext.validateQuery`를 호출한다.
+  - Captured request field를 `bluetape4k-assertions`로 assert한다.
+- [ ] 추가: test `dry run surfaces BigQuery validation errors without execution`:
+  - Mocked response는 error를 포함한다.
+  - `validateQuery`는 `BigQueryQueryException`을 던진다.
+  - Assertion은 `io.bluetape4k.assertions.assertFailsWith`를 사용한다.
+- [ ] 실행:
 
 ```bash
 ./gradlew :01-bigquery-dry-run:test --tests 'exposed.examples.bigquery.dryrun.BigQueryDryRunWorkshopTest' --no-daemon
 ```
 
-Expected RED: tests fail because `BigQueryDryRunWorkshop.kt` has not been
-implemented yet, or because actual BigQuery API signatures require import/API
-adjustments. The failure must be about missing implementation or API wiring, not
-syntax typos. If tests pass immediately because existing APIs fully cover the
-test without production helper gaps, record that as TDD evidence instead of
-forcing an artificial failure.
+예상 RED: `BigQueryDryRunWorkshop.kt`가 아직 구현되지 않았거나 실제 BigQuery API signature에
+import/API 조정이 필요해서 test가 실패한다. Failure는 syntax typo가 아니라 missing implementation
+또는 API wiring 때문이어야 한다. Existing API가 production helper gap 없이 test를 완전히 충족해
+test가 즉시 통과하면 artificial failure를 강제하지 말고 이를 TDD evidence로 기록한다.
 
-## Task 3: GREEN Implementation By Wiring Existing BigQuery APIs
+## 작업 3: 기존 BigQuery API wiring으로 GREEN 구현
 
 complexity: medium
 
-Apply `$bluetape4k-code-patterns` and `ecc-kotlin-exposed`.
+`$bluetape4k-code-patterns`와 `ecc-kotlin-exposed`를 적용한다.
 
-- [ ] Create
+- [ ] 생성:
   `13-ecosystem-integrations/01-bigquery-dry-run/src/main/kotlin/exposed/examples/bigquery/dryrun/BigQueryDryRunWorkshop.kt`.
-- [ ] Implement public KDoc-backed workshop helpers:
+- [ ] 공개 KDoc이 있는 workshop helper를 구현한다:
   - `Events` table with `eventId`, `region`, `eventType`, `revenue`, and
     `occurredAt` columns
   - `buildRegionalRevenueQuery`
   - `defaultDryRunOptions`
   - `validateRegionalRevenueDryRun`
-- [ ] Fix imports and helper code so tests compile against the actual
-  `BigQueryContext`, `BigQueryQueryOptions`, `BigQueryQueryPriority`, and
-  `BigQueryQueryException` APIs.
-- [ ] Create the H2 SQL-generation database deterministically in test setup.
+- [ ] 실제 `BigQueryContext`, `BigQueryQueryOptions`, `BigQueryQueryPriority`,
+  `BigQueryQueryException` API에 대해 test가 compile되도록 import와 helper code를 고친다.
+- [ ] 생성: Test setup에서 H2 SQL-generation database를 deterministic하게 만든다.
   Use `Database.connect("jdbc:h2:mem:bigquery_dry_run;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE", driver = "org.h2.Driver")`
-  or the matching `BigQueryContext` factory when available. Recreate the mocked
-  BigQuery REST client per test, keep mutable request capture per test, and rely
-  on `BigQueryContext.validateQuery` for transaction boundaries so Exposed state
-  does not leak across tests.
-- [ ] Do not add any path that reads `System.getenv`, `System.getProperty`,
-  ADC, service-account files, project secrets, endpoint overrides, tokens, API
-  keys, or constructs a real Google Cloud BigQuery client.
-- [ ] Avoid deprecated Exposed imports such as `SqlExpressionBuilder.eq`.
-- [ ] Use durable SQL fragment assertions instead of exact full-SQL matching.
-- [ ] Run:
+  또는 사용할 수 있으면 matching `BigQueryContext` factory를 사용한다. Test마다 mocked BigQuery
+  REST client를 다시 만들고 mutable request capture를 test별로 유지하며, Exposed state가 test
+  사이에 leak되지 않도록 transaction boundary는 `BigQueryContext.validateQuery`에 맡긴다.
+- [ ] `System.getenv`, `System.getProperty`, ADC, service-account file, project secret, endpoint
+  override, token, API key를 읽거나 real Google Cloud BigQuery client를 만드는 path를 추가하지
+  않는다.
+- [ ] 회피: deprecated Exposed imports such as `SqlExpressionBuilder.eq`.
+- [ ] Exact full-SQL matching 대신 durable SQL fragment assertion을 사용한다.
+- [ ] 실행:
 
 ```bash
 ./gradlew :01-bigquery-dry-run:test --no-daemon
 ```
 
-Expected GREEN: all tests in `:01-bigquery-dry-run` pass.
+예상 GREEN: `:01-bigquery-dry-run`의 모든 test가 통과한다.
 
-## Task 4: Module README Pair And Diagram
+## 작업 4: Module README pair와 diagram
 
 complexity: medium
 
-Apply `$bluetape4k-diagram` and README locale policy.
+`$bluetape4k-diagram`과 README locale policy를 적용한다.
 
-- [ ] Create `README.md` and `README.ko.md` under the module.
-- [ ] Include language switches:
+- [ ] 생성: Module 아래 `README.md`와 `README.ko.md`.
+- [ ] 포함: language switches:
   - English file: `English | [한국어](README.ko.md)`
   - Korean file: `[English](README.md) | 한국어`
-- [ ] Keep README locale parity. Both files must contain matching sections for:
-  purpose, dry-run vs execution, credential-free command, no-cloud-credential
-  guarantee, tested behavior, diagram reference, and real BigQuery out-of-scope
-  warning.
-- [ ] Explain:
-  - dry run parses and validates a query without executing a billable query
-  - default test path uses a mocked BigQuery REST client
-  - no credentials, ADC, project secrets, or network calls are required
+- [ ] 유지: README locale parity. 두 file은 purpose, dry-run vs execution, credential-free
+  command, no-cloud-credential guarantee, tested behavior, diagram reference, real BigQuery
+  out-of-scope warning에 대한 matching section을 가져야 한다.
+- [ ] 설명:
+  - Dry run은 billable query를 실행하지 않고 query를 parse/validate한다.
+  - Default test path는 mocked BigQuery REST client를 사용한다.
+  - Credential, ADC, project secret, network call은 필요하지 않다.
   - command: `./gradlew :01-bigquery-dry-run:test`
-  - expected result: the command uses only H2 plus mocked BigQuery REST calls
-    and passes without `GOOGLE_APPLICATION_CREDENTIALS`
-- [ ] Create `docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.svg` with
-  English labels and source-backed flow: Exposed query -> SQL generation DB ->
-  BigQuery dry-run request -> mocked REST response -> workshop assertions.
-- [ ] Embed the diagram in both README files with alt text or a caption that
-  includes `mocked BigQuery REST response`.
-- [ ] Render PNG:
+  - Expected result: Command는 H2와 mocked BigQuery REST call만 사용하며
+    `GOOGLE_APPLICATION_CREDENTIALS` 없이 통과한다.
+- [ ] 생성: English label과 source-backed flow를 가진
+  `docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.svg`: Exposed query -> SQL
+  generation DB -> BigQuery dry-run request -> mocked REST response -> workshop assertions.
+- [ ] embed: 두 README file에 diagram을 넣고 `mocked BigQuery REST response`를 포함한 alt text
+  또는 caption을 둔다.
+- [ ] PNG render:
 
 ```bash
 ~/.local/bin/cairosvg docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.svg \
   -o docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.png -s 2
 ```
 
-- [ ] Validate:
+- [ ] 검증:
 
 ```bash
 xmllint --noout docs/images/readme-diagrams/01-bigquery-dry-run-flow-01.svg
 ```
 
-- [ ] Inspect rendered PNG at full size before accepting the diagram.
+- [ ] Diagram을 수용하기 전에 rendered PNG를 full size로 검사한다.
 
-## Task 5: Chapter, Root README, And Workflow Wiring
+## 작업 5: Chapter, root README, workflow wiring
 
 complexity: low
 
-Apply `$bluetape4k-code-patterns` for module registration and workflow rules.
+Module registration과 workflow rule에는 `$bluetape4k-code-patterns`를 적용한다.
 
-- [ ] Update `13-ecosystem-integrations/README.md` and `README.ko.md`:
-  - change #138 status from `Planned` to `Ready`
-  - link `01-bigquery-dry-run/README.md` and
+- [ ] 갱신: `13-ecosystem-integrations/README.md`와 `README.ko.md`:
+  - #138 status를 `Planned`에서 `Ready`로 변경한다.
+  - `01-bigquery-dry-run/README.md`와
     `01-bigquery-dry-run/README.ko.md`
-  - keep #139-#145 as planned
-- [ ] Update root `README.md` and `README.ko.md` under Chapter 13 to include the
-  first runnable child module link.
-- [ ] Add `:01-bigquery-dry-run:build` to the selected Examples workflow Gradle
-  invocation, near the chapter 13 comment.
-- [ ] Complete the new-module registration audit and record the result in the
-  review document:
-  - `settings.gradle.kts`: automatic chapter include covers the module
-  - repo-local module list: root/chapter README pairs updated
-  - CI workflow: no child-module path/job change required because broad Gradle
-    test jobs cover discovered projects
-  - Nightly workflow: N/A for this issue because the module is mock-only and the
-    Examples workflow owns runnable example coverage
-  - Examples workflow: path filters already include chapter 13 and selected
-    build task is added
-  - summary `needs`: unchanged unless the Examples job graph changes
-  - coverage artifacts: unchanged; no Kover threshold or Codecov gate is added
-- [ ] Run:
+    를 link한다.
+  - #139-#145는 planned 상태로 유지한다.
+- [ ] 갱신: Chapter 13 아래 root `README.md`와 `README.ko.md`에 첫 runnable child module link를
+  포함한다.
+- [ ] 추가: Chapter 13 comment 근처 selected Examples workflow Gradle invocation에
+  `:01-bigquery-dry-run:build`.
+- [ ] 완료: New-module registration audit를 수행하고 review document에 결과를 기록한다:
+  - `settings.gradle.kts`: Automatic chapter include가 module을 포함한다.
+  - Repo-local module list: root/chapter README pair가 갱신됐다.
+  - CI workflow: Broad Gradle test job이 discovered project를 다루므로 child-module path/job 변경은
+    필요하지 않다.
+  - Nightly workflow: 이 module은 mock-only이고 Examples workflow가 runnable example coverage를
+    소유하므로 N/A.
+  - Examples workflow: Path filter는 이미 chapter 13을 포함하고 selected build task가 추가된다.
+  - Summary `needs`: Examples job graph가 바뀌지 않으면 unchanged.
+  - Coverage artifact: 변경 없음. Kover threshold나 Codecov gate를 추가하지 않는다.
+- [ ] 실행:
 
 ```bash
 actionlint .github/workflows/examples.yml
 ```
 
-Expected: exit 0.
+예상: exit 0.
 
-## Task 6: Verification And Review Evidence
+## 작업 6: 검증과 review evidence
 
 complexity: medium
 
-Apply `verification-before-completion`, `$bluetape4k-code-patterns`, and
-`$bluetape4k-diagram`.
+`verification-before-completion`, `$bluetape4k-code-patterns`, `$bluetape4k-diagram`을
+적용한다.
 
-- [ ] Run module tests:
+- [ ] 실행: Module test:
 
 ```bash
 ./gradlew :01-bigquery-dry-run:test --no-daemon
 ```
 
-- [ ] Run module build:
+- [ ] 실행: Module build:
 
 ```bash
 ./gradlew :01-bigquery-dry-run:build --no-daemon
 ```
 
-- [ ] Run project discovery:
+- [ ] 실행: Project discovery:
 
 ```bash
 ./gradlew projects --quiet
 ```
 
-- [ ] Run workflow lint:
+- [ ] 실행: Workflow lint:
 
 ```bash
 actionlint .github/workflows/examples.yml
 ```
 
-- [ ] Run diff whitespace check:
+- [ ] 실행: Diff whitespace check:
 
 ```bash
 git diff --check
 ```
 
-- [ ] Run README local-link check for touched README files:
+- [ ] 실행: 변경된 README file의 local-link check:
 
 ```bash
 ruby -e 'files=%w[README.md README.ko.md 13-ecosystem-integrations/README.md 13-ecosystem-integrations/README.ko.md 13-ecosystem-integrations/01-bigquery-dry-run/README.md 13-ecosystem-integrations/01-bigquery-dry-run/README.ko.md]; bad=[]; files.each{|f| text=File.read(f); text.scan(/!?\[[^\]]*\]\(([^)#][^)]*)\)/).flatten.each{|href| next if href =~ %r{\Ahttps?://}; path=href.split("#",2).first; next if path.empty?; target=File.expand_path(path, File.dirname(f)); bad << "#{f} -> #{href}" unless File.exist?(target)}}; abort(bad.join("\n")) unless bad.empty?'
 ```
-- [ ] Run credential drift scan for touched module/docs:
+- [ ] 실행: 변경된 module/docs의 credential drift scan:
 
 ```bash
 rg -in "GOOGLE_APPLICATION_CREDENTIALS|application-default|Application Default Credentials|\\bADC\\b|service[-_ ]account|client_secret|password|token|api[_-]?key|project[-_ ]?ids?|projectId|endpoint secret" \
   13-ecosystem-integrations README.md README.ko.md docs/images/readme-diagrams .github/workflows/examples.yml
 ```
 
-Expected: only explanatory policy/warning text and placeholder dataset/project
-IDs, no real secrets.
+예상: Explanatory policy/warning text와 placeholder dataset/project ID만 나오며 real secret은 없다.
 
-- [ ] Run executable-path real-client scan:
+- [ ] 실행: Executable-path real-client scan:
 
 ```bash
 rg -n "System\\.getenv|System\\.getProperty|GoogleCredentials|BigQueryOptions|ServiceAccount|GOOGLE_CLOUD_PROJECT|GOOGLE_APPLICATION_CREDENTIALS|setApplicationName|new Bigquery|Bigquery\\.Builder" \
   13-ecosystem-integrations/01-bigquery-dry-run/src .github/workflows/examples.yml
 ```
 
-Expected: zero matches, except mocked `Bigquery` type usage in the test helper
-when the match is not real-client construction.
+예상: Real-client construction이 아닌 test helper의 mocked `Bigquery` type usage를 제외하면 match
+0개.
 
-- [ ] Write `docs/review/2026-06-29-issue-138-bigquery-dry-run-code-review.md`
-  with severity counts and findings derived from actual review evidence. Do not
-  predeclare P0/P1 results before the review is complete.
-- [ ] Record rendered PNG visual QA evidence in the review document after
-  inspecting the generated image.
+- [ ] 작성: `docs/review/2026-06-29-issue-138-bigquery-dry-run-code-review.md`
+  에 실제 review evidence에서 파생된 severity count와 finding을 기록한다. 검토 완료 전에 P0/P1
+  result를 미리 선언하지 않는다.
+- [ ] 기록: Generated image를 검사한 뒤 review document에 rendered PNG visual QA evidence를
+  기록한다.
 
-## Task 7: Lessons, Commit, PR, And CI
+## 작업 7: Lesson, commit, PR, CI
 
 complexity: low
 
-- [ ] Create `docs/lessons/2026-06-29-issue-138-bigquery-dry-run.md` with the
-  module, credential-free default, and workflow task wiring lesson.
-- [ ] Commit spec and plan before implementation if not already committed.
-- [ ] Commit implementation/docs/review/lesson with Lore commit trailers.
-- [ ] Push branch `feat/issue-138-bigquery-dry-run`.
-- [ ] Read live issue metadata before creating the PR:
+- [ ] 생성: Module, credential-free default, workflow task wiring lesson을 담은
+  `docs/lessons/2026-06-29-issue-138-bigquery-dry-run.md`.
+- [ ] commit: 아직 commit하지 않았다면 implementation 전에 spec과 plan을 commit한다.
+- [ ] commit: Implementation/docs/review/lesson을 Lore commit trailer와 함께 commit한다.
+- [ ] push: Branch `feat/issue-138-bigquery-dry-run`.
+- [ ] 읽기: PR 생성 전 live issue metadata:
 
 ```bash
 gh issue view 138 --json assignees,labels,milestone,state
 ```
 
-- [ ] Create PR:
+- [ ] 생성: PR:
   - title: `feat: add BigQuery dry-run workshop example`
-  - body closes #138 and references #137
-  - assignee, milestone, and labels mirrored from live issue #138 metadata
-  - final section exactly `## DoD Status`
-- [ ] Verify live PR metadata:
+  - Body는 #138을 close하고 #137을 reference한다.
+  - Assignee, milestone, label은 live issue #138 metadata를 반영한다.
+  - 마지막 section은 정확히 `## DoD Status`다.
+- [ ] 검증: live PR metadata:
 
 ```bash
 gh pr view <number> --json body,assignees,labels,milestone,state,isDraft
 ```
 
-- [ ] Verify parent epic #137 remains open:
+- [ ] 검증: parent epic #137 remains open:
 
 ```bash
 gh issue view 137 --json state
 ```
 
-- [ ] Watch/check CI with `gh pr checks <number>` and proceed to final DoD only
-  after checks are success or an evidence-backed blocker is reported.
+- [ ] `gh pr checks <number>`로 CI를 watch/check하고, check success 또는 evidence-backed blocker를
+  보고한 뒤에만 final DoD로 진행한다.
 
-## Step 3-R Self Review
+## 단계 3-R Self review
 
-- Spec coverage: every #138 acceptance criterion maps to Tasks 1-7.
-- Placeholder scan: no `TBD`, `TODO`, or open-ended implementation steps remain.
-- Type consistency: module name, package name, test class, diagram filenames,
-  and Gradle task names are consistent across tasks.
-- Concurrency helpers: not applicable; this module has no race, structured
-  concurrency, virtual-thread, or suspend stress behavior.
-- Testcontainers: not applicable; default path is mock REST client plus H2 SQL
-  generation DB.
+- Spec coverage: 모든 #138 acceptance criterion은 작업 1-7에 mapping된다.
+- Placeholder scan: `TBD`, `TODO`, open-ended implementation step이 남아 있지 않다.
+- Type consistency: Module name, package name, test class, diagram filename, Gradle task name이
+  task 전체에서 일관된다.
+- Concurrency helpers: 해당 없음. 이 module에는 race, structured concurrency, virtual-thread,
+  suspend stress behavior가 없다.
+- Testcontainers: 해당 없음. Default path는 mock REST client와 H2 SQL generation DB다.

--- a/docs/superpowers/plans/2026-06-29-issue-139-trino-session-options-plan.md
+++ b/docs/superpowers/plans/2026-06-29-issue-139-trino-session-options-plan.md
@@ -1,84 +1,96 @@
-# Issue #139 Trino Session Options Implementation Plan
+# Issue #139 Trino session options 구현 계획
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans or inline execution with TDD. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Agentic worker용:** REQUIRED SUB-SKILL: superpowers:executing-plans 또는 inline TDD 실행을
+> 사용한다. 단계 추적에는 checkbox(`- [ ]`) syntax를 사용한다.
 
-**Goal:** Add a credential-free `02-trino-session-options` workshop module that teaches typed Trino JDBC/session options and local pushdown request-shape verification.
+**목표:** Typed Trino JDBC/session option과 local pushdown request-shape verification을 가르치는
+credential-free `02-trino-session-options` workshop module을 추가한다.
 
-**Architecture:** The module exposes small Kotlin helpers for a validated Trino analytical profile, conversion to `TrinoConnectionOptions`, Exposed SQL generation, and `EXPLAIN` request creation. Tests run on H2 for SQL generation and inspect public typed options plus generated request strings.
+**아키텍처:** Module은 validated Trino analytical profile, `TrinoConnectionOptions` 변환,
+Exposed SQL generation, `EXPLAIN` request creation을 위한 작은 Kotlin helper를 노출한다. Test는
+SQL generation을 위해 H2에서 실행되고 public typed option 및 generated request string을 검사한다.
 
-**Tech Stack:** Kotlin 2.4, Exposed 1.3.0, `bluetape4k-exposed-trino`, H2, JUnit 5, bluetape4k assertions, CairoSVG for README diagram rendering.
+**기술 스택:** Kotlin 2.4, Exposed 1.3.0, `bluetape4k-exposed-trino`, H2, JUnit 5,
+bluetape4k assertions, README diagram rendering용 CairoSVG.
 
 ---
 
-## Task 1: Register dependency and module scaffold
+## 작업 1: Dependency 및 module scaffold 등록
 
-**Files:**
-- Modify: `gradle/libs.versions.toml`
-- Create: `13-ecosystem-integrations/02-trino-session-options/build.gradle.kts`
-- Create: `13-ecosystem-integrations/02-trino-session-options/src/test/resources/junit-platform.properties`
-- Create: `13-ecosystem-integrations/02-trino-session-options/src/test/resources/logback-test.xml`
+**파일:**
+- 수정: `gradle/libs.versions.toml`
+- 생성: `13-ecosystem-integrations/02-trino-session-options/build.gradle.kts`
+- 생성: `13-ecosystem-integrations/02-trino-session-options/src/test/resources/junit-platform.properties`
+- 생성: `13-ecosystem-integrations/02-trino-session-options/src/test/resources/logback-test.xml`
 
-- [ ] Add `exposed-trino = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-trino" }` near other Exposed aliases.
-- [ ] Create the module build file with `implementation(libs.exposed.trino)`, `implementation(libs.jetbrains.exposed.core)`, `implementation(libs.jetbrains.exposed.jdbc)`, `runtimeOnly(libs.h2.v2)`, and `testImplementation(libs.bluetape4k.junit5)`.
-- [ ] Add standard JUnit/logback test resources matching `01-bigquery-dry-run`.
-- [ ] Verify `./gradlew projects --quiet | grep ':02-trino-session-options'`.
+- [ ] 추가: `exposed-trino = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-trino" }`를 다른 Exposed alias 근처에 둔다.
+- [ ] 생성: `implementation(libs.exposed.trino)`, `implementation(libs.jetbrains.exposed.core)`,
+  `implementation(libs.jetbrains.exposed.jdbc)`, `runtimeOnly(libs.h2.v2)`,
+  `testImplementation(libs.bluetape4k.junit5)`를 사용하는 module build file.
+- [ ] 추가: `01-bigquery-dry-run`과 맞는 standard JUnit/logback test resource.
+- [ ] 검증: `./gradlew projects --quiet | grep ':02-trino-session-options'`.
 
-## Task 2: RED tests for typed Trino options and request shape
+## 작업 2: Typed Trino option 및 request shape용 RED test
 
-**Files:**
-- Create: `13-ecosystem-integrations/02-trino-session-options/src/test/kotlin/exposed/examples/trino/options/TrinoSessionOptionsWorkshopTest.kt`
+**파일:**
+- 생성: `13-ecosystem-integrations/02-trino-session-options/src/test/kotlin/exposed/examples/trino/options/TrinoSessionOptionsWorkshopTest.kt`
 
-- [ ] Write failing tests for:
-  - default analytical profile maps to `TrinoConnectionOptions` fields.
-  - profile preview contains stable Trino JDBC property names and values.
-  - unsafe blank catalog/schema/source/tag/session property values are rejected.
-  - generated analytical SQL and `EXPLAIN` request preserve predicate, projection, order, and top-N shape.
-- [ ] Run `./gradlew :02-trino-session-options:test --no-daemon` and confirm it fails because production symbols are unresolved.
+- [ ] 작성: 다음을 기대하는 failing test.
+  - Default analytical profile이 `TrinoConnectionOptions` field로 mapping된다.
+  - Profile preview가 stable Trino JDBC property name/value를 포함한다.
+  - Unsafe blank catalog/schema/source/tag/session property value는 거부된다.
+  - Generated analytical SQL과 `EXPLAIN` request는 predicate, projection, order, top-N shape를
+    보존한다.
+- [ ] 실행: `./gradlew :02-trino-session-options:test --no-daemon`을 실행하고 production symbol이
+  unresolved라 실패하는지 확인한다.
 
-## Task 3: Implement minimal workshop helpers
+## 작업 3: 최소 workshop helper 구현
 
-**Files:**
-- Create: `13-ecosystem-integrations/02-trino-session-options/src/main/kotlin/exposed/examples/trino/options/TrinoSessionOptionsWorkshop.kt`
+**파일:**
+- 생성: `13-ecosystem-integrations/02-trino-session-options/src/main/kotlin/exposed/examples/trino/options/TrinoSessionOptionsWorkshop.kt`
 
-- [ ] Add `TrinoWorkshopConnectionProfile` with validation and `toConnectionOptions()`.
-- [ ] Add `jdbcPropertyPreview(user: String)` for stable local assertions and README inspection.
-- [ ] Add `WarehouseOrders` Exposed table and `buildRegionalTopOrdersQuery(minimumRevenue)`.
-- [ ] Add `generateRegionalTopOrdersSql()` using an H2 SQL-generation transaction and `prepareSQL(prepared = false)`.
-- [ ] Add `buildExplainRequest(sql)` that wraps generated SQL in an `EXPLAIN` statement.
-- [ ] Add English KDoc for public functions/classes.
-- [ ] Run `./gradlew :02-trino-session-options:test --no-daemon` and confirm green.
+- [ ] 추가: validation과 `toConnectionOptions()`가 있는 `TrinoWorkshopConnectionProfile`.
+- [ ] 추가: stable local assertion 및 README inspection용 `jdbcPropertyPreview(user: String)`.
+- [ ] 추가: `WarehouseOrders` Exposed table 및 `buildRegionalTopOrdersQuery(minimumRevenue)`.
+- [ ] 추가: H2 SQL-generation transaction과 `prepareSQL(prepared = false)`를 사용하는
+  `generateRegionalTopOrdersSql()`.
+- [ ] 추가: Generated SQL을 `EXPLAIN` statement로 감싸는 `buildExplainRequest(sql)`.
+- [ ] 추가: Public function/class용 한국어 KDoc.
+- [ ] 실행: `./gradlew :02-trino-session-options:test --no-daemon`을 실행하고 green을 확인한다.
 
-## Task 4: README and diagram
+## 작업 4: README와 diagram
 
-**Files:**
-- Create: `13-ecosystem-integrations/02-trino-session-options/README.md`
-- Create: `13-ecosystem-integrations/02-trino-session-options/README.ko.md`
-- Create: `docs/images/readme-diagrams/13-trino-session-options-sequence-01.svg`
-- Create: `docs/images/readme-diagrams/13-trino-session-options-sequence-01.png`
-- Modify: `13-ecosystem-integrations/README.md`
-- Modify: `13-ecosystem-integrations/README.ko.md`
-- Modify: `README.md`
-- Modify: `README.ko.md`
+**파일:**
+- 생성: `13-ecosystem-integrations/02-trino-session-options/README.md`
+- 생성: `13-ecosystem-integrations/02-trino-session-options/README.ko.md`
+- 생성: `docs/images/readme-diagrams/13-trino-session-options-sequence-01.svg`
+- 생성: `docs/images/readme-diagrams/13-trino-session-options-sequence-01.png`
+- 수정: `13-ecosystem-integrations/README.md`
+- 수정: `13-ecosystem-integrations/README.ko.md`
+- 수정: `README.md`
+- 수정: `README.ko.md`
 
-- [ ] Write English/Korean README pair with language switch.
-- [ ] State local-only validation versus real Trino connector validation.
-- [ ] Embed the PNG diagram and keep diagram labels English.
-- [ ] Draw a best-practices-style sequence diagram: application profile, typed options, Exposed SQL generation, `EXPLAIN` request, and real Trino as opt-in.
-- [ ] Validate SVG XML, geometry/endpoint audits where applicable, CairoSVG render, and full-size PNG inspection.
-- [ ] Mark #139 Ready in chapter README pair and link the module from root README pair.
+- [ ] 작성: Language switch가 있는 English/Korean README pair.
+- [ ] 명시: Local-only validation과 real Trino connector validation의 차이.
+- [ ] embed: PNG diagram을 넣고 diagram label은 English로 유지한다.
+- [ ] 그리기: application profile, typed option, Exposed SQL generation, `EXPLAIN` request, opt-in
+  real Trino를 보여 주는 best-practices-style sequence diagram.
+- [ ] validate: 적용 가능한 SVG XML, geometry/endpoint audit, CairoSVG render, full-size PNG
+  inspection.
+- [ ] 표시: Chapter README pair에서 #139를 Ready로 표시하고 root README pair에서 module을 link한다.
 
-## Task 5: CI registration and verification
+## 작업 5: CI 등록과 검증
 
-**Files:**
-- Modify: `.github/workflows/examples.yml`
-- Create: `docs/review/2026-06-29-issue-139-trino-session-options-code-review.md`
-- Create: `docs/lessons/2026-06-29-issue-139-trino-session-options.md`
+**파일:**
+- 수정: `.github/workflows/examples.yml`
+- 생성: `docs/review/2026-06-29-issue-139-trino-session-options-code-review.md`
+- 생성: `docs/lessons/2026-06-29-issue-139-trino-session-options.md`
 
-- [ ] Add `:02-trino-session-options:build` to the selected Examples workflow.
-- [ ] Run `actionlint .github/workflows/examples.yml`.
-- [ ] Run `./gradlew :02-trino-session-options:test --no-daemon`.
-- [ ] Run `./gradlew :02-trino-session-options:build --no-daemon`.
-- [ ] Run `./gradlew projects --quiet`.
-- [ ] Run `git diff --check`.
-- [ ] Record 7-tier current-session review with P0=0/P1=0.
-- [ ] Commit with Lore trailers, push, create PR closing #139 and referencing #137.
+- [ ] 추가: Selected Examples workflow에 `:02-trino-session-options:build`.
+- [ ] 실행: `actionlint .github/workflows/examples.yml`.
+- [ ] 실행: `./gradlew :02-trino-session-options:test --no-daemon`.
+- [ ] 실행: `./gradlew :02-trino-session-options:build --no-daemon`.
+- [ ] 실행: `./gradlew projects --quiet`.
+- [ ] 실행: `git diff --check`.
+- [ ] 기록: P0=0/P1=0인 7-tier current-session review.
+- [ ] commit: Lore trailer로 commit하고 push한 뒤 #139를 close하고 #137을 reference하는 PR을 만든다.

--- a/docs/superpowers/plans/2026-06-29-issue-140-cockroachdb-retry-plan.md
+++ b/docs/superpowers/plans/2026-06-29-issue-140-cockroachdb-retry-plan.md
@@ -1,37 +1,35 @@
-# Issue #140 CockroachDB Serializable Retry Workshop Plan
+# Issue #140 CockroachDB serializable retry workshop 계획
 
-Date: 2026-06-29
-Issue: https://github.com/bluetape4k/exposed-workshop/issues/140
+일자: 2026-06-29
+이슈: https://github.com/bluetape4k/exposed-workshop/issues/140
 
-## Step 1 - Red Tests
+## 단계 1 - RED test
 
-Action: Add the module skeleton plus tests that reference the desired workshop
-API.
+작업: 원하는 workshop API를 참조하는 module skeleton과 test를 추가한다.
 
-DoD: `./gradlew :03-cockroachdb-retry:test` fails only because the workshop
-implementation or catalog wiring is missing.
+DoD: `./gradlew :03-cockroachdb-retry:test`는 workshop implementation 또는 catalog wiring이
+없어서만 실패한다.
 
-## Step 2 - Implementation
+## 단계 2 - 구현
 
-Action: Implement inventory reservation helpers using public
-`bluetape4k-exposed-cockroachdb` APIs.
+작업: Public `bluetape4k-exposed-cockroachdb` API를 사용해 inventory reservation helper를
+구현한다.
 
-DoD: Tests prove successful commit, retryable failure replay, non-retryable
-failure boundary, and schema bootstrap.
+DoD: Test는 successful commit, retryable failure replay, non-retryable failure boundary, schema
+bootstrap을 증명한다.
 
-## Step 3 - Documentation And Diagram
+## 단계 3 - 문서와 diagram
 
-Action: Add README.md, README.ko.md, chapter/root README links, and a validated
-SVG+PNG sequence diagram.
+작업: `README.md`, `README.ko.md`, chapter/root README link, 검증된 SVG+PNG sequence diagram을
+추가한다.
 
-DoD: README locale pair embeds the same PNG and explains the local Testcontainers
-path without raw Mermaid.
+DoD: README locale pair는 같은 PNG를 embed하고 raw Mermaid 없이 local Testcontainers path를
+설명한다.
 
-## Step 4 - Workflow And Verification
+## 단계 4 - Workflow와 검증
 
-Action: Add the module to the Examples workflow, run targeted local checks,
-review the diff, commit, open PR, monitor CI, merge after green, and sync local
-develop.
+작업: Module을 Examples workflow에 추가하고 targeted local check를 실행하며 diff를 review하고
+commit, PR open, CI monitor를 수행한 뒤 green 이후 merge하고 local develop을 sync한다.
 
-DoD: Local verification passes; PR mirrors issue metadata; CI passes; PR is
-rebased into develop; issue #140 closes.
+DoD: Local verification이 통과하고 PR이 issue metadata를 반영하며 CI가 통과한다. PR은 develop에
+반영되고 issue #140은 닫힌다.

--- a/docs/superpowers/plans/2026-06-29-issue-141-starrocks-olap-local-plan.md
+++ b/docs/superpowers/plans/2026-06-29-issue-141-starrocks-olap-local-plan.md
@@ -1,26 +1,25 @@
-# Issue 141 - StarRocks Local-First OLAP Plan
+# Issue 141 - StarRocks local-first OLAP 계획
 
 ## Lane
 
-Type A new workshop module under `13-ecosystem-integrations`.
+`13-ecosystem-integrations` 아래 Type A new workshop module이다.
 
-## Steps
+## 단계
 
-1. Read issue #141, epic #137, prior chapter examples, and the current
-   `bluetape4k-exposed` StarRocks helper source.
-2. Add a RED test suite for typed profile validation, StarRocks DDL shape,
-   query rendering, and local aggregation.
-3. Implement the minimum module code to pass the tests.
-4. Add README.md, README.ko.md, root/chapter links, and Examples workflow
-   coverage.
-5. Create a source-backed architecture diagram as SVG plus PNG and validate it
-   with the current `$bluetape4k-diagram` checklist.
-6. Run targeted module tests, build, project discovery, workflow lint, diagram
-   checks, and `git diff --check`.
-7. Run code review, commit with Lore trailers, open a PR, verify live PR body and
-   metadata, then monitor CI.
+1. Issue #141, epic #137, prior chapter example, current `bluetape4k-exposed` StarRocks helper
+   source를 읽는다.
+2. Typed profile validation, StarRocks DDL shape, query rendering, local aggregation을 위한 RED
+   test suite를 추가한다.
+3. Test를 통과시키는 최소 module code를 구현한다.
+4. `README.md`, `README.ko.md`, root/chapter link, Examples workflow coverage를 추가한다.
+5. Source-backed architecture diagram을 SVG와 PNG로 만들고 current `$bluetape4k-diagram`
+   checklist로 검증한다.
+6. Targeted module test, build, project discovery, workflow lint, diagram check,
+   `git diff --check`를 실행한다.
+7. Code review를 실행하고 Lore trailer로 commit하며 PR을 열고 live PR body/metadata를 검증한 뒤
+   CI를 monitor한다.
 
-## Validation Commands
+## 검증 명령
 
 - `./gradlew :04-starrocks-olap-local:test --no-daemon --no-configuration-cache`
 - `./gradlew :04-starrocks-olap-local:build --no-daemon --no-configuration-cache`

--- a/docs/superpowers/plans/2026-06-29-issue-142-exposed-ktor-integration-plan.md
+++ b/docs/superpowers/plans/2026-06-29-issue-142-exposed-ktor-integration-plan.md
@@ -1,42 +1,40 @@
-# Issue #142 Plan - Explicit Ktor Exposed Integration
+# Issue #142 계획 - 명시적 Ktor Exposed integration
 
-## Step 1 - Source and Requirement Grounding
+## 단계 1 - Source 및 requirement grounding
 
-- Action: inspect issue #142, chapter 13 README, existing Ktor examples, and
-  `bluetape4k-exposed-ktor` source/demo code.
-- DoD: record the chosen module path, helper APIs, and acceptance evidence in
-  the design artifact.
+- 작업: issue #142, chapter 13 README, existing Ktor example,
+  `bluetape4k-exposed-ktor` source/demo code를 검사한다.
+- DoD: 선택한 module path, helper API, acceptance evidence를 design artifact에 기록한다.
 
-## Step 2 - TDD Contract
+## 단계 2 - TDD Contract
 
-- Action: add the new module skeleton and tests before production code.
+- 작업: Production code보다 먼저 새 module skeleton과 test를 추가한다.
 - DoD: `./gradlew :05-ktor-exposed-integration:test --no-daemon --no-configuration-cache`
-  fails at compile time because the production API is intentionally missing.
+  는 production API가 의도적으로 없기 때문에 compile time에 실패한다.
 
-## Step 3 - Implementation
+## 단계 3 - 구현
 
-- Action: implement the local H2 Ktor example, caller-owned resources, CRUD
-  routes, readiness routes, and sanitized error route.
-- DoD: targeted module tests pass locally.
+- 작업: Local H2 Ktor example, caller-owned resource, CRUD route, readiness route, sanitized
+  error route를 구현한다.
+- DoD: Targeted module test가 local에서 통과한다.
 
-## Step 4 - Documentation and Diagram
+## 단계 4 - 문서와 diagram
 
-- Action: add bilingual module README files and a `$bluetape4k-diagram`
-  compliant SVG/PNG architecture diagram.
-- DoD: SVG geometry and endpoint audits pass, PNG renders successfully, and the
-  README links point to the rendered asset.
+- 작업: Bilingual module README file과 `$bluetape4k-diagram` compliant SVG/PNG architecture
+  diagram을 추가한다.
+- DoD: SVG geometry/endpoint audit가 통과하고 PNG가 성공적으로 render되며 README link가 rendered
+  asset을 가리킨다.
 
-## Step 5 - Registration and Automation
+## 단계 5 - 등록과 자동화
 
-- Action: update chapter/root README links, version catalog aliases, and
-  `.github/workflows/examples.yml`.
-- DoD: Gradle project discovery includes the module and the Examples workflow
-  includes `:05-ktor-exposed-integration:build`.
+- 작업: Chapter/root README link, version catalog alias, `.github/workflows/examples.yml`을
+  갱신한다.
+- DoD: Gradle project discovery가 module을 포함하고 Examples workflow가
+  `:05-ktor-exposed-integration:build`를 포함한다.
 
-## Step 6 - Verification and PR
+## 단계 6 - 검증과 PR
 
-- Action: run targeted tests, `git diff --check`, review local diff, write a
-  review note and lesson, then open a PR linked to issue #142.
-- DoD: PR metadata mirrors issue #142 assignee, labels, and milestone; PR body
-  ends with `## DoD Status`.
-
+- 작업: Targeted test, `git diff --check`를 실행하고 local diff를 review하며 review note와
+  lesson을 작성한 뒤 issue #142에 연결된 PR을 연다.
+- DoD: PR metadata는 issue #142 assignee, label, milestone을 반영하고 PR body는
+  `## DoD Status`로 끝난다.

--- a/docs/superpowers/plans/2026-06-30-issue-145-ddd-modulith-boundaries-plan.md
+++ b/docs/superpowers/plans/2026-06-30-issue-145-ddd-modulith-boundaries-plan.md
@@ -1,58 +1,56 @@
-# Issue #145 DDD Modulith Boundary Plan
+# Issue #145 DDD Modulith boundary 계획
 
-## Step 1 - Scaffold Tests First
+## 단계 1 - Test 우선 scaffold
 
-Action:
-- Add `08-ddd-modulith-boundaries` Gradle module skeleton.
-- Add Spring Boot integration tests for positive Modulith verification,
-  negative boundary violation fixture, and event-driven persistence handoff.
-- Run the module test command before adding production code and record the
-  expected failure.
-
-DoD:
-- Tests compile or fail for missing production symbols only.
-- Failure proves the new module is not implemented yet.
-
-## Step 2 - Implement Bounded Contexts
-
-Action:
-- Implement `orders` and `shipping` bounded contexts.
-- Keep Exposed tables and repositories internal to each context.
-- Publish and consume `OrderAcceptedEvent` through the `orders.events` named
-  interface.
+작업:
+- `08-ddd-modulith-boundaries` Gradle module skeleton을 추가한다.
+- Positive Modulith verification, negative boundary violation fixture, event-driven persistence
+  handoff를 위한 Spring Boot integration test를 추가한다.
+- Production code를 추가하기 전에 module test command를 실행하고 expected failure를 기록한다.
 
 DoD:
-- Positive verifier test passes.
-- Event handoff test proves `shipping` writes its own table without direct
-  access to `orders.internal`.
+- Test는 compile되거나 missing production symbol 때문에만 실패한다.
+- Failure는 새 module이 아직 구현되지 않았음을 증명한다.
 
-## Step 3 - Document and Diagram
+## 단계 2 - Bounded context 구현
 
-Action:
-- Add `README.md`, `README.ko.md`, and a generated SVG/PNG diagram.
-- Update Chapter 13 and root README links.
+작업:
+- `orders`와 `shipping` bounded context를 구현한다.
+- Exposed table과 repository를 각 context 내부로 유지한다.
+- `orders.events` named interface를 통해 `OrderAcceptedEvent`를 publish/consume한다.
 
 DoD:
-- Both README files explain the DDD/Modulith/Exposed flow.
-- Diagram passes automated audits and full-size visual inspection.
+- Positive verifier test가 통과한다.
+- Event handoff test는 `shipping`이 `orders.internal` direct access 없이 자체 table에 write함을
+  증명한다.
 
-## Step 4 - Register CI Surface
+## 단계 3 - 문서와 diagram
 
-Action:
-- Add the module build task to `.github/workflows/examples.yml`.
-- Verify module registration with Gradle project listing.
+작업:
+- `README.md`, `README.ko.md`, generated SVG/PNG diagram을 추가한다.
+- Chapter 13 및 root README link를 갱신한다.
+
+DoD:
+- 두 README file은 DDD/Modulith/Exposed flow를 설명한다.
+- Diagram은 automated audit와 full-size visual inspection을 통과한다.
+
+## 단계 4 - Register CI Surface
+
+작업:
+- Module build task를 `.github/workflows/examples.yml`에 추가한다.
+- Gradle project listing으로 module registration을 검증한다.
 
 DoD:
 - `:08-ddd-modulith-boundaries` appears in `./gradlew projects`.
-- Workflow syntax validates with `actionlint`.
+- Workflow syntax는 validate된다 with `actionlint`.
 
-## Step 5 - Review and PR
+## 단계 5 - 검토 및 PR
 
-Action:
-- Run targeted tests/build, diff checks, verifier checklist, and review gates.
-- Commit with Lore trailers and open a PR for issue #145.
+작업:
+- Targeted tests/build, diff check, verifier checklist, review gate를 실행한다.
+- Lore trailer로 commit하고 issue #145용 PR을 연다.
 
 DoD:
-- PR mirrors issue assignee, milestone, and labels.
-- PR body ends with `## DoD Status`.
-- Live PR and issue metadata are verified with `gh`.
+- PR은 issue assignee, milestone, label을 반영한다.
+- PR body는 `## DoD Status`로 끝난다.
+- Live PR 및 issue metadata는 `gh`로 검증된다.


### PR DESCRIPTION
## Summary
- Localizes 13 single-language superpowers implementation plan documents to Korean.
- Preserves commands, API identifiers, URLs, issue numbers, exact technical names, and workflow references.
- Keeps bilingual README/manual pairs and LLM-facing operating documents out of scope.

Closes #179

## Validation
- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-178-korean-superpowers-specs --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `git diff --check`

## DoD Status
- Scope: only `docs/superpowers/plans/*.md` files changed.
- Locale policy: GitHub metadata remains English; repository-facing plan prose is Korean.
- Build: not run because this PR changes only Markdown prose.
