### PR TITLE
Localize shared test comments

### DIFF
--- a/00-shared/exposed-shared-tests/build.gradle.kts
+++ b/00-shared/exposed-shared-tests/build.gradle.kts
@@ -4,14 +4,14 @@ configurations {
 
 dependencies {
 
-    // Bluetape4k Exposed
+    // Bluetape4k Exposed 의존성
     api(libs.exposed.core)
     api(libs.exposed.dao)
     api(libs.exposed.jdbc)
     implementation(libs.exposed.jackson2)
     implementation(libs.exposed.fastjson2)
 
-    // Exposed
+    // JetBrains Exposed 의존성
     api(libs.jetbrains.exposed.core)
     api(libs.jetbrains.exposed.dao)
     api(libs.jetbrains.exposed.jdbc)
@@ -44,17 +44,17 @@ dependencies {
     implementation(libs.bluetape4k.idgenerators)
     implementation(libs.java.uuid.generator)
 
-    // Coroutines
+    // 코루틴 테스트 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)
 
-    // Java Money
+    // Java Money 테스트 의존성
     testImplementation(libs.bluetape4k.money)
     testImplementation(libs.javax.money.api)
     testImplementation(libs.javamoney.moneta)
 
-    // Logcaptor
+    // Logcaptor 테스트 의존성
     testImplementation(libs.logcaptor)
 
 }

--- a/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/WithDBSuspending.kt
+++ b/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/WithDBSuspending.kt
@@ -67,7 +67,7 @@ suspend fun withDbSuspending(
                 statement(testDB)
             }
         } finally {
-            // revert any new configuration to not be carried over to the next test in suite
+            // 이번 테스트에서 새로 적용한 설정이 다음 테스트로 넘어가지 않도록 원래 DB 설정으로 되돌립니다.
             if (configure != null) {
                 testDB.db = registeredDb
             }

--- a/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/WithDb.kt
+++ b/00-shared/exposed-shared-tests/src/main/kotlin/exposed/shared/tests/WithDb.kt
@@ -78,7 +78,7 @@ fun withDb(
                 statement(testDB)
             }
         } finally {
-            // revert any new configuration to not be carried over to the next test in suite
+            // 이번 테스트에서 새로 적용한 설정이 다음 테스트로 넘어가지 않도록 원래 DB 설정으로 되돌립니다.
             if (configure != null) {
                 testDB.db = registeredDb
             }

--- a/00-shared/exposed-shared-tests/src/test/kotlin/exposed/shared/repository/ActorRepositoryCoroutineTest.kt
+++ b/00-shared/exposed-shared-tests/src/test/kotlin/exposed/shared/repository/ActorRepositoryCoroutineTest.kt
@@ -176,9 +176,9 @@ class ActorRepositoryCoroutineTest: AbstractExposedTest() {
             val savedActor = repository.save(actor)
             savedActor.id.shouldNotBeNull()
 
-            // Delete savedActor
+            // 저장한 배우 레코드를 삭제합니다.
             repository.deleteById(savedActor.id) shouldBeEqualTo 1
-            // Already deleted
+            // 이미 삭제된 레코드는 다시 삭제되지 않습니다.
             repository.deleteById(savedActor.id) shouldBeEqualTo 0
         }
     }
@@ -191,10 +191,10 @@ class ActorRepositoryCoroutineTest: AbstractExposedTest() {
             val savedActor = repository.save(actor)
             savedActor.id.shouldNotBeNull()
 
-            // Delete savedActor
+            // 저장한 배우 레코드를 삭제합니다.
             repository.deleteById(savedActor.id) shouldBeEqualTo 1
 
-            // Already deleted
+            // 이미 삭제된 레코드는 다시 삭제되지 않습니다.
             repository.deleteById(savedActor.id) shouldBeEqualTo 0
         }
     }
@@ -207,7 +207,7 @@ class ActorRepositoryCoroutineTest: AbstractExposedTest() {
 
             repository.deleteAll { ActorTable.lastName eq "Depp" } shouldBeEqualTo 1
 
-            // Delete 1 actor
+            // 조건으로 삭제한 1건을 제외한 배우 레코드를 모두 삭제합니다.
             repository.deleteAll() shouldBeEqualTo count.toInt() - 1
         }
     }
@@ -222,7 +222,7 @@ class ActorRepositoryCoroutineTest: AbstractExposedTest() {
 
             repository.deleteAllIgnore { ActorTable.lastName eq "Depp" } shouldBeEqualTo 1
 
-            // Delete 1 actor
+            // 조건으로 삭제한 1건을 제외한 배우 레코드를 모두 삭제합니다.
             repository.deleteAllIgnore() shouldBeEqualTo count.toInt() - 1
         }
     }

--- a/00-shared/exposed-shared-tests/src/test/kotlin/exposed/shared/repository/ActorRepositoryTest.kt
+++ b/00-shared/exposed-shared-tests/src/test/kotlin/exposed/shared/repository/ActorRepositoryTest.kt
@@ -180,9 +180,9 @@ class ActorRepositoryTest: AbstractExposedTest() {
             val savedActor = repository.save(actor)
             savedActor.id.shouldNotBeNull()
 
-            // Delete savedActor
+            // 저장한 배우 레코드를 삭제합니다.
             repository.deleteById(savedActor.id) shouldBeEqualTo 1
-            // Already deleted
+            // 이미 삭제된 레코드는 다시 삭제되지 않습니다.
             repository.deleteById(savedActor.id) shouldBeEqualTo 0
         }
     }
@@ -195,10 +195,10 @@ class ActorRepositoryTest: AbstractExposedTest() {
             val savedActor = repository.save(actor)
             savedActor.id.shouldNotBeNull()
 
-            // Delete savedActor
+            // 저장한 배우 레코드를 삭제합니다.
             repository.deleteById(savedActor.id) shouldBeEqualTo 1
 
-            // Already deleted
+            // 이미 삭제된 레코드는 다시 삭제되지 않습니다.
             repository.deleteById(savedActor.id) shouldBeEqualTo 0
         }
     }
@@ -211,7 +211,7 @@ class ActorRepositoryTest: AbstractExposedTest() {
 
             repository.deleteAll { ActorTable.lastName eq "Depp" } shouldBeEqualTo 1
 
-            // Delete 1 actor
+            // 조건으로 삭제한 1건을 제외한 배우 레코드를 모두 삭제합니다.
             repository.deleteAll() shouldBeEqualTo count.toInt() - 1
         }
     }
@@ -232,7 +232,7 @@ class ActorRepositoryTest: AbstractExposedTest() {
 
             repository.deleteAllIgnore { ActorTable.lastName eq "Depp" } shouldBeEqualTo 1
 
-            // Delete 1 actor
+            // 조건으로 삭제한 1건을 제외한 배우 레코드를 모두 삭제합니다.
             repository.deleteAllIgnore() shouldBeEqualTo count.toInt() - 1
         }
     }


### PR DESCRIPTION
## Summary
- Localizes the remaining English-only comments in `00-shared/exposed-shared-tests`.
- Keeps dependency names, SQL examples, code identifiers, and test names unchanged.
- Leaves behavior untouched; this PR changes comments only.

Closes #181

## Validation
- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-180-korean-superpowers-research --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `git diff --check`
- `USE_FAST_DB=true ./gradlew :exposed-shared-tests:test --no-daemon` (149 passing, 6 pending, BUILD SUCCESSFUL)

## DoD Status
- Scope: only shared-test Gradle/Kotlin comment prose changed.
- Behavior: no production or test logic changed.
- Evidence: shared-test task passed after the comment localization.
