### PR TITLE
Localize basic and DDL comments

### DIFF
--- a/03-exposed-basic/exposed-dao-example/build.gradle.kts
+++ b/03-exposed-basic/exposed-dao-example/build.gradle.kts
@@ -17,14 +17,14 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Jdbc Drivers
+    // JDBC 드라이버 의존성
     testRuntimeOnly(libs.h2.v2)
     testRuntimeOnly(libs.mariadb.java.client)
     testRuntimeOnly(libs.mysql.connector.j)
     testRuntimeOnly(libs.postgresql.driver)
     testRuntimeOnly(libs.pgjdbc.ng)
 
-    // Coroutines
+    // 코루틴 테스트 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/03-exposed-basic/exposed-dao-example/src/test/kotlin/exposed/dao/example/Schema.kt
+++ b/03-exposed-basic/exposed-dao-example/src/test/kotlin/exposed/dao/example/Schema.kt
@@ -69,7 +69,7 @@ object Schema {
         var name: String by UserTable.name
         var age: Int by UserTable.age
 
-        // many-to-one
+        // 다대일 관계
         var city: City? by City optionalReferencedOn UserTable.cityId
 
         override fun equals(other: Any?): Boolean = other is User && id._value == other.id._value

--- a/03-exposed-basic/exposed-sql-example/build.gradle.kts
+++ b/03-exposed-basic/exposed-sql-example/build.gradle.kts
@@ -18,14 +18,14 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Jdbc Drivers
+    // JDBC 드라이버 의존성
     testRuntimeOnly(libs.h2.v2)
     testRuntimeOnly(libs.mariadb.java.client)
     testRuntimeOnly(libs.mysql.connector.j)
     testRuntimeOnly(libs.postgresql.driver)
     testRuntimeOnly(libs.pgjdbc.ng)
 
-    // Coroutines
+    // 코루틴 테스트 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/04-exposed-ddl/01-connection/build.gradle.kts
+++ b/04-exposed-ddl/01-connection/build.gradle.kts
@@ -20,14 +20,14 @@ dependencies {
 
     testImplementation(libs.hikaricp)
 
-    // Jdbc Drivers
+    // JDBC 드라이버 의존성
     testRuntimeOnly(libs.h2.v2)
     testRuntimeOnly(libs.mariadb.java.client)
     testRuntimeOnly(libs.mysql.connector.j)
     testRuntimeOnly(libs.postgresql.driver)
     testRuntimeOnly(libs.pgjdbc.ng)
 
-    // Coroutines
+    // 코루틴 테스트 의존성
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/04-exposed-ddl/01-connection/src/test/kotlin/exposed/examples/connection/Ex03_ConnectionTimeout.kt
+++ b/04-exposed-ddl/01-connection/src/test/kotlin/exposed/examples/connection/Ex03_ConnectionTimeout.kt
@@ -77,7 +77,7 @@ class Ex03_ConnectionTimeout: AbstractExposedTest() {
 
         try {
             try {
-                // transaction block should use default DatabaseConfig values when no property is set
+                // 별도 속성이 없으면 transaction block은 기본 DatabaseConfig 값을 사용해야 합니다.
                 transaction(db = db, transactionIsolation = Connection.TRANSACTION_SERIALIZABLE) {
                     exec("SELECT 1;")
                 }
@@ -90,7 +90,7 @@ class Ex03_ConnectionTimeout: AbstractExposedTest() {
             datasource.connectCount = 0
 
             try {
-                // property set in transaction block should override default DatabaseConfig
+                // transaction block에서 지정한 속성은 기본 DatabaseConfig 값을 재정의해야 합니다.
                 transaction(db = db, transactionIsolation = Connection.TRANSACTION_SERIALIZABLE) {
                     maxAttempts = 5
                     exec("SELECT 1;")

--- a/04-exposed-ddl/01-connection/src/test/kotlin/exposed/examples/connection/h2/Ex02_H2_MultiDatabase.kt
+++ b/04-exposed-ddl/01-connection/src/test/kotlin/exposed/examples/connection/h2/Ex02_H2_MultiDatabase.kt
@@ -297,7 +297,7 @@ class Ex02_H2_MultiDatabase {
         TransactionManager.defaultDatabase = db1
         newSuspendedTransaction(coroutineDispatcher1) {
             TransactionManager.current().db.name shouldBeEqualTo db1.name
-            // when running all tests together, this one usually fails
+            // 전체 테스트를 함께 실행하면 이 쿼리는 대체로 실패합니다.
             // `Dual.select(intLiteral(1))`
             TransactionManager.current().exec("SELECT 1") { rs ->
                 rs.next().ifTrue { rs.getInt(1) } shouldBeEqualTo 1

--- a/04-exposed-ddl/02-ddl/build.gradle.kts
+++ b/04-exposed-ddl/02-ddl/build.gradle.kts
@@ -22,14 +22,14 @@ dependencies {
 
     testRuntimeOnly(libs.hikaricp)
 
-    // Jdbc Drivers
+    // JDBC 드라이버 의존성
     testRuntimeOnly(libs.h2.v2)
     testRuntimeOnly(libs.mariadb.java.client)
     testRuntimeOnly(libs.mysql.connector.j)
     testImplementation(libs.postgresql.driver)
     testRuntimeOnly(libs.pgjdbc.ng)
 
-    // Coroutines
+    // 코루틴 테스트 의존성
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/04-exposed-ddl/02-ddl/src/test/kotlin/exposed/examples/ddl/Ex05_CreateIndex.kt
+++ b/04-exposed-ddl/02-ddl/src/test/kotlin/exposed/examples/ddl/Ex05_CreateIndex.kt
@@ -212,7 +212,7 @@ class Ex05_CreateIndex: AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `functional index 생성`(testDB: TestDB) {
-        // H2 does not support functional indexes
+        // H2는 functional index를 지원하지 않습니다.
         Assumptions.assumeTrue { testDB in setOf(TestDB.POSTGRESQL, TestDB.MYSQL_V8) }
 
         val tester = object: IntIdTable("tester") {

--- a/04-exposed-ddl/02-ddl/src/test/kotlin/exposed/examples/ddl/Ex10_DDL_Examples.kt
+++ b/04-exposed-ddl/02-ddl/src/test/kotlin/exposed/examples/ddl/Ex10_DDL_Examples.kt
@@ -137,7 +137,7 @@ class Ex10_DDL_Examples: AbstractExposedTest() {
                         "$columnName ${tester.name.columnType.sqlType()} NOT NULL)"
             tester.ddl.single() shouldBeEqualTo expectedCreate
 
-            // check that insert and select statement identifiers also match in DB without throwing SQLException
+            // insert/select statement identifier가 SQLException 없이 DB에서도 일치하는지 확인합니다.
             tester.insert { it[name] = "A" }
 
             val expectedSelect = "SELECT $tableName.$columnName FROM $tableName"
@@ -145,7 +145,7 @@ class Ex10_DDL_Examples: AbstractExposedTest() {
                 it.prepareSQL(this, prepared = false) shouldBeEqualTo expectedSelect
             }
 
-            // check that identifiers match with returned jdbc metadata
+            // 반환된 JDBC metadata와 identifier가 일치하는지 확인합니다.
             val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tester, withLogs = false)
             statements.isEmpty().shouldBeTrue()
 
@@ -214,7 +214,7 @@ class Ex10_DDL_Examples: AbstractExposedTest() {
 
             keywordTable.ddl.single() shouldBeEqualTo expectedCreate
 
-            // check that insert and select statement identifiers also match in DB without throwing SQLException
+            // insert/select statement identifier가 SQLException 없이 DB에서도 일치하는지 확인합니다.
             keywordTable.insert {
                 it[public] = true
                 it[data] = 999
@@ -227,7 +227,7 @@ class Ex10_DDL_Examples: AbstractExposedTest() {
                 it.prepareSQL(this, prepared = false) shouldBeEqualTo expectedSelect
             }
 
-            // check that identifiers match with returned jdbc metadata
+            // 반환된 JDBC metadata와 identifier가 일치하는지 확인합니다.
             val statements = MigrationUtils.statementsRequiredForDatabaseMigration(keywordTable, withLogs = false)
             statements.shouldBeEmpty()
 
@@ -380,7 +380,7 @@ class Ex10_DDL_Examples: AbstractExposedTest() {
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `auto increment on unsigned columns`(testDB: TestDB) {
         /**
-         * separate tables are necessary as some db only allow a single column to be auto-incrementing
+         * 일부 DB는 auto-increment column을 하나만 허용하므로 별도 테이블이 필요합니다.
          * ```sql
          * -- Postgres
          * CREATE TABLE IF NOT EXISTS u_int_tester (


### PR DESCRIPTION
## Summary
- Localizes remaining English-only comment prose in `03-exposed-basic` and `04-exposed-ddl`.
- Preserves SQL snippets, `@see` references, API identifiers, and test behavior.
- Keeps the diff to comment/KDoc/build-label prose only.

Closes #183

## Validation
- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-182-korean-spring-alternatives-comments --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `git diff --check`
- `USE_FAST_DB=true ./gradlew :exposed-dao-example:test :exposed-sql-example:test :01-connection:test :02-ddl:test --no-daemon`
  - `:exposed-dao-example:test`: 30 passing
  - `:exposed-sql-example:test`: 30 passing
  - `:01-connection:test`: 23 passing
  - `:02-ddl:test`: 153 passing, 17 pending

## DoD Status
- Scope: only basic/DDL comment prose changed.
- Behavior: no executable logic changed.
- Evidence: all touched module test tasks completed successfully.
