### PR TITLE
Localize Spring and alternatives comments

### DIFF
--- a/01-spring-boot/spring-mvc-exposed/build.gradle.kts
+++ b/01-spring-boot/spring-mvc-exposed/build.gradle.kts
@@ -34,7 +34,7 @@ configurations {
 dependencies {
     testImplementation(project(":exposed-shared-tests"))
 
-    // Exposed
+    // JetBrains Exposed 의존성
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)
     implementation(libs.jetbrains.exposed.dao)
@@ -42,27 +42,27 @@ dependencies {
     implementation(libs.jetbrains.exposed.migration.jdbc)
     implementation(libs.jetbrains.exposed.spring.boot.starter)
 
-    // bluetape4k
+    // bluetape4k 공통 의존성
     implementation(libs.exposed.core)
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.testcontainers)
 
-    // Database Drivers
+    // 데이터베이스 드라이버
     runtimeOnly(libs.hikaricp)
 
     // H2
     runtimeOnly(libs.h2.v2)
 
-    // MySQL
+    // MySQL 드라이버와 Testcontainers 의존성
     implementation(libs.testcontainers.mysql)
     runtimeOnly(libs.mysql.connector.j)
 
-    // PostgreSQL
+    // PostgreSQL 드라이버와 Testcontainers 의존성
     implementation(libs.testcontainers.postgresql)
     runtimeOnly(libs.postgresql.driver)
 
-    // Spring Boot
+    // Spring Boot 애플리케이션 의존성
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
@@ -82,25 +82,25 @@ dependencies {
         exclude(module = "mockito-core")
     }
 
-    // Coroutines
+    // 코루틴 테스트 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.reactor)
     testImplementation(libs.kotlinx.coroutines.test)
 
-    // Reactor
+    // Reactor 테스트 의존성
     testImplementation(libs.reactor.netty)
     testImplementation(libs.reactor.kotlin.extensions)
     testImplementation(libs.reactor.test)
 
-    // Monitoring
+    // 모니터링 의존성
     implementation(libs.micrometer.core)
     implementation(libs.micrometer.registry.prometheus)
 
-    // SpringDoc - OpenAPI 3.0
+    // SpringDoc OpenAPI 3.0 UI 의존성
     implementation(libs.springdoc.openapi.starter.webmvc.ui)
 
-    // Gatling
+    // Gatling 부하 테스트 의존성
     implementation(libs.gatling.app)
     implementation(libs.gatling.core.java)
     implementation(libs.gatling.http.java)

--- a/01-spring-boot/spring-mvc-exposed/src/test/kotlin/exposed/workshop/springmvc/domain/DomainSQLTest.kt
+++ b/01-spring-boot/spring-mvc-exposed/src/test/kotlin/exposed/workshop/springmvc/domain/DomainSQLTest.kt
@@ -53,7 +53,7 @@ class DomainSQLTest: AbstractSpringMvcTest() {
     open inner class VirtualThread {
 
         /**
-         * Retrieves and validates actors within virtual thread
+         * Virtual thread 안에서 배우 목록을 조회하고 결과가 비어 있지 않은지 검증합니다.
          */
         @RepeatedTest(REPEAT_SIZE)
         open fun `get all actors`() {
@@ -66,7 +66,7 @@ class DomainSQLTest: AbstractSpringMvcTest() {
         }
 
         /**
-         * Tests actor retrieval across multiple virtual threads
+         * 여러 virtual thread에서 배우 조회가 동시에 정상 수행되는지 검증합니다.
          */
         @Test
         open fun `get all actors in multiple virtual threads`() {

--- a/01-spring-boot/spring-webflux-exposed/build.gradle.kts
+++ b/01-spring-boot/spring-webflux-exposed/build.gradle.kts
@@ -35,13 +35,13 @@ configurations {
 dependencies {
     testImplementation(project(":exposed-shared-tests"))
 
-    // Exposed
+    // JetBrains Exposed 의존성
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)
     implementation(libs.jetbrains.exposed.java.time)
     implementation(libs.jetbrains.exposed.spring.boot.starter)
 
-    // bluetape4k
+    // bluetape4k 공통 의존성
     implementation(libs.exposed.core)
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jackson2)
@@ -49,21 +49,21 @@ dependencies {
     testImplementation(libs.bluetape4k.spring.boot.core)
     implementation(libs.bluetape4k.testcontainers)
 
-    // Database Drivers
+    // 데이터베이스 드라이버
     runtimeOnly(libs.hikaricp)
 
     // H2
     runtimeOnly(libs.h2.v2)
 
-    // MySQL
+    // MySQL 드라이버와 Testcontainers 의존성
     implementation(libs.testcontainers.mysql)
     runtimeOnly(libs.mysql.connector.j)
 
-    // PostgreSQL
+    // PostgreSQL 드라이버와 Testcontainers 의존성
     implementation(libs.testcontainers.postgresql)
     runtimeOnly(libs.postgresql.driver)
 
-    // Spring Boot
+    // Spring Boot WebFlux 애플리케이션 의존성
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
@@ -81,25 +81,25 @@ dependencies {
         exclude(module = "mockito-core")
     }
 
-    // Coroutines
+    // 코루틴 의존성
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.reactor)
     testImplementation(libs.kotlinx.coroutines.test)
 
-    // Reactor
+    // Reactor 의존성
     implementation(libs.reactor.netty)
     implementation(libs.reactor.kotlin.extensions)
     testImplementation(libs.reactor.test)
 
-    // Monitoring
+    // 모니터링 의존성
     implementation(libs.micrometer.core)
     implementation(libs.micrometer.registry.prometheus)
 
-    // SpringDoc - OpenAPI 3.0
+    // SpringDoc OpenAPI 3.0 UI 의존성
     implementation(libs.springdoc.openapi.starter.webflux.ui)
 
-    // Gatling
+    // Gatling 부하 테스트 의존성
     implementation(libs.gatling.app)
     implementation(libs.gatling.core.java)
     implementation(libs.gatling.http.java)

--- a/02-alternatives-to-jpa/hibernate-reactive-example/build.gradle.kts
+++ b/02-alternatives-to-jpa/hibernate-reactive-example/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
     api(libs.jakarta.persistence.api)
     api(libs.jakarta.transaction.api)
 
-    // Hibernate Reactive
+    // Hibernate Reactive 의존성
     implementation(libs.bluetape4k.hibernate.reactive)
     implementation(libs.hibernate.reactive.core)
     implementation("com.ongres.scram:scram-client:3.2") // vert.x sql client 에서 사용하는데 제외되었다.
@@ -79,17 +79,17 @@ dependencies {
     kapt(libs.hibernate.jpamodelgen)
     kaptTest(libs.hibernate.jpamodelgen)
 
-    // Mutiny & Coroutines
+    // Mutiny 및 코루틴 의존성
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.reactor)
     testImplementation(libs.kotlinx.coroutines.test)
 
-    // Vaidators
+    // Validation 의존성
     implementation(libs.hibernate.validator)
     implementation(libs.jakarta.validation.api)
 
-    // Spring Boot Webflux
+    // Spring Boot WebFlux 애플리케이션 의존성
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
@@ -99,7 +99,7 @@ dependencies {
         exclude(module = "mockito-core")
     }
 
-    // Postgres
+    // PostgreSQL reactive client와 Testcontainers 의존성
     implementation(libs.testcontainers.postgresql)
     implementation(libs.vertx.pg.client)
 
@@ -107,10 +107,10 @@ dependencies {
     // reactive 방식에서는 항상 verx-pg-client 를 사용합니다
     runtimeOnly(libs.postgresql.driver)
 
-    // Monitoring
+    // 모니터링 의존성
     implementation(libs.micrometer.core)
     implementation(libs.micrometer.registry.prometheus)
 
-    // SpringDoc - OpenAPI 3.0
+    // SpringDoc OpenAPI 3.0 UI 의존성
     implementation(libs.springdoc.openapi.starter.webflux.ui)
 }

--- a/02-alternatives-to-jpa/r2dbc-example/build.gradle.kts
+++ b/02-alternatives-to-jpa/r2dbc-example/build.gradle.kts
@@ -17,22 +17,22 @@ dependencies {
     implementation(libs.bluetape4k.jackson2)
     testImplementation(libs.bluetape4k.junit5)
 
-    // PostgreSql Server
+    // PostgreSQL 테스트 서버 의존성
     implementation(libs.bluetape4k.testcontainers)
     implementation(libs.testcontainers.postgresql)
 
-    // Coroutines
+    // 코루틴 의존성
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.reactor)
     testImplementation(libs.kotlinx.coroutines.test)
 
-    // Reactor
+    // Reactor 의존성
     implementation(libs.reactor.core)
     implementation(libs.reactor.kotlin.extensions)
     testImplementation(libs.reactor.test)
 
-    // R2DBC
+    // R2DBC 애플리케이션 의존성
     implementation(libs.bluetape4k.spring.boot.r2dbc)
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
     runtimeOnly(libs.r2dbc.postgresql)

--- a/02-alternatives-to-jpa/vertx-sqlclient-example/build.gradle.kts
+++ b/02-alternatives-to-jpa/vertx-sqlclient-example/build.gradle.kts
@@ -8,16 +8,16 @@ dependencies {
     testImplementation(libs.bluetape4k.jdbc)
     testImplementation(libs.bluetape4k.junit5)
 
-    // Vertx
+    // Vert.x 테스트 의존성
     testImplementation(libs.bluetape4k.vertx)
     testImplementation(libs.vertx.junit5)
 
-    // Vertx Kotlin
+    // Vert.x Kotlin 및 coroutine 의존성
     testImplementation(libs.vertx.core)
     testImplementation(libs.vertx.lang.kotlin)
     testImplementation(libs.vertx.lang.kotlin.coroutines)
 
-    // Vertx SqlClient
+    // Vert.x SQL client 의존성
     testImplementation(libs.vertx.sql.client)
     testImplementation(libs.vertx.sql.client.templates)
     testImplementation(libs.vertx.mysql.client)
@@ -29,7 +29,7 @@ dependencies {
     testImplementation(libs.vertx.jdbc.client)
     testImplementation(libs.agroal.pool)
 
-    // MyBatis
+    // MyBatis dynamic SQL 의존성
     testImplementation(libs.mybatis.dynamic.sql)
 
     // Vetx SqlClient Templates 에서 Jackson Databind 를 이용한 매핑을 사용한다
@@ -40,13 +40,13 @@ dependencies {
     testRuntimeOnly(libs.h2)
     testRuntimeOnly(libs.mysql.connector.j)
 
-    // Testcontainers
+    // Testcontainers 데이터베이스 의존성
     testImplementation(libs.bluetape4k.testcontainers)
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Coroutines
+    // 코루틴 테스트 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)


### PR DESCRIPTION
## Summary
- Localizes remaining English-only comment prose in `01-spring-boot` and `02-alternatives-to-jpa`.
- Preserves commented-out code samples, URLs, dependency names, API identifiers, and test behavior.
- Keeps the diff to build/KDoc/comment prose only.

Closes #182

## Validation
- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-181-korean-shared-test-comments --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `git diff --check`
- `USE_FAST_DB=true ./gradlew :spring-mvc-exposed:test :spring-webflux-exposed:test :hibernate-reactive-example:test :r2dbc-example:test :vertx-sqlclient-example:test --no-daemon`
  - `:spring-mvc-exposed:test`: 49 passing
  - `:spring-webflux-exposed:test`: 47 passing
  - `:hibernate-reactive-example:test`: 22 passing
  - `:r2dbc-example:test`: 23 passing
  - `:vertx-sqlclient-example:test`: 10 passing

## DoD Status
- Scope: only scoped Spring Boot and alternatives comment prose changed.
- Behavior: no executable logic changed.
- Evidence: all touched module test tasks completed successfully.
