### PR TITLE
Localize advanced Exposed comments

### DIFF
--- a/06-advanced/01-exposed-crypt/build.gradle.kts
+++ b/06-advanced/01-exposed-crypt/build.gradle.kts
@@ -23,18 +23,18 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Jdbc Drivers
+    // 테스트 데이터베이스별 JDBC 드라이버 의존성
     testRuntimeOnly(libs.h2.v2)
     testRuntimeOnly(libs.mariadb.java.client)
     testRuntimeOnly(libs.mysql.connector.j)
     testRuntimeOnly(libs.postgresql.driver)
     testRuntimeOnly(libs.pgjdbc.ng)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)
 
-    // Logcaptor
+    // SQL 로그 검증을 위한 LogCaptor 의존성
     testImplementation(libs.logcaptor)
 }

--- a/06-advanced/01-exposed-crypt/src/test/kotlin/exposed/examples/crypt/Ex02_EncryptedColumnWithEntity.kt
+++ b/06-advanced/01-exposed-crypt/src/test/kotlin/exposed/examples/crypt/Ex02_EncryptedColumnWithEntity.kt
@@ -123,7 +123,7 @@ class Ex02_EncryptedColumnWithEntity : AbstractExposedTest() {
     }
 
     /**
-     * find by encrypted value
+     * 암호화된 값으로 엔티티를 조회한다.
      *
      * Exposed Encryptor는 매번 다른 값으로 암호화하기 때문에, WHERE 절에 쓸 수는 없습니다.
      * Jasypt 를 사용해서 매번 같은 값으로 암호화를 하도록 하면 가능합니다.

--- a/06-advanced/02-exposed-javatime/build.gradle.kts
+++ b/06-advanced/02-exposed-javatime/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     // java time 지원 라이브러리
     implementation(libs.jetbrains.exposed.java.time)
 
-    // Kotlin Serialization Json
+    // Kotlin Serialization JSON 컬럼 직렬화 의존성
     implementation(libs.jetbrains.exposed.json)
     implementation(platform(libs.kotlinx.serialization.bom))
     implementation(libs.kotlinx.serialization.json)
@@ -33,14 +33,14 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Jdbc Drivers
+    // 테스트 데이터베이스별 JDBC 드라이버 의존성
     testRuntimeOnly(libs.h2.v2)
     testRuntimeOnly(libs.mariadb.java.client)
     testRuntimeOnly(libs.mysql.connector.j)
     testRuntimeOnly(libs.postgresql.driver)
     testRuntimeOnly(libs.pgjdbc.ng)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제 의존성
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/06-advanced/02-exposed-javatime/src/test/kotlin/exposed/examples/java/time/Ex01_JavaTime.kt
+++ b/06-advanced/02-exposed-javatime/src/test/kotlin/exposed/examples/java/time/Ex01_JavaTime.kt
@@ -96,7 +96,7 @@ class Ex01_JavaTime : AbstractExposedTest() {
             val now = LocalDateTime.now()
 
             /**
-             * Insert a city with local time
+             * `LocalTime` 값을 가진 도시 행을 삽입한다.
              * ```sql
              * -- Postgres
              * INSERT INTO citiestime ("name", local_time)
@@ -110,7 +110,7 @@ class Ex01_JavaTime : AbstractExposedTest() {
                 }
 
             /**
-             * Select the city with local time
+             * `LocalTime` 컬럼에서 시간 구성요소를 조회한다.
              *
              * ```sql
              * -- Postgres
@@ -228,14 +228,14 @@ class Ex01_JavaTime : AbstractExposedTest() {
      * )
      * ```
      *
-     * Insert two `LocalDateTime` with nanos
+     * 나노초 정밀도를 포함한 `LocalDateTime` 값 두 개를 삽입한다.
      * ```sql
      * -- Postgres
      * INSERT INTO testlocaldatetime ("time") VALUES ('2025-02-04T09:13:33.000111112')
      * INSERT INTO testlocaldatetime ("time") VALUES ('2025-02-04T09:13:33.000111118')
      * ```
      *
-     * Load the `LocalDateTime` with nanos from the DB
+     * 데이터베이스에서 나노초 정밀도의 `LocalDateTime` 값을 다시 읽어온다.
      * ```
      * -- Postgres, MySQL, H2_PSQL
      * dateTimesFromDB=[2025-02-04T09:24:16.000111, 2025-02-04T09:24:16.000111]
@@ -286,12 +286,12 @@ class Ex01_JavaTime : AbstractExposedTest() {
      *      deleted DATE NOT NULL
      * )
      * ```
-     * Insert [LocalDate] values
+     * [LocalDate] 값을 테스트 테이블에 삽입한다.
      * ```sql
      * INSERT INTO test_table (created, deleted) VALUES ('2024-05-04', '2024-05-04');
      * INSERT INTO test_table (created, deleted) VALUES ('2024-05-04', '2024-05-05');
      * ```
-     * Select [LocalDate] values
+     * [LocalDate] 컬럼을 날짜/월/연도 조건으로 조회한다.
      * ```sql
      * -- Same date
      * SELECT test_table.created, test_table.deleted
@@ -337,7 +337,7 @@ class Ex01_JavaTime : AbstractExposedTest() {
             sameDateResult shouldHaveSize 1
             sameDateResult.single()[testTable.deleted] shouldBeEqualTo mayTheFourth
 
-            // Same Month
+            // 같은 월에 속하는 행만 조회한다.
             val sameMonthResult =
                 testTable
                     .selectAll()
@@ -345,10 +345,10 @@ class Ex01_JavaTime : AbstractExposedTest() {
                     .toList()
             sameMonthResult shouldHaveSize 2
 
-            // Same Year
+            // 같은 연도에 속하는 행만 조회한다.
             val year2024 =
                 if (currentDialect is PostgreSQLDialect) {
-                    // PostgreSQL requires explicit type cast to resolve function date_part
+                    // PostgreSQL은 date_part 함수 오버로드를 해석하려면 명시적 타입 캐스트가 필요하다.
                     dateParam(mayTheFourth).castTo(JavaLocalDateColumnType()).year()
                 } else {
                     dateParam(mayTheFourth).year()
@@ -414,7 +414,7 @@ class Ex01_JavaTime : AbstractExposedTest() {
                     it[modified] = now
                 }
 
-            // these DB take the nanosecond value 871_130_789 and round up to default precision (e.g. in Oracle: 871_131)
+            // 이 데이터베이스들은 나노초 값 871_130_789를 기본 정밀도로 반올림한다(예: Oracle에서는 871_131).
             val requiresExplicitDTCast = setOf(TestDB.H2_PSQL)
             val dateTime =
                 when (testDB) {
@@ -499,12 +499,12 @@ class Ex01_JavaTime : AbstractExposedTest() {
 
             val prefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
 
-            // value extracted in same manner it is stored, a json string
+            // 저장된 방식과 동일하게 JSON 문자열 형태로 값을 추출한다.
             val modifiedAsString = tester.modified.extract<String>("${prefix}timestamp")
             val allModifiedAsString = tester.select(modifiedAsString)
             allModifiedAsString.all { it[modifiedAsString] == dateTimeNow.toString() }.shouldBeTrue()
 
-            // PostgreSQL requires explicit type cast to timestamp for in-DB comparison
+            // PostgreSQL은 데이터베이스 내부 비교에서 timestamp 명시적 타입 캐스트가 필요하다.
             val dateModified =
                 when (currentDialectTest) {
                     is PostgreSQLDialect -> {
@@ -565,7 +565,7 @@ class Ex01_JavaTime : AbstractExposedTest() {
         val systemTimeZone = TimeZone.getDefault()
 
         withTables(testDB, tester) {
-            // Africa/Cairo time zone
+            // Africa/Cairo 시간대 기준으로 값을 삽입하고 조회한다.
             TimeZone.setDefault(TimeZone.getTimeZone("Africa/Cairo"))
             ZoneId.systemDefault().id shouldBeEqualTo "Africa/Cairo"
 
@@ -585,7 +585,7 @@ class Ex01_JavaTime : AbstractExposedTest() {
             // UTC 로 반환
             log.debug { "cairoNowInsertedInCairoTimeZone=$cairoNowInsertedInCairoTimeZone" }
 
-            // UTC time zone
+            // UTC 시간대 기준으로 값을 삽입하고 조회한다.
             TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))
             ZoneId.systemDefault().id shouldBeEqualTo "UTC"
 
@@ -610,7 +610,7 @@ class Ex01_JavaTime : AbstractExposedTest() {
                     .single()[tester.timestampWithTimeZone]
             log.debug { "cairoNowInsertedInUTCTimeZone=$cairoNowInsertedInUTCTimeZone" }
 
-            // Seoul time zone
+            // Seoul 시간대 기준으로 값을 삽입하고 조회한다.
             TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
             ZoneId.systemDefault().id shouldBeEqualTo "Asia/Seoul"
 
@@ -632,28 +632,28 @@ class Ex01_JavaTime : AbstractExposedTest() {
                     .single()[tester.timestampWithTimeZone]
             log.debug { "cairoNowInsertedInSeoulTimeZone=$cairoNowInsertedInSeoulTimeZone" }
 
-            // PostgreSQL and MySQL always store the timestamp in UTC, thereby losing the original time zone.
-            // To preserve the original time zone, store the time zone information in a separate column.
+            // PostgreSQL과 MySQL은 timestamp 값을 항상 UTC로 저장하므로 원래 시간대 정보가 사라진다.
+            // 원래 시간대를 보존하려면 시간대 정보를 별도 컬럼에 저장해야 한다.
             val isOriginalTimeZonePreserved = testDB !in (TestDB.ALL_MYSQL + TestDB.ALL_POSTGRES)
             if (isOriginalTimeZonePreserved) {
-                // Assert that time zone is preserved when the same value is inserted in different time zones
+                // 같은 값을 서로 다른 시간대에서 삽입해도 시간대 정보가 보존되는지 검증한다.
                 cairoNowInsertedInCairoTimeZone shouldTemporalEqualTo cairoNow
                 cairoNowInsertedInUTCTimeZone shouldTemporalEqualTo cairoNow
                 cairoNowInsertedInSeoulTimeZone shouldTemporalEqualTo cairoNow
 
-                // Assert that time zone is preserved when the same record is retrieved in different time zones
+                // 같은 레코드를 서로 다른 시간대에서 조회해도 시간대 정보가 보존되는지 검증한다.
                 cairoNowRetrievedInUTCTimeZone shouldTemporalEqualTo cairoNow
                 cairoNowRetrievedInSeoulTimeZone shouldTemporalEqualTo cairoNow
             } else {
-                // Assert equivalence in UTC when the same value is inserted in different time zones
+                // 같은 값을 서로 다른 시간대에서 삽입했을 때 UTC 기준 값이 동등한지 검증한다.
                 cairoNowInsertedInUTCTimeZone shouldTemporalEqualTo cairoNowInsertedInCairoTimeZone
                 cairoNowInsertedInSeoulTimeZone shouldTemporalEqualTo cairoNowInsertedInUTCTimeZone
 
-                // Assert equivalence in UTC when the same record is retrieved in different time zones
+                // 같은 레코드를 서로 다른 시간대에서 조회했을 때 UTC 기준 값이 동등한지 검증한다.
                 cairoNowRetrievedInSeoulTimeZone shouldTemporalEqualTo cairoNowRetrievedInUTCTimeZone
             }
 
-            // Reset to original time zone as set up in DatabaseTestsBase init block
+            // DatabaseTestsBase 초기화 블록에서 설정한 원래 시간대로 복원한다.
             TimeZone.setDefault(systemTimeZone)
             ZoneId.systemDefault().id shouldBeEqualTo systemTimeZone.id
         }
@@ -702,7 +702,7 @@ class Ex01_JavaTime : AbstractExposedTest() {
             }
 
         withTables(testDB, tester) {
-            // UTC time zone
+            // UTC 시간대 기준으로 값을 삽입하고 조회한다.
             TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))
             ZoneId.systemDefault().id shouldBeEqualTo "UTC"
 
@@ -904,7 +904,7 @@ class Ex01_JavaTime : AbstractExposedTest() {
             val localTime = LocalTime.of(13, 5)
             val localTimeLiteral = timeLiteral(localTime)
 
-            // UTC time zone
+            // UTC 시간대 기준으로 값을 삽입하고 조회한다.
             TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))
             ZoneId.systemDefault().id shouldBeEqualTo "UTC"
 
@@ -1021,11 +1021,11 @@ infix fun Int.shouldFractionalPartEqualTo(nano2: Int) {
     val dialect = currentDialectTest
 
     when (dialect) {
-        // accurate to 100 nanoseconds
+        // 100나노초 단위까지 정확도를 검증한다.
         is SQLServerDialect -> {
             nano1.nanoRoundTo100Nanos() shouldBeEqualTo nano2.nanoRoundTo100Nanos()
         }
-        // microsecond
+        // 마이크로초 정밀도를 검증한다.
         is MariaDBDialect -> {
             nano1.nanoFloorToMicro() shouldBeEqualTo nano2.nanoFloorToMicro()
         }
@@ -1040,7 +1040,7 @@ infix fun Int.shouldFractionalPartEqualTo(nano2: Int) {
                 else -> {} // don't compare fractional part
             }
         }
-        // milliseconds
+        // 밀리초 정밀도를 검증한다.
         is OracleDialect -> {
             nano1.nanoRoundToMilli() shouldBeEqualTo nano2.nanoRoundToMilli()
         }

--- a/06-advanced/02-exposed-javatime/src/test/kotlin/exposed/examples/java/time/Ex02_Defaults.kt
+++ b/06-advanced/02-exposed-javatime/src/test/kotlin/exposed/examples/java/time/Ex02_Defaults.kt
@@ -502,7 +502,7 @@ class Ex02_Defaults: AbstractExposedTest() {
      * 컬럼의 기본값을 Custom Expression 으로 설정하기
      *
      * ```sql
-     * -- Postgres:
+     * -- Postgres 예:
      * CREATE TABLE IF NOT EXISTS tester (
      *      id SERIAL PRIMARY KEY,
      *      "name" TEXT NOT NULL,
@@ -511,7 +511,7 @@ class Ex02_Defaults: AbstractExposedTest() {
      *      "defaultInt" INT DEFAULT (ABS(-100)) NOT NULL
      * );
      *
-     * -- MySQL V8:
+     * -- MySQL V8 예:
      * CREATE TABLE IF NOT EXISTS tester (
      *      id INT AUTO_INCREMENT PRIMARY KEY,
      *      `name` text NOT NULL,
@@ -539,7 +539,7 @@ class Ex02_Defaults: AbstractExposedTest() {
             val defaultInt = integer("defaultInt").defaultExpression(abs(-100))
         }
 
-        // MySql 5 is excluded because it does not support `CURRENT_DATE()` as a default value
+        // MySQL 5는 `CURRENT_DATE()`를 기본값으로 지원하지 않으므로 제외한다.
         Assumptions.assumeTrue { testDB !in setOf(TestDB.MYSQL_V5) }
         withTables(testDB, tester) {
             val id = tester.insertAndGetId {
@@ -671,14 +671,14 @@ class Ex02_Defaults: AbstractExposedTest() {
      * Timestamp 에 Time Zone 을 포함한 컬럼을 사용할 때 (`TIMESTAMP WITH TIME ZONE DEFAULT`)
      *
      * ```sql
-     * -- Postgres:
+     * -- Postgres 예:
      * CREATE TABLE IF NOT EXISTS t (
      *      id SERIAL PRIMARY KEY,
      *      t1 TIMESTAMP WITH TIME ZONE DEFAULT '2024-07-18 13:19:44+00'::timestamp with time zone NOT NULL,
      *      t2 TIMESTAMP WITH TIME ZONE DEFAULT '2024-07-18 13:19:44+00'::timestamp with time zone NOT NULL,
      *      t3 TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL
      * );
-     * -- MySQL V8:
+     * -- MySQL V8 예:
      * CREATE TABLE IF NOT EXISTS t (
      *      id INT AUTO_INCREMENT PRIMARY KEY,
      *      t1 TIMESTAMP(6) DEFAULT '2024-07-18 13:19:44.000000' NOT NULL,
@@ -691,7 +691,7 @@ class Ex02_Defaults: AbstractExposedTest() {
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `Timestamp with TimeZone Default`(testDB: TestDB) {
         Assumptions.assumeTrue { testDB !in TestDB.ALL_MARIADB + TestDB.MYSQL_V5 }
-        // UTC time zone
+        // UTC 시간대 기준으로 값을 삽입하고 조회한다.
         java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
         ZoneId.systemDefault().id shouldBeEqualTo "UTC"
 
@@ -812,7 +812,7 @@ class Ex02_Defaults: AbstractExposedTest() {
             val dateWithDefault = date("dateWithDefault").default(date)
         }
 
-        // SQLite does not support ALTER TABLE on a column that has a default value
+        // SQLite는 기본값이 있는 컬럼에 대한 ALTER TABLE을 지원하지 않는다.
         withTables(testDB, tester) {
             val statements = SchemaUtils.addMissingColumnsStatements(tester)
             statements.shouldBeEmpty()
@@ -823,13 +823,13 @@ class Ex02_Defaults: AbstractExposedTest() {
      * Timestamp 컬럼에 Default 값을 설정할 때, ALTER TABLE 문이 발생하지 않아야 한다.
      *
      * ```sql
-     * -- Postgres:
+     * -- Postgres 예:
      * CREATE TABLE IF NOT EXISTS tester (
      *      "timestampWithDefault" TIMESTAMP DEFAULT '2023-05-04 05:04:00.7'::timestamp without time zone NOT NULL,
      *      "timestampWithDefaultExpression" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
      * );
      *
-     * -- MYSQL V8:
+     * -- MySQL V8 예:
      * CREATE TABLE IF NOT EXISTS tester (
      *      timestampWithDefault DATETIME(6) DEFAULT '2023-05-04 05:04:00.700000' NOT NULL,
      *      timestampWithDefaultExpression DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) NOT NULL
@@ -839,7 +839,7 @@ class Ex02_Defaults: AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun testTimestampDefaultDoesNotTriggerAlterStatement(testDB: TestDB) {
-        val instant = Instant.parse("2023-05-04T05:04:00.700Z") // In UTC
+        val instant = Instant.parse("2023-05-04T05:04:00.700Z") // UTC 기준 값이다.
 
         val tester = object: Table("tester") {
             val timestampWithDefault = timestamp("timestampWithDefault").default(instant)
@@ -847,7 +847,7 @@ class Ex02_Defaults: AbstractExposedTest() {
                 timestamp("timestampWithDefaultExpression").defaultExpression(CurrentTimestamp)
         }
 
-        // SQLite does not support ALTER TABLE on a column that has a default value
+        // SQLite는 기본값이 있는 컬럼에 대한 ALTER TABLE을 지원하지 않는다.
         withTables(testDB, tester) {
             val statements = SchemaUtils.addMissingColumnsStatements(tester)
             statements.shouldBeEmpty()
@@ -872,7 +872,7 @@ class Ex02_Defaults: AbstractExposedTest() {
                 datetime("datetimeWithDefaultExpression").defaultExpression(CurrentDateTime)
         }
 
-        // SQLite does not support ALTER TABLE on a column that has a default value
+        // SQLite는 기본값이 있는 컬럼에 대한 ALTER TABLE을 지원하지 않는다.
         withTables(testDB, tester) {
             val statements = SchemaUtils.addMissingColumnsStatements(tester)
             statements.shouldBeEmpty()
@@ -898,7 +898,7 @@ class Ex02_Defaults: AbstractExposedTest() {
             val timeWithDefault = time("timeWithDefault").default(time)
         }
 
-        // SQLite does not support ALTER TABLE on a column that has a default value
+        // SQLite는 기본값이 있는 컬럼에 대한 ALTER TABLE을 지원하지 않는다.
         withTables(testDB, tester) {
             val statements = SchemaUtils.addMissingColumnsStatements(tester)
             statements.shouldBeEmpty()
@@ -924,8 +924,8 @@ class Ex02_Defaults: AbstractExposedTest() {
                 timestampWithTimeZone("timestampWithTimeZoneWithDefault").default(offsetDateTime)
         }
 
-        // SQLite does not support ALTER TABLE on a column that has a default value
-        // MariaDB does not support TIMESTAMP WITH TIME ZONE column type
+        // SQLite는 기본값이 있는 컬럼에 대한 ALTER TABLE을 지원하지 않는다.
+        // MariaDB는 TIMESTAMP WITH TIME ZONE 컬럼 타입을 지원하지 않는다.
         val unsupportedDatabases = TestDB.ALL_MARIADB + listOf(TestDB.MYSQL_V5)
         Assumptions.assumeTrue { testDB !in unsupportedDatabases }
         withTables(testDB, tester) {
@@ -986,7 +986,7 @@ class Ex02_Defaults: AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun testCustomDefaultTimestampFunctionWithInsertStatement(testDB: TestDB) {
-        // Only Postgres allows to get timestamp values directly from the insert statement due to implicit 'returning *'
+        // Postgres만 암시적 'returning *' 덕분에 insert 문에서 timestamp 값을 직접 얻을 수 있다.
         Assumptions.assumeTrue { testDB in TestDB.ALL_POSTGRES }
 
         withTables(testDB, DefaultTimestampTable) {

--- a/06-advanced/02-exposed-javatime/src/test/kotlin/exposed/examples/java/time/Ex04_MiscTable.kt
+++ b/06-advanced/02-exposed-javatime/src/test/kotlin/exposed/examples/java/time/Ex04_MiscTable.kt
@@ -331,8 +331,8 @@ class Ex04_MiscTable: AbstractExposedTest() {
         }
     }
 
-    // these DB take the datetime nanosecond value and round up to default precision
-    // which causes flaky comparison failures if not cast to TIMESTAMP first
+    // 이 데이터베이스들은 datetime 나노초 값을 기본 정밀도로 반올림한다.
+    // 먼저 TIMESTAMP로 캐스팅하지 않으면 비교 검증이 불안정하게 실패할 수 있다.
     private val requiresExplicitDTCast = setOf(TestDB.H2_PSQL)
 
     @ParameterizedTest
@@ -1143,7 +1143,7 @@ class Ex04_MiscTable: AbstractExposedTest() {
     }
 
     /**
-     * Update nullable columns to null
+     * nullable 컬럼을 null 값으로 갱신한다.
      *
      * ```sql
      * -- Postgres
@@ -1253,7 +1253,7 @@ class Ex04_MiscTable: AbstractExposedTest() {
     }
 
     /**
-     * Update varchar column
+     * varchar 컬럼 값을 갱신한다.
      */
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
@@ -1378,7 +1378,7 @@ class Ex04_MiscTable: AbstractExposedTest() {
         withDb(testDB) {
             exec(zeroDateTimeTableDdl)
             try {
-                // Need ignore to bypass strict mode
+                // strict mode 검사를 우회하려면 ignore 처리가 필요하다.
                 exec("INSERT IGNORE INTO `zerodatetimetable` (dt1,dt2,ts1,ts2) VALUES ('0000-00-00 00:00:00', '0000-00-00 00:00:00', '0000-00-00 00:00:00', '0000-00-00 00:00:00');")
                 val row = ZeroDateTimeTable.selectAll().first()
 

--- a/06-advanced/03-exposed-kotlin-datetime/build.gradle.kts
+++ b/06-advanced/03-exposed-kotlin-datetime/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     // java time 지원 라이브러리
     testImplementation(libs.jetbrains.exposed.kotlin.datetime)
 
-    // Kotlin Serialization Json
+    // Kotlin Serialization JSON 컬럼 직렬화 의존성
     testImplementation(platform(libs.kotlinx.serialization.bom))
     testImplementation(libs.kotlinx.serialization.json)
 
@@ -32,14 +32,14 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Jdbc Drivers
+    // 테스트 데이터베이스별 JDBC 드라이버 의존성
     testRuntimeOnly(libs.h2.v2)
     testRuntimeOnly(libs.mariadb.java.client)
     testRuntimeOnly(libs.mysql.connector.j)
     testRuntimeOnly(libs.postgresql.driver)
     testRuntimeOnly(libs.pgjdbc.ng)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/06-advanced/03-exposed-kotlin-datetime/src/test/kotlin/exposed/examples/kotlin/datetime/Ex01_KotlinDateTime.kt
+++ b/06-advanced/03-exposed-kotlin-datetime/src/test/kotlin/exposed/examples/kotlin/datetime/Ex01_KotlinDateTime.kt
@@ -103,7 +103,7 @@ class Ex01_KotlinDateTime: AbstractExposedTest() {
             }
 
             /**
-             * Time functions
+             * 시간 함수 동작을 검증한다.
              *
              * ```sql
              * -- H2
@@ -314,7 +314,7 @@ class Ex01_KotlinDateTime: AbstractExposedTest() {
             sameMonthResult shouldHaveSize 2
 
             val year2023 = if (currentDialectTest is PostgreSQLDialect) {
-                // PostgreSQL requires explicit type cast to resolve function date_part
+                // PostgreSQL은 date_part 함수 오버로드를 해석하려면 명시적 타입 캐스트가 필요하다.
                 dateParam(mayTheFourth).castTo(KotlinLocalDateColumnType()).year()
             } else {
                 dateParam(mayTheFourth).year()
@@ -378,7 +378,7 @@ class Ex01_KotlinDateTime: AbstractExposedTest() {
                 it[modified] = nowDT
             }
 
-            // these DB take the nanosecond value 871_130_789 and round up to default precision (e.g. in Oracle: 871_131)
+            // 이 데이터베이스들은 나노초 값 871_130_789를 기본 정밀도로 반올림한다(예: Oracle에서는 871_131).
 //            val requiresExplicitDTCast =
 //                listOf(TestDB.ORACLE, TestDB.H2_V2_ORACLE, TestDB.H2_V2_PSQL, TestDB.H2_V2_SQLSERVER)
             val requiresExplicitDTCast = listOf(TestDB.H2_PSQL)
@@ -553,7 +553,7 @@ class Ex01_KotlinDateTime: AbstractExposedTest() {
             val cairoNowInsertedInCairoTimeZone =
                 tester.selectAll().where { tester.id eq cairoId }.single()[tester.timestampWithTimeZone]
 
-            // UTC time zone
+            // UTC 시간대 기준으로 값을 삽입하고 조회한다.
             java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
             ZoneId.systemDefault().id shouldBeEqualTo "UTC"
 
@@ -567,7 +567,7 @@ class Ex01_KotlinDateTime: AbstractExposedTest() {
             val cairoNowInsertedInUTCTimeZone =
                 tester.selectAll().where { tester.id eq utcID }.single()[tester.timestampWithTimeZone]
 
-            // Seoul time zone
+            // Seoul 시간대 기준으로 값을 삽입하고 조회한다.
             java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Asia/Seoul"))
             ZoneId.systemDefault().id shouldBeEqualTo "Asia/Seoul"
 
@@ -581,28 +581,28 @@ class Ex01_KotlinDateTime: AbstractExposedTest() {
             val cairoNowInsertedInTokyoTimeZone =
                 tester.selectAll().where { tester.id eq seoulID }.single()[tester.timestampWithTimeZone]
 
-            // PostgreSQL and MySQL always store the timestamp in UTC, thereby losing the original time zone.
-            // To preserve the original time zone, store the time zone information in a separate column.
+            // PostgreSQL과 MySQL은 timestamp 값을 항상 UTC로 저장하므로 원래 시간대 정보가 사라진다.
+            // 원래 시간대를 보존하려면 시간대 정보를 별도 컬럼에 저장해야 한다.
             val isOriginalTimeZonePreserved = testDB !in (TestDB.ALL_MYSQL_MARIADB + TestDB.ALL_POSTGRES)
             if (isOriginalTimeZonePreserved) {
-                // Assert that time zone is preserved when the same value is inserted in different time zones
+                // 같은 값을 서로 다른 시간대에서 삽입해도 시간대 정보가 보존되는지 검증한다.
                 cairoNowInsertedInCairoTimeZone shouldDateTimeEqualTo cairoNow
                 cairoNowInsertedInUTCTimeZone shouldDateTimeEqualTo cairoNow
                 cairoNowInsertedInTokyoTimeZone shouldDateTimeEqualTo cairoNow
 
-                // Assert that time zone is preserved when the same record is retrieved in different time zones
+                // 같은 레코드를 서로 다른 시간대에서 조회해도 시간대 정보가 보존되는지 검증한다.
                 cairoNowRetrievedInUTCTimeZone shouldDateTimeEqualTo cairoNow
                 cairoNowRetrievedInSeoulTimeZone shouldDateTimeEqualTo cairoNow
             } else {
-                // Assert equivalence in UTC when the same value is inserted in different time zones
+                // 같은 값을 서로 다른 시간대에서 삽입했을 때 UTC 기준 값이 동등한지 검증한다.
                 cairoNowInsertedInUTCTimeZone shouldDateTimeEqualTo cairoNowInsertedInCairoTimeZone
                 cairoNowInsertedInTokyoTimeZone shouldDateTimeEqualTo cairoNowInsertedInUTCTimeZone
 
-                // Assert equivalence in UTC when the same record is retrieved in different time zones
+                // 같은 레코드를 서로 다른 시간대에서 조회했을 때 UTC 기준 값이 동등한지 검증한다.
                 cairoNowRetrievedInSeoulTimeZone shouldDateTimeEqualTo cairoNowRetrievedInUTCTimeZone
             }
 
-            // Reset to original time zone as set up in DatabaseTestsBase init block
+            // DatabaseTestsBase 초기화 블록에서 설정한 원래 시간대로 복원한다.
             java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
             ZoneId.systemDefault().id shouldBeEqualTo "UTC"
         }
@@ -665,7 +665,7 @@ class Ex01_KotlinDateTime: AbstractExposedTest() {
         }
 
         withTables(testDB, tester) {
-            // UTC time zone
+            // UTC 시간대 기준으로 값을 삽입하고 조회한다.
             java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
             ZoneId.systemDefault().id shouldBeEqualTo "UTC"
 
@@ -869,7 +869,7 @@ class Ex01_KotlinDateTime: AbstractExposedTest() {
             val localTime = LocalTime(13, 0)
             val localTimeLiteral = timeLiteral(localTime)
 
-            // UTC time zone
+            // UTC 시간대 기준으로 값을 삽입하고 조회한다.
             java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
             ZoneId.systemDefault().id shouldBeEqualTo "UTC"
 

--- a/06-advanced/03-exposed-kotlin-datetime/src/test/kotlin/exposed/examples/kotlin/datetime/Ex02_Defaults.kt
+++ b/06-advanced/03-exposed-kotlin-datetime/src/test/kotlin/exposed/examples/kotlin/datetime/Ex02_Defaults.kt
@@ -233,7 +233,7 @@ class Ex02_Defaults: AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun testDefaultsWithExplicit02(testDB: TestDB) {
-        // MySql 5 is excluded because it does not support `CURRENT_DATE()` as a default value
+        // MySQL 5는 `CURRENT_DATE()`를 기본값으로 지원하지 않으므로 제외한다.
         Assumptions.assumeTrue { testDB != TestDB.MYSQL_V5 }
         withTables(testDB, TableWithDBDefault) {
             val created = listOf(
@@ -502,7 +502,7 @@ class Ex02_Defaults: AbstractExposedTest() {
             val defaultInt = integer("defaultInteger").defaultExpression(abs(-100))
         }
 
-        // MySql 5 is excluded because it does not support `CURRENT_DATE()` as a default value
+        // MySQL 5는 `CURRENT_DATE()`를 기본값으로 지원하지 않으므로 제외한다.
         Assumptions.assumeTrue { testDB !in setOf(TestDB.MYSQL_V5) }
 
         withTables(testDB, tester) {
@@ -642,7 +642,7 @@ class Ex02_Defaults: AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun testTimestampWithTimeZoneDefaults(testDB: TestDB) {
-        // UTC time zone
+        // UTC 시간대 기준으로 값을 삽입하고 조회한다.
         java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
         ZoneId.systemDefault().id shouldBeEqualTo "UTC"
 
@@ -785,7 +785,7 @@ class Ex02_Defaults: AbstractExposedTest() {
                 .defaultExpression(CurrentDateTime)
         }
 
-        // SQLite does not support ALTER TABLE on a column that has a default value
+        // SQLite는 기본값이 있는 컬럼에 대한 ALTER TABLE을 지원하지 않는다.
         withTables(testDB, tester) {
             val statements = SchemaUtils.addMissingColumnsStatements(tester)
             statements.shouldBeEmpty()
@@ -808,7 +808,7 @@ class Ex02_Defaults: AbstractExposedTest() {
             val dateWithDefault = date("dateWithDefault").default(date)
         }
 
-        // SQLite does not support ALTER TABLE on a column that has a default value
+        // SQLite는 기본값이 있는 컬럼에 대한 ALTER TABLE을 지원하지 않는다.
         withTables(testDB, tester) {
             val statements = SchemaUtils.addMissingColumnsStatements(tester)
             statements.shouldBeEmpty()
@@ -830,7 +830,7 @@ class Ex02_Defaults: AbstractExposedTest() {
             val timeWithDefault = time("timeWithDefault").default(time)
         }
 
-        // SQLite does not support ALTER TABLE on a column that has a default value
+        // SQLite는 기본값이 있는 컬럼에 대한 ALTER TABLE을 지원하지 않는다.
         withTables(testDB, tester) {
             val statements = SchemaUtils.addMissingColumnsStatements(tester)
             statements.shouldBeEmpty()
@@ -840,7 +840,7 @@ class Ex02_Defaults: AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun testTimestampDefaultDoesNotTriggerAlterStatement(testDB: TestDB) {
-        val instant = Instant.parse("2023-05-04T05:04:00.700Z") // In UTC
+        val instant = Instant.parse("2023-05-04T05:04:00.700Z") // UTC 기준 값이다.
 
         val tester = object: Table("tester") {
             val timestampWithDefault = timestamp("timestampWithDefault").default(instant)
@@ -848,7 +848,7 @@ class Ex02_Defaults: AbstractExposedTest() {
                 .defaultExpression(CurrentTimestamp)
         }
 
-        // SQLite does not support ALTER TABLE on a column that has a default value
+        // SQLite는 기본값이 있는 컬럼에 대한 ALTER TABLE을 지원하지 않는다.
         withTables(testDB, tester) {
             val statements = SchemaUtils.addMissingColumnsStatements(tester)
             statements.shouldBeEmpty()
@@ -878,8 +878,8 @@ class Ex02_Defaults: AbstractExposedTest() {
                 timestampWithTimeZone("timestampWithTimeZoneWithDefault").default(offsetDateTime)
         }
 
-        // SQLite does not support ALTER TABLE on a column that has a default value
-        // MariaDB does not support TIMESTAMP WITH TIME ZONE column type
+        // SQLite는 기본값이 있는 컬럼에 대한 ALTER TABLE을 지원하지 않는다.
+        // MariaDB는 TIMESTAMP WITH TIME ZONE 컬럼 타입을 지원하지 않는다.
         val unsupportedDatabases = TestDB.ALL_MARIADB + TestDB.MYSQL_V5
         Assumptions.assumeTrue { testDB !in unsupportedDatabases }
         withTables(testDB, tester) {
@@ -921,7 +921,7 @@ class Ex02_Defaults: AbstractExposedTest() {
 
             Thread.sleep(1000)
 
-            // Update the row -> 이 때 `created` 컬럼의 값이 [CurrentDateTime] 값으로 변경되어야 함
+            // 행을 갱신하면 `created` 컬럼 값이 [CurrentDateTime] 값으로 변경되어야 한다.
             tester.update {
                 it[amount] = 111
             }
@@ -985,7 +985,7 @@ class Ex02_Defaults: AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun testCustomDefaultTimestampFunctionWithInsertStatement(testDB: TestDB) {
-        // Only Postgres allows to get timestamp values directly from the insert statement due to implicit 'returning *'
+        // Postgres만 암시적 'returning *' 덕분에 insert 문에서 timestamp 값을 직접 얻을 수 있다.
         Assumptions.assumeTrue { testDB in TestDB.ALL_POSTGRES }
 
         withTables(testDB, DefaultTimestampTable) {

--- a/06-advanced/03-exposed-kotlin-datetime/src/test/kotlin/exposed/examples/kotlin/datetime/KotlinTimeAssertions.kt
+++ b/06-advanced/03-exposed-kotlin-datetime/src/test/kotlin/exposed/examples/kotlin/datetime/KotlinTimeAssertions.kt
@@ -61,9 +61,9 @@ internal infix fun Int.shouldFractionalPartEqualTo(nano2: Int) {
     val dialect = currentDialectTest
     val db = dialect.name
     when (dialect) {
-        // accurate to 100 nanoseconds
+        // 100나노초 단위까지 정확도를 검증한다.
         is SQLServerDialect                                 -> nano1.nanoRoundTo100Nanos() shouldBeEqualTo nano2.nanoRoundTo100Nanos()
-        // microseconds
+        // 마이크로초 정밀도를 검증한다.s
         is MariaDBDialect                                   -> nano1.nanoFloorToMicro() shouldBeEqualTo nano2.nanoFloorToMicro()
 
         is H2Dialect, is PostgreSQLDialect, is MysqlDialect -> {
@@ -74,7 +74,7 @@ internal infix fun Int.shouldFractionalPartEqualTo(nano2: Int) {
                 else       -> {} // don't compare fractional part
             }
         }
-        // milliseconds
+        // 밀리초 정밀도를 검증한다.
         is OracleDialect                                    -> nano1.nanoRoundToMilli() shouldBeEqualTo nano2.nanoRoundToMilli()
         is SQLiteDialect                                    -> nano1.nanoFloorToMilli() shouldBeEqualTo nano2.nanoFloorToMilli()
         else                                                -> io.bluetape4k.assertions.fail("Unknown dialect $db")

--- a/06-advanced/04-exposed-json/build.gradle.kts
+++ b/06-advanced/04-exposed-json/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     // Exposed Json 지원 라이브러리 (kotlinx.serialization 을 사용합니다)
     testImplementation(libs.jetbrains.exposed.json)
 
-    // Kotlin Serialization Json
+    // Kotlin Serialization JSON 컬럼 직렬화 의존성
     testImplementation(platform(libs.kotlinx.serialization.bom))
     testImplementation(libs.kotlinx.serialization.json)
 
@@ -31,14 +31,14 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Jdbc Drivers
+    // 테스트 데이터베이스별 JDBC 드라이버 의존성
     testRuntimeOnly(libs.h2.v2)
     testRuntimeOnly(libs.mariadb.java.client)
     testRuntimeOnly(libs.mysql.connector.j)
     testRuntimeOnly(libs.postgresql.driver)
     testRuntimeOnly(libs.pgjdbc.ng)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/AbstractExposedJsonTest.kt
+++ b/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/AbstractExposedJsonTest.kt
@@ -96,8 +96,8 @@ abstract class AbstractExposedJsonTest: AbstractExposedTest() {
              * ```
              */
             val tripleId = tester.insertAndGetId {
-                // User name = "B", "C", "D"
-                // User team = "Team B", "Team C", "Team D"
+                // 생성되는 사용자 이름은 "B", "C", "D"이다.
+                // 생성되는 사용자 팀은 "Team B", "Team C", "Team D"이다.
                 it[tester.groups] = UserGroup(List(3) { i -> User("${'B' + i}", "Team ${'B' + i}") })
                 it[numbers] = intArrayOf(3, 4, 5)
             }

--- a/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/Ex01_JsonColumn.kt
+++ b/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/Ex01_JsonColumn.kt
@@ -65,7 +65,7 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
     companion object: KLogging()
 
     /**
-     * Insert and Select JSON data
+     * JSON 데이터를 삽입하고 조회한다.
      *
      * ```sql
      * -- Postgres
@@ -103,7 +103,7 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
     }
 
     /**
-     * Update with JSON
+     * JSON 값으로 컬럼을 갱신한다.
      */
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
@@ -129,7 +129,7 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
     }
 
     /**
-     * Select with slice extract
+     * JSON 경로 추출 결과를 select slice로 조회한다.
      */
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
@@ -138,7 +138,7 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
 
         withJsonTable(testDB) { tester, user1, data1 ->
             val pathPrefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
-            // SQLServer & Oracle return null if extracted JSON is not scalar
+            // SQLServer와 Oracle은 추출된 JSON 값이 스칼라가 아니면 null을 반환한다.
             val requiresScalar = currentDialectTest is SQLServerDialect || currentDialectTest is OracleDialect
 
             /**
@@ -217,7 +217,7 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
                 it[jsonColumn] = data1.copy(logins = 1000)
             }
 
-            // Postgres requires type casting to compare json field as integer value in DB
+            // Postgres는 json 필드를 DB 내부에서 정수 값으로 비교하려면 타입 캐스팅이 필요하다.
             val logins = when (currentDialectTest) {
                 is PostgreSQLDialect -> JsonTable.jsonColumn.extract<Int>("logins").castTo(IntegerColumnType())
 
@@ -240,8 +240,8 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
 
         withDb(testDB) {
             expectException<SerializationException> {
-                // Throws with message: Serializer for class 'Fake' is not found.
-                // Please ensure that class is marked as '@Serializable' and that the serialization compiler plugin is applied.
+                // 다음 메시지로 예외가 발생한다: Serializer for class 'Fake' is not found.
+                // 해당 클래스에 '@Serializable'을 지정하고 serialization compiler plugin이 적용되었는지 확인해야 한다.
                 object: Table("tester") {
                     val jCol = json<Fake>("J_col", Json)
                 }
@@ -296,11 +296,11 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
 
             dataEntity.all().single().jsonColumn shouldBeEqualTo updatedJson
 
-            // Json Path
+            // JSON 경로 조건을 검증한다.
             Assumptions.assumeTrue { testDB !in TestDB.ALL_H2 }
 
             /**
-             * Insert new entity
+             * 새 엔티티를 삽입한다.
              *
              * ```sql
              * INSERT INTO j_table (j_column)
@@ -342,8 +342,8 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
 
         withJsonTable(testDB) { tester, user1, data1 ->
             /**
-             * Insert new entity
-             * Postgres:
+             * 새 엔티티를 삽입한다.
+             * Postgres 예:
              * ```sql
              * INSERT INTO j_table (j_column)
              * VALUES ({"user":{"name":"Admin","team":"Alpha"},"logins":10,"active":true,"team":null})
@@ -388,7 +388,7 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
             val userIsInAlphaTeam = JsonTable.jsonColumn.contains(stringLiteral(alphaTreamUserAsJson))
             tester.selectAll().where { userIsInAlphaTeam }.count() shouldBeEqualTo 1L
 
-            // test target contains candidate at specified path
+            // 지정한 경로의 대상 JSON이 후보 값을 포함하는지 검증한다.
             if (testDB in TestDB.ALL_MYSQL_LIKE) {
                 /**
                  * 아쉽게도 Postgres 에서는 JSON Path 의 값을 비교하는 방식은 지원하지 않습니다.
@@ -431,7 +431,7 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
             val optional = if (testDB in TestDB.ALL_MYSQL_LIKE) "one" else null
 
             /**
-             * test data at path root `$` exists by providing no path arguments
+             * 경로 인자를 전달하지 않아 루트 경로 `$`의 데이터 존재 여부를 검증한다.
              *
              * ```sql
              * -- Postgres
@@ -476,11 +476,11 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
             val hasLogins = JsonTable.jsonColumn.exists(".logins", optional = optional)
             tester.selectAll().where { hasLogins }.count() shouldBeEqualTo 2L
 
-            // test data at path exists with filter condition & optional arguments
+            // 필터 조건과 선택 인자를 사용해 경로의 데이터 존재 여부를 검증한다.
             val testDialect = currentDialectTest
             if (testDialect is PostgreSQLDialect) {
                 /**
-                 * Postgres:
+                 * Postgres 예:
                  * ```sql
                  * SELECT j_table.id
                  *   FROM j_table
@@ -493,7 +493,7 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
                 usersWithMaxLogin.single()[tester.id] shouldBeEqualTo newId
 
                 /**
-                 * Postgres:
+                 * Postgres 예:
                  * ```sql
                  * SELECT j_table.id
                  *   FROM j_table
@@ -547,7 +547,7 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
              * SELECT JSON_UNQUOTE(JSON_EXTRACT(j_arrays.numbers, "$[0]")) FROM j_arrays;
              * ```
              */
-            // older MySQL and MariaDB versions require non-scalar extracted value from JSON Array
+            // 오래된 MySQL 및 MariaDB 버전은 JSON 배열에서 추출한 비스칼라 값 형식이 필요하다.
             val toScala = testDB != TestDB.MYSQL_V5
             val path2 = if (currentDialectTest is PostgreSQLDialect) "0" else "[0]"
             val firstNumber = JsonArrayTable.numbers.extract<Int>(path2, toScalar = toScala)
@@ -755,7 +755,7 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
                 SchemaUtils.create(defaultTester)
                 defaultTester.exists().shouldBeTrue()
 
-                // ensure defaults match returned metadata defaults
+                // 반환된 메타데이터의 기본값과 선언한 기본값이 일치하는지 검증한다.
                 // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
                 // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
                 val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
@@ -806,7 +806,7 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
         }
 
         withTables(testDB, iterables) {
-            // the logger is left in to test that it does not throw ClassCastException on insertion of iterables
+            // Iterable 값을 삽입할 때 ClassCastException이 발생하지 않는지 검증하려고 logger를 남겨 둔다.
             addLogger(StdOutSqlLogger)
 
             val user1 = User("A", "Team A")
@@ -958,7 +958,7 @@ class Ex01_JsonColumn: AbstractExposedJsonTest() {
             val value = json<User>("value", Json.Default).databaseGenerated()
         }
 
-        // MySQL versions prior to 8.0.13 do not accept default values on JSON columns
+        // MySQL 8.0.13 이전 버전은 JSON 컬럼 기본값을 허용하지 않는다.
         withTables(testDB, tester) {
             testerDatabaseGenerated.insert { }
 

--- a/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/Ex02_JsonBColumn.kt
+++ b/06-advanced/04-exposed-json/src/test/kotlin/exposed/examples/json/Ex02_JsonBColumn.kt
@@ -71,7 +71,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
      * JSONB 컬럼 생성 및 조회 테스트
      *
      * ```sql
-     * -- Postgres:
+     * -- Postgres 예:
      * INSERT INTO j_b_table (j_b_column)
      * VALUES ({"user":{"name":"Pro","team":"Alpha"},"logins":999,"active":true,"team":"A"});
      *
@@ -95,10 +95,10 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
     }
 
     /**
-     * Update JSONB column
+     * JSONB 컬럼 값을 갱신한다.
      *
      * ```sql
-     * -- Postgres:
+     * -- Postgres 예:
      * UPDATE j_b_table
      *   SET j_b_column={"user":{"name":"Admin","team":null},"logins":10,"active":false,"team":null}
      * ```
@@ -130,7 +130,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
 
         withJsonBTable(testDB) { tester, user1, data1 ->
             val pathPrefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
-            // SQLServer & Oracle return null if extracted JSON is not scalar
+            // SQLServer와 Oracle은 추출된 JSON 값이 스칼라가 아니면 null을 반환한다.
             val requiresScalar = currentDialectTest is SQLServerDialect || currentDialectTest is OracleDialect
 
             /**
@@ -194,7 +194,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
                 it[JsonBTable.jsonBColumn] = data1.copy(logins = 1000)
             }
 
-            // Postgres requires type casting to compare json field as integer value in DB
+            // Postgres는 json 필드를 DB 내부에서 정수 값으로 비교하려면 타입 캐스팅이 필요하다.
             val logins = when (currentDialectTest) {
                 is PostgreSQLDialect ->
                     JsonBTable.jsonBColumn.extract<Int>("logins").castTo(IntegerColumnType())
@@ -205,12 +205,12 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
 
             /**
              * ```sql
-             * -- Postgres:
+             * -- Postgres 예:
              * SELECT j_b_table.id
              *   FROM j_b_table
              *  WHERE CAST(JSONB_EXTRACT_PATH_TEXT(j_b_table.j_b_column, 'logins') AS INT) >= 1000;
              *
-             * -- MySQL V8:
+             * -- MySQL V8 예:
              * SELECT j_b_table.id
              *   FROM j_b_table
              *  WHERE JSON_UNQUOTE(JSON_EXTRACT(j_b_table.j_b_column, "$.logins")) >= 1000;
@@ -234,8 +234,8 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
 
         withDb(testDB) {
             expectException<SerializationException> {
-                // Throws with message: Serializer for class 'Fake' is not found.
-                // Please ensure that class is marked as '@Serializable' and that the serialization compiler plugin is applied.
+                // 다음 메시지로 예외가 발생한다: Serializer for class 'Fake' is not found.
+                // 해당 클래스에 '@Serializable'을 지정하고 serialization compiler plugin이 적용되었는지 확인해야 한다.
                 object: Table("tester") {
                     val jCol = jsonb<Fake>("J_col", Json)
                 }
@@ -256,7 +256,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
 
         withTables(testDB, dataTable) {
             /**
-             * Insert new entity
+             * 새 엔티티를 삽입한다.
              * ```sql
              * INSERT INTO j_b_table (j_b_column)
              * VALUES ({"user":{"name":"Admin","team":"Alpha"},"logins":10,"active":true,"team":null})
@@ -273,10 +273,10 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
             dataEntity.findById(-1).shouldBeNull()
 
             /**
-             * Update by DSL
+             * DSL 방식으로 값을 갱신한다.
              *
              * ```sql
-             * -- Postgres:
+             * -- Postgres 예:
              * UPDATE j_b_table
              *   SET j_b_column={"user":{"name":"Lead","team":"Beta"},"logins":10,"active":true,"team":null}
              * ```
@@ -288,11 +288,11 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
 
             dataEntity.all().single().jsonBColumn shouldBeEqualTo updatedJson
 
-            // Json Path
+            // JSON 경로 조건을 검증한다.
             Assumptions.assumeTrue { testDB !in TestDB.ALL_H2 }
 
             /**
-             * Insert new entity
+             * 새 엔티티를 삽입한다.
              *
              * ```sql
              * INSERT INTO j_b_table (j_b_column)
@@ -307,12 +307,12 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
 
             /**
              * ```sql
-             * -- Postgres:
+             * -- Postgres 예:
              * SELECT j_b_table.id, j_b_table.j_b_column
              *   FROM j_b_table
              *  WHERE JSONB_EXTRACT_PATH_TEXT(j_b_table.j_b_column, 'user', 'team') LIKE 'B%';
              *
-             * -- MySQL V8:
+             * -- MySQL V8 예:
              * SELECT j_b_table.id, j_b_table.j_b_column
              *   FROM j_b_table
              *  WHERE JSON_UNQUOTE(JSON_EXTRACT(j_b_table.j_b_column, "$.user.team")) LIKE 'B%';
@@ -329,7 +329,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
      * JSONB 컬럼의 객체 내부의 속성을 잉용하여 검색하는 테스트
      *
      * ```sql
-     * -- Postgres:
+     * -- Postgres 예:
      * SELECT j_b_table.id, j_b_table.j_b_column
      *   FROM j_b_table
      *  WHERE j_b_table.j_b_column @> '{"active":false}';
@@ -339,7 +339,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
      *  WHERE j_b_table.j_b_column @> '{"user":{"name":"Admin","team":"Alpha"}}';
      * ```
      * ```sql
-     * -- MySQL V8:
+     * -- MySQL V8 예:
      * SELECT j_b_table.id, j_b_table.j_b_column
      *   FROM j_b_table
      *  WHERE JSON_CONTAINS(j_b_table.j_b_column, '{"active":false}');
@@ -372,7 +372,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
             val userIsInAlphaTeam = JsonBTable.jsonBColumn.contains(stringLiteral(alphaTreamUserAsJson))
             tester.selectAll().where { userIsInAlphaTeam }.count() shouldBeEqualTo 1L
 
-            // test target contains candidate at specified path
+            // 지정한 경로의 대상 JSON이 후보 값을 포함하는지 검증한다.
             if (testDB in TestDB.ALL_MYSQL_LIKE) {
                 // Path 를 이용하여 특정 필드를 비교할 수 있습니다.
                 val userIsInAlphaTeam2 = JsonBTable.jsonBColumn.contains("\"Alpha\"", path = ".user.team")
@@ -396,7 +396,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
 
             /**
              * ```sql
-             * -- Postgres:
+             * -- Postgres 예:
              * INSERT INTO j_b_table (j_b_column)
              * VALUES ({"user":{"name":"Admin","team":"A"},"logins":1000,"active":true,"team":null})
              * ```
@@ -407,19 +407,19 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
 
             /**
              * ```sql
-             * -- Postgres:
+             * -- Postgres 예:
              * SELECT COUNT(*) FROM j_b_table WHERE JSONB_PATH_EXISTS(j_b_table.j_b_column, '$')
              * ```
              */
             val optional = if (testDB in TestDB.ALL_MYSQL_LIKE) "one" else null
 
-            // test data at path root `$` exists by providing no path arguments
+            // 경로 인자를 전달하지 않아 루트 경로 `$`의 데이터 존재 여부를 검증한다.
             val hasAnyData = JsonBTable.jsonBColumn.exists(optional = optional)
             tester.selectAll().where { hasAnyData }.count() shouldBeEqualTo 2L
 
             /**
              * ```sql
-             * -- Postgres:
+             * -- Postgres 예:
              * SELECT COUNT(*)
              *   FROM j_b_table
              *  WHERE JSONB_PATH_EXISTS(j_b_table.j_b_column, '$.fakeKey')
@@ -430,7 +430,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
 
             /**
              * ```sql
-             * -- Postgres:
+             * -- Postgres 예:
              * SELECT COUNT(*)
              *   FROM j_b_table
              *  WHERE JSONB_PATH_EXISTS(j_b_table.j_b_column, '$.logins')
@@ -439,12 +439,12 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
             val hasLogins = JsonBTable.jsonBColumn.exists(".logins", optional = optional)
             tester.selectAll().where { hasLogins }.count() shouldBeEqualTo 2L
 
-            // test data at path exists with filter condition & optional arguments
+            // 필터 조건과 선택 인자를 사용해 경로의 데이터 존재 여부를 검증한다.
             val testDialect = currentDialectTest
             if (testDialect is PostgreSQLDialect) {
                 /**
                  * ```sql
-                 * -- Postgres:
+                 * -- Postgres 예:
                  * SELECT j_b_table.id
                  *   FROM j_b_table
                  *  WHERE JSONB_PATH_EXISTS(j_b_table.j_b_column, '$.logins ? (@ == 1000)')
@@ -457,7 +457,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
 
                 /**
                  * ```sql
-                 * -- Postgres:
+                 * -- Postgres 예:
                  * SELECT j_b_table.id
                  *   FROM j_b_table
                  *  WHERE JSONB_PATH_EXISTS(j_b_table.j_b_column, '$.user.team ? (@ == $team)', '{"team":"A"}')
@@ -476,7 +476,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
      * JSONB 컬럼에 Array 데이터를 저장하고 검색하는 테스트
      *
      * ```sql
-     * -- Postgres:
+     * -- Postgres 예:
      * SELECT j_b_arrays.id, j_b_arrays."groups", j_b_arrays.numbers
      *   FROM j_b_arrays
      *  WHERE JSONB_EXTRACT_PATH_TEXT(j_b_arrays."groups", 'users', '0', 'team') = 'Team A';
@@ -485,7 +485,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
      * ```
      *
      * ```sql
-     * -- Postgres:
+     * -- Postgres 예:
      * SELECT j_b_arrays.id, j_b_arrays.`groups`, j_b_arrays.numbers
      *   FROM j_b_arrays
      *  WHERE JSON_UNQUOTE(JSON_EXTRACT(j_b_arrays.`groups`, "$.users[0].team")) = 'Team A';
@@ -508,7 +508,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
                 .where { firstIsOnTeamA }
                 .single()[tester.id] shouldBeEqualTo singleId
 
-            // older MySQL and MariaDB versions require non-scalar extracted value from JSON Array
+            // 오래된 MySQL 및 MariaDB 버전은 JSON 배열에서 추출한 비스칼라 값 형식이 필요하다.
             val toScala = testDB != TestDB.MYSQL_V5
             val path2 = if (currentDialectTest is PostgreSQLDialect) "0" else "[0]"
             val firstNumber = JsonBArrayTable.numbers.extract<Int>(path2, toScalar = toScala)
@@ -568,12 +568,12 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
 
             /**
              * ```sql
-             * -- Postgres:
+             * -- Postgres 예:
              * SELECT j_b_arrays.id, j_b_arrays."groups", j_b_arrays.numbers
              *   FROM j_b_arrays
              *  WHERE JSONB_PATH_EXISTS(j_b_arrays."groups", '$.users[1]');
              *
-             * -- MySQL V8:
+             * -- MySQL V8 예:
              * SELECT j_b_arrays.id, j_b_arrays.`groups`, j_b_arrays.numbers
              *   FROM j_b_arrays
              *  WHERE JSON_CONTAINS_PATH(j_b_arrays.`groups`, 'one', '$.users[1]');
@@ -584,12 +584,12 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
 
             /**
              * ```sql
-             * -- Postgres:
+             * -- Postgres 예:
              * SELECT j_b_arrays.id, j_b_arrays."groups", j_b_arrays.numbers
              *   FROM j_b_arrays
              *  WHERE JSONB_PATH_EXISTS(j_b_arrays.numbers, '$[2]');
              *
-             * -- MySQL V8:
+             * -- MySQL V8 예:
              * SELECT j_b_arrays.id, j_b_arrays.`groups`, j_b_arrays.numbers
              *   FROM j_b_arrays
              *  WHERE JSON_CONTAINS_PATH(j_b_arrays.numbers, 'one', '$[2]');
@@ -607,9 +607,9 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
         // MariaDB: JSONB(JSON) 컬럼 default 메타데이터가 declared schema와 round-trip되지 않아 migration diff 발생 → 스킵
         Assumptions.assumeFalse { testDB == TestDB.MARIADB }
         /**
-         * Default value for JSON column
+         * JSON 컬럼 기본값을 검증한다.
          * ```sql
-         * -- Postgres:
+         * -- Postgres 예:
          * CREATE TABLE IF NOT EXISTS default_tester (
          *      user_1 JSONB DEFAULT '{"name":"UNKNOWN","team":"UNASSIGNED"}'::jsonb NOT NULL,
          *      user_2 JSONB NOT NULL
@@ -631,7 +631,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
                 SchemaUtils.create(defaultTester)
                 defaultTester.exists().shouldBeTrue()
 
-                // ensure defaults match returned metadata defaults
+                // 반환된 메타데이터의 기본값과 선언한 기본값이 일치하는지 검증한다.
                 // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
                 // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
                 val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
@@ -640,7 +640,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
                 /**
                  * Client default 값이므로, Insert 시에는 값이 제공된다.
                  * ```sql
-                 * -- Postgres:
+                 * -- Postgres 예:
                  * INSERT INTO default_tester (user_2)
                  * VALUES ({"name":"UNKNOWN","team":"UNASSIGNED"})
                  */
@@ -681,7 +681,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
         }
 
         withTables(testDB, iterables) {
-            // the logger is left in to test that it does not throw ClassCastException on insertion of iterables
+            // Iterable 값을 삽입할 때 ClassCastException이 발생하지 않는지 검증하려고 logger를 남겨 둔다.
             addLogger(StdOutSqlLogger)
 
             val user1 = User("A", "Team A")
@@ -708,7 +708,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
      * JSONB 컬럼에 대한 NULL 값 테스트
      *
      * ```sql
-     * -- Postgres:
+     * -- Postgres 예:
      * CREATE TABLE IF NOT EXISTS nullable_tester (
      *      id SERIAL PRIMARY KEY,
      *      "user" JSONB NULL
@@ -750,14 +750,14 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
      * JSONB 컬럼에 대한 UPSERT 테스트
      *
      * ```sql
-     * -- Postgres:
+     * -- Postgres 예:
      * INSERT INTO j_b_table (id, j_b_column)
      * VALUES (2, {"user":{"name":"Pro","team":"Alpha"},"logins":999,"active":false,"team":"A"})
      * ON CONFLICT (id) DO UPDATE SET j_b_column=EXCLUDED.j_b_column;
      * ```
      *
      * ```sql
-     * -- MySQL V8:
+     * -- MySQL V8 예:
      * INSERT INTO j_b_table (id, j_b_column)
      * VALUES (2, {"user":{"name":"Pro","team":"Alpha"},"logins":999,"active":false,"team":"A"})
      * AS NEW ON DUPLICATE KEY UPDATE id=NEW.id, j_b_column=NEW.j_b_column;
@@ -833,7 +833,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
             val value = jsonb<User>("value", Json.Default).databaseGenerated()
         }
 
-        // MySQL versions prior to 8.0.13 do not accept default values on JSON columns
+        // MySQL 8.0.13 이전 버전은 JSON 컬럼 기본값을 허용하지 않는다.
         withTables(testDB, tester) {
             testerDatabaseGenerated.insert { }
 
@@ -853,7 +853,7 @@ class Ex02_JsonBColumn: AbstractExposedJsonTest() {
      * **단, Postgres 에서만 사용 가능합니다.**
      *
      * ```sql
-     * -- Postgres:
+     * -- Postgres 예:
      *
      * SELECT j_b_table.id, j_b_table.j_b_column
      *   FROM j_b_table

--- a/06-advanced/05-exposed-money/build.gradle.kts
+++ b/06-advanced/05-exposed-money/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     testImplementation(libs.jetbrains.exposed.jdbc)
     testImplementation(libs.exposed.core)
 
-    // Money
+    // 금액/통화 타입 예제를 위한 JSR 354 의존성
     testImplementation(libs.jetbrains.exposed.money)
     testImplementation(libs.javax.money.api)
     testImplementation(libs.javamoney.moneta)
@@ -29,14 +29,14 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Jdbc Drivers
+    // 테스트 데이터베이스별 JDBC 드라이버 의존성
     testRuntimeOnly(libs.h2.v2)
     testRuntimeOnly(libs.mariadb.java.client)
     testRuntimeOnly(libs.mysql.connector.j)
     testRuntimeOnly(libs.postgresql.driver)
     testRuntimeOnly(libs.pgjdbc.ng)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/06-advanced/05-exposed-money/src/test/kotlin/exposed/examples/money/Ex02_Money.kt
+++ b/06-advanced/05-exposed-money/src/test/kotlin/exposed/examples/money/Ex02_Money.kt
@@ -288,7 +288,7 @@ class Ex02_Money: AbstractExposedTest() {
             result2[tester.nullableMoney.currency] shouldBeEqualTo currencyUnit
 
             /**
-             * manual composite columns should still accept composite values
+             * 수동으로 선언한 복합 컬럼도 복합 값을 정상적으로 받아야 한다.
              *
              * ```sql
              * INSERT INTO tester (amount, currency, nullable_amount, nullable_currency)
@@ -308,7 +308,7 @@ class Ex02_Money: AbstractExposedTest() {
             }
 
             /**
-             * Search by composite column
+             * 복합 컬럼 값으로 행을 검색한다.
              *
              * ```sql
              * SELECT COUNT(*) FROM tester

--- a/06-advanced/06-custom-columns/build.gradle.kts
+++ b/06-advanced/06-custom-columns/build.gradle.kts
@@ -13,12 +13,12 @@ dependencies {
 
     implementation(libs.bluetape4k.io)
 
-    // Compression
+    // 압축 컬럼 타입 예제를 위한 압축 의존성
     testRuntimeOnly(libs.lz4.java)
     testRuntimeOnly(libs.snappy.java)
     testRuntimeOnly(libs.zstd.jni)
 
-    // Serialization
+    // 사용자 정의 컬럼 직렬화를 위한 Kotlin Serialization 의존성
     testRuntimeOnly(libs.kryo)
     testRuntimeOnly(libs.fory.kotlin)
 
@@ -34,14 +34,14 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Jdbc Drivers
+    // 테스트 데이터베이스별 JDBC 드라이버 의존성
     testRuntimeOnly(libs.h2.v2)
     testRuntimeOnly(libs.mariadb.java.client)
     testRuntimeOnly(libs.mysql.connector.j)
     testRuntimeOnly(libs.postgresql.driver)
     testRuntimeOnly(libs.pgjdbc.ng)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/06-advanced/07-custom-entities/build.gradle.kts
+++ b/06-advanced/07-custom-entities/build.gradle.kts
@@ -15,10 +15,10 @@ dependencies {
     testImplementation(libs.jetbrains.exposed.dao)
     testImplementation(libs.exposed.core)
 
-    // Id Generators
-    // - Snowflake
-    // - Timebased UUID
-    // - Ksuids
+    // 사용자 정의 엔티티 ID 생성기 의존성
+    // - Snowflake 기반 정렬 가능 ID 생성기
+    // - 시간 기반 UUID 생성기
+    // - KSUID 기반 시간 정렬 ID 생성기
     // Identifier 자동 생성
     testImplementation(libs.bluetape4k.idgenerators)
 
@@ -30,14 +30,14 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Jdbc Drivers
+    // 테스트 데이터베이스별 JDBC 드라이버 의존성
     testRuntimeOnly(libs.h2.v2)
     testRuntimeOnly(libs.mariadb.java.client)
     testRuntimeOnly(libs.mysql.connector.j)
     testRuntimeOnly(libs.postgresql.driver)
     testRuntimeOnly(libs.pgjdbc.ng)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/06-advanced/08-exposed-jackson/build.gradle.kts
+++ b/06-advanced/08-exposed-jackson/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/06-advanced/08-exposed-jackson/src/test/kotlin/exposed/examples/jackson/JacksonBColumnTest.kt
+++ b/06-advanced/08-exposed-jackson/src/test/kotlin/exposed/examples/jackson/JacksonBColumnTest.kt
@@ -166,7 +166,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
                 it[jacksonBColumn] = data1.copy(logins = 1000)
             }
 
-            // Postgres requires type casting to compare jsonb field as integer value in DB ???
+            // Postgres는 jsonb 필드를 DB 내부에서 정수 값으로 비교하려면 타입 캐스팅이 필요하다.
             val logins = when (currentDialectTest) {
                 is PostgreSQLDialect ->
                     tester.jacksonBColumn.extract<Int>("logins").castTo(IntegerColumnType())
@@ -272,7 +272,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
             val userIsInAlphaTeam = tester.jacksonBColumn.contains(alphaTeamUserAsJson)
             tester.selectAll().where { userIsInAlphaTeam }.count() shouldBeEqualTo 1L
 
-            // test target contains candidate at specified path
+            // 지정한 경로의 대상 JSON이 후보 값을 포함하는지 검증한다.
             if (testDB in TestDB.ALL_MYSQL_MARIADB) {
                 val userIsInAlphaTeam2 = tester.jacksonBColumn.contains("\"Alpha\"", ".user.team")
                 val alphaTeamUsers = tester.select(tester.id).where { userIsInAlphaTeam2 }
@@ -295,7 +295,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
 
             val optional = if (testDB in TestDB.ALL_MYSQL_LIKE) "one" else null
 
-            // test data at path root '$' exists by providing no path arguments
+            // 경로 인자를 전달하지 않아 루트 경로 '$'의 데이터 존재 여부를 검증한다.
             // SELECT COUNT(*) FROM jackson_b_table WHERE JSONB_PATH_EXISTS(jackson_b_table.jackson_b_column, '$')
             val hasAnyData = tester.jacksonBColumn.exists(optional = optional)
             tester.selectAll().where { hasAnyData }.count() shouldBeEqualTo 2L
@@ -308,7 +308,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
             val hasLogins = tester.jacksonBColumn.exists(".logins", optional = optional)
             tester.selectAll().where { hasLogins }.count() shouldBeEqualTo 2L
 
-            // test data at path exists with filter condition & optional arguments
+            // 필터 조건과 선택 인자를 사용해 경로의 데이터 존재 여부를 검증한다.
             if (currentDialectTest is PostgreSQLDialect) {
                 // SELECT jackson_b_table.id FROM jackson_b_table
                 //  WHERE JSONB_PATH_EXISTS(jackson_b_table.jackson_b_column, '$.logins ? (@ == 1000)')
@@ -359,7 +359,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
             val firstIsOnTeamA = tester.groups.extract<String>(*path1) eq "Team A"
             tester.selectAll().where { firstIsOnTeamA }.single()[tester.id] shouldBeEqualTo singleId
 
-            // older MySQL and MariaDB versions require non-scalar extracted value from JSON Array
+            // 오래된 MySQL 및 MariaDB 버전은 JSON 배열에서 추출한 비스칼라 값 형식이 필요하다.
             val toScalar = testDB != TestDB.MYSQL_V5
             val path2 = when (currentDialectTest) {
                 is PostgreSQLDialect -> "0"
@@ -460,7 +460,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
                 SchemaUtils.create(defaultTester)
                 defaultTester.exists().shouldBeTrue()
 
-                // ensure defaults match returned metadata defaults
+                // 반환된 메타데이터의 기본값과 선언한 기본값이 일치하는지 검증한다.
                 // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
                 // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
                 val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
@@ -492,7 +492,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
         }
 
         withTables(testDB, iterables) {
-            // the logger is left in to test that it does not throw ClassCastException on insertion of iterables
+            // Iterable 값을 삽입할 때 ClassCastException이 발생하지 않는지 검증하려고 logger를 남겨 둔다.
             addLogger(StdOutSqlLogger)
 
             val user1 = User("A", "Team A")
@@ -594,7 +594,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
             val value = jacksonb<User>("value").databaseGenerated()
         }
 
-        // MySQL versions prior to 8.0.13 do not accept default values on JSON columns
+        // MySQL 8.0.13 이전 버전은 JSON 컬럼 기본값을 허용하지 않는다.
         Assumptions.assumeTrue { testDB != TestDB.MYSQL_V5 }
         withTables(testDB, tester) {
             testerDatabaseGenerated.insert { }

--- a/06-advanced/08-exposed-jackson/src/test/kotlin/exposed/examples/jackson/JacksonColumnTest.kt
+++ b/06-advanced/08-exposed-jackson/src/test/kotlin/exposed/examples/jackson/JacksonColumnTest.kt
@@ -127,7 +127,7 @@ class JacksonColumnTest: AbstractExposedTest() {
         withJacksonTable(testDB) { tester, user1, data1 ->
             val pathPrefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
 
-            // SQLServer & Oracle return null if extracted JSON is not scalar
+            // SQLServer와 Oracle은 추출된 JSON 값이 스칼라가 아니면 null을 반환한다.
             val requiresScala = currentDialectTest is SQLServerDialect || currentDialectTest is OracleDialect
             val isActive = tester.jacksonColumn.extract<Boolean>("${pathPrefix}active", toScalar = requiresScala)
             val row = tester.select(isActive).singleOrNull()
@@ -170,7 +170,7 @@ class JacksonColumnTest: AbstractExposedTest() {
                 it[jacksonColumn] = data1.copy(logins = 1000)
             }
 
-            // Postgres requires type casting to compare json field as integer value in DB
+            // Postgres는 json 필드를 DB 내부에서 정수 값으로 비교하려면 타입 캐스팅이 필요하다.
             val logins = when (currentDialectTest) {
                 is PostgreSQLDialect -> tester.jacksonColumn.extract<Int>("logins").castTo(IntegerColumnType())
                 else -> tester.jacksonColumn.extract<Int>(".logins")
@@ -292,7 +292,7 @@ class JacksonColumnTest: AbstractExposedTest() {
             var userIsInAlphaTeam = tester.jacksonColumn.contains(stringLiteral(alphaTeamUserAsJson))
             tester.selectAll().where { userIsInAlphaTeam }.count() shouldBeEqualTo 1L
 
-            // test target contains candidate at specified path
+            // 지정한 경로의 대상 JSON이 후보 값을 포함하는지 검증한다.
             if (testDB in TestDB.ALL_MYSQL_LIKE) {
                 userIsInAlphaTeam = tester.jacksonColumn.contains("\"Alpha\"", ".user.team")
                 val alphaTeamUsers = tester.select(tester.id).where { userIsInAlphaTeam }
@@ -338,7 +338,7 @@ class JacksonColumnTest: AbstractExposedTest() {
 
             val optional = if (testDB in TestDB.ALL_MYSQL_LIKE) "one" else null
 
-            // test data at path root '$' exists by providing no path arguments
+            // 경로 인자를 전달하지 않아 루트 경로 '$'의 데이터 존재 여부를 검증한다.
             val hasAnyData = tester.jacksonColumn.exists(optional = optional)
             tester.selectAll().where { hasAnyData }.count() shouldBeEqualTo 2L
 
@@ -350,7 +350,7 @@ class JacksonColumnTest: AbstractExposedTest() {
             val hasLogins = tester.jacksonColumn.exists(".logins", optional = optional)
             tester.selectAll().where { hasLogins }.count() shouldBeEqualTo 2L
 
-            // test data at path exists with filter condition & optional arguments
+            // 필터 조건과 선택 인자를 사용해 경로의 데이터 존재 여부를 검증한다.
             val testDialect = currentDialectTest
             if (testDialect is OracleDialect || testDialect is SQLServerDialect) {
                 val filterPath = when (testDialect) {
@@ -404,7 +404,7 @@ class JacksonColumnTest: AbstractExposedTest() {
             val firstIsOnTeamA = tester.groups.extract<String>(*path1) eq "Team A"
             tester.selectAll().where { firstIsOnTeamA }.single()[tester.id] shouldBeEqualTo singleId
 
-            // older MySQL and MariaDB versions require non-scalar extracted value from JSON Array
+            // 오래된 MySQL 및 MariaDB 버전은 JSON 배열에서 추출한 비스칼라 값 형식이 필요하다.
             val toScalar = testDB != TestDB.MYSQL_V5
             val path2 = when (currentDialectTest) {
                 is PostgreSQLDialect -> "0"
@@ -581,7 +581,7 @@ class JacksonColumnTest: AbstractExposedTest() {
                 SchemaUtils.create(defaultTester)
                 defaultTester.exists().shouldBeTrue()
 
-                // ensure defaults match returned metadata defaults
+                // 반환된 메타데이터의 기본값과 선언한 기본값이 일치하는지 검증한다.
                 // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
                 // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
                 val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
@@ -613,7 +613,7 @@ class JacksonColumnTest: AbstractExposedTest() {
         }
 
         withTables(testDB, iterables) {
-            // the logger is left in to test that it does not throw ClassCastException on insertion of iterables
+            // Iterable 값을 삽입할 때 ClassCastException이 발생하지 않는지 검증하려고 logger를 남겨 둔다.
             addLogger(StdOutSqlLogger)
 
             val user1 = User("A", "Team A")
@@ -738,7 +738,7 @@ class JacksonColumnTest: AbstractExposedTest() {
             val value = jackson<User>("value").databaseGenerated()
         }
 
-        // MySQL versions prior to 8.0.13 do not accept default values on JSON columns
+        // MySQL 8.0.13 이전 버전은 JSON 컬럼 기본값을 허용하지 않는다.
         Assumptions.assumeTrue { testDB != TestDB.MYSQL_V5 }
         withTables(testDB, tester) {
             testerDatabaseGenerated.insert { }

--- a/06-advanced/09-exposed-fastjson2/build.gradle.kts
+++ b/06-advanced/09-exposed-fastjson2/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/06-advanced/09-exposed-fastjson2/src/test/kotlin/exposed/examples/fastjson2/FastjsonBColumnTest.kt
+++ b/06-advanced/09-exposed-fastjson2/src/test/kotlin/exposed/examples/fastjson2/FastjsonBColumnTest.kt
@@ -166,7 +166,7 @@ class FastjsonBColumnTest: AbstractExposedTest() {
                 it[fastjsonBColumn] = data1.copy(logins = 1000)
             }
 
-            // Postgres requires type casting to compare jsonb field as integer value in DB ???
+            // Postgres는 jsonb 필드를 DB 내부에서 정수 값으로 비교하려면 타입 캐스팅이 필요하다.
             val logins = when (currentDialectTest) {
                 is PostgreSQLDialect ->
                     tester.fastjsonBColumn.extract<Int>("logins").castTo(IntegerColumnType())
@@ -272,7 +272,7 @@ class FastjsonBColumnTest: AbstractExposedTest() {
             val userIsInAlphaTeam = tester.fastjsonBColumn.contains(alphaTeamUserAsJson)
             tester.selectAll().where { userIsInAlphaTeam }.count() shouldBeEqualTo 1L
 
-            // test target contains candidate at specified path
+            // 지정한 경로의 대상 JSON이 후보 값을 포함하는지 검증한다.
             if (testDB in TestDB.ALL_MYSQL_MARIADB) {
                 val userIsInAlphaTeam2 = tester.fastjsonBColumn.contains("\"Alpha\"", ".user.team")
                 val alphaTeamUsers = tester.select(tester.id).where { userIsInAlphaTeam2 }
@@ -295,7 +295,7 @@ class FastjsonBColumnTest: AbstractExposedTest() {
 
             val optional = if (testDB in TestDB.ALL_MYSQL_LIKE) "one" else null
 
-            // test data at path root '$' exists by providing no path arguments
+            // 경로 인자를 전달하지 않아 루트 경로 '$'의 데이터 존재 여부를 검증한다.
             // SELECT COUNT(*) FROM fastjson_b_table WHERE JSONB_PATH_EXISTS(fastjson_b_table.fastjson_b_column, '$')
             val hasAnyData = tester.fastjsonBColumn.exists(optional = optional)
             tester.selectAll().where { hasAnyData }.count() shouldBeEqualTo 2L
@@ -308,7 +308,7 @@ class FastjsonBColumnTest: AbstractExposedTest() {
             val hasLogins = tester.fastjsonBColumn.exists(".logins", optional = optional)
             tester.selectAll().where { hasLogins }.count() shouldBeEqualTo 2L
 
-            // test data at path exists with filter condition and optional arguments
+            // 필터 조건과 선택 인자를 사용해 경로의 데이터 존재 여부를 검증한다.
             if (currentDialectTest is PostgreSQLDialect) {
                 // SELECT fastjson_b_table.id FROM fastjson_b_table
                 //  WHERE JSONB_PATH_EXISTS(fastjson_b_table.fastjson_b_column, '$.logins ? (@ == 1000)')
@@ -359,7 +359,7 @@ class FastjsonBColumnTest: AbstractExposedTest() {
             val firstIsOnTeamA = tester.groups.extract<String>(*path1) eq "Team A"
             tester.selectAll().where { firstIsOnTeamA }.single()[tester.id] shouldBeEqualTo singleId
 
-            // older MySQL and MariaDB versions require non-scalar extracted value from JSON Array
+            // 오래된 MySQL 및 MariaDB 버전은 JSON 배열에서 추출한 비스칼라 값 형식이 필요하다.
             val toScalar = testDB != TestDB.MYSQL_V5
             val path2 = when (currentDialectTest) {
                 is PostgreSQLDialect -> "0"
@@ -460,7 +460,7 @@ class FastjsonBColumnTest: AbstractExposedTest() {
                 SchemaUtils.create(defaultTester)
                 defaultTester.exists().shouldBeTrue()
 
-                // ensure defaults match returned metadata defaults
+                // 반환된 메타데이터의 기본값과 선언한 기본값이 일치하는지 검증한다.
                 // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
                 // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
                 val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
@@ -492,7 +492,7 @@ class FastjsonBColumnTest: AbstractExposedTest() {
         }
 
         withTables(testDB, iterables) {
-            // the logger is left in to test that it does not throw ClassCastException on insertion of iterables
+            // Iterable 값을 삽입할 때 ClassCastException이 발생하지 않는지 검증하려고 logger를 남겨 둔다.
             addLogger(StdOutSqlLogger)
 
             val user1 = User("A", "Team A")
@@ -594,7 +594,7 @@ class FastjsonBColumnTest: AbstractExposedTest() {
             val value = fastjsonb<User>("value").databaseGenerated()
         }
 
-        // MySQL versions prior to 8.0.13 do not accept default values on JSON columns
+        // MySQL 8.0.13 이전 버전은 JSON 컬럼 기본값을 허용하지 않는다.
         Assumptions.assumeTrue { testDB != TestDB.MYSQL_V5 }
         withTables(testDB, tester) {
             testerDatabaseGenerated.insert { }

--- a/06-advanced/09-exposed-fastjson2/src/test/kotlin/exposed/examples/fastjson2/FastjsonColumnTest.kt
+++ b/06-advanced/09-exposed-fastjson2/src/test/kotlin/exposed/examples/fastjson2/FastjsonColumnTest.kt
@@ -127,7 +127,7 @@ class FastjsonColumnTest: AbstractExposedTest() {
         withFastjsonTable(testDB) { tester, user1, data1 ->
             val pathPrefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
 
-            // SQLServer & Oracle return null if extracted JSON is not scalar
+            // SQLServer와 Oracle은 추출된 JSON 값이 스칼라가 아니면 null을 반환한다.
             val requiresScala = currentDialectTest is SQLServerDialect || currentDialectTest is OracleDialect
             val isActive = tester.fastjsonColumn.extract<Boolean>("${pathPrefix}active", toScalar = requiresScala)
             val row = tester.select(isActive).singleOrNull()
@@ -171,7 +171,7 @@ class FastjsonColumnTest: AbstractExposedTest() {
                 it[fastjsonColumn] = data1.copy(logins = 1000)
             }
 
-            // Postgres requires type casting to compare json field as integer value in DB
+            // Postgres는 json 필드를 DB 내부에서 정수 값으로 비교하려면 타입 캐스팅이 필요하다.
             val logins = when (currentDialectTest) {
                 is PostgreSQLDialect -> tester.fastjsonColumn.extract<Int>("logins").castTo(IntegerColumnType())
                 else -> tester.fastjsonColumn.extract<Int>(".logins")
@@ -341,7 +341,7 @@ class FastjsonColumnTest: AbstractExposedTest() {
 
             val optional = if (testDB in TestDB.ALL_MYSQL_LIKE) "one" else null
 
-            // test data at path root '$' exists by providing no path arguments
+            // 경로 인자를 전달하지 않아 루트 경로 '$'의 데이터 존재 여부를 검증한다.
             val hasAnyData = tester.fastjsonColumn.exists(optional = optional)
             tester.selectAll().where { hasAnyData }.count() shouldBeEqualTo 2L
 
@@ -353,7 +353,7 @@ class FastjsonColumnTest: AbstractExposedTest() {
             val hasLogins = tester.fastjsonColumn.exists(".logins", optional = optional)
             tester.selectAll().where { hasLogins }.count() shouldBeEqualTo 2L
 
-            // test data at path exists with filter condition and optional arguments
+            // 필터 조건과 선택 인자를 사용해 경로의 데이터 존재 여부를 검증한다.
             val testDialect = currentDialectTest
             if (testDialect is OracleDialect || testDialect is SQLServerDialect) {
                 val filterPath = when (testDialect) {
@@ -407,7 +407,7 @@ class FastjsonColumnTest: AbstractExposedTest() {
             val firstIsOnTeamA = tester.groups.extract<String>(*path1) eq "Team A"
             tester.selectAll().where { firstIsOnTeamA }.single()[tester.id] shouldBeEqualTo singleId
 
-            // older MySQL and MariaDB versions require non-scalar extracted value from JSON Array
+            // 오래된 MySQL 및 MariaDB 버전은 JSON 배열에서 추출한 비스칼라 값 형식이 필요하다.
             val toScalar = testDB != TestDB.MYSQL_V5
             val path2 = when (currentDialectTest) {
                 is PostgreSQLDialect -> "0"
@@ -584,7 +584,7 @@ class FastjsonColumnTest: AbstractExposedTest() {
                 SchemaUtils.create(defaultTester)
                 defaultTester.exists().shouldBeTrue()
 
-                // ensure defaults match returned metadata defaults
+                // 반환된 메타데이터의 기본값과 선언한 기본값이 일치하는지 검증한다.
                 // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
                 // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
                 val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
@@ -616,7 +616,7 @@ class FastjsonColumnTest: AbstractExposedTest() {
         }
 
         withTables(testDB, iterables) {
-            // the logger is left in to test that it does not throw ClassCastException on insertion of iterables
+            // Iterable 값을 삽입할 때 ClassCastException이 발생하지 않는지 검증하려고 logger를 남겨 둔다.
             addLogger(StdOutSqlLogger)
 
             val user1 = User("A", "Team A")
@@ -741,7 +741,7 @@ class FastjsonColumnTest: AbstractExposedTest() {
             val value = fastjson<User>("value").databaseGenerated()
         }
 
-        // MySQL versions prior to 8.0.13 do not accept default values on JSON columns
+        // MySQL 8.0.13 이전 버전은 JSON 컬럼 기본값을 허용하지 않는다.
         Assumptions.assumeTrue { testDB != TestDB.MYSQL_V5 }
         withTables(testDB, tester) {
             testerDatabaseGenerated.insert { }

--- a/06-advanced/11-exposed-jackson3/build.gradle.kts
+++ b/06-advanced/11-exposed-jackson3/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     testImplementation(libs.exposed.core)
     testImplementation(libs.exposed.jackson3)
 
-    // Jackson 3
+    // Jackson 3 JSON 컬럼 직렬화 의존성
     testImplementation(libs.bluetape4k.jackson3)
     testImplementation(libs.jackson3.module.kotlin)
     testImplementation(libs.jackson3.module.blackbird)
@@ -33,7 +33,7 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/06-advanced/11-exposed-jackson3/src/test/kotlin/exposed/examples/jackson3/JacksonBColumnTest.kt
+++ b/06-advanced/11-exposed-jackson3/src/test/kotlin/exposed/examples/jackson3/JacksonBColumnTest.kt
@@ -166,7 +166,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
                 it[jacksonBColumn] = data1.copy(logins = 1000)
             }
 
-            // Postgres requires type casting to compare jsonb field as integer value in DB ???
+            // Postgres는 jsonb 필드를 DB 내부에서 정수 값으로 비교하려면 타입 캐스팅이 필요하다.
             val logins = when (currentDialectTest) {
                 is PostgreSQLDialect ->
                     tester.jacksonBColumn.extract<Int>("logins").castTo(IntegerColumnType())
@@ -272,7 +272,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
             val userIsInAlphaTeam = tester.jacksonBColumn.contains(alphaTeamUserAsJson)
             tester.selectAll().where { userIsInAlphaTeam }.count() shouldBeEqualTo 1L
 
-            // test target contains candidate at specified path
+            // 지정한 경로의 대상 JSON이 후보 값을 포함하는지 검증한다.
             if (testDB in TestDB.ALL_MYSQL_MARIADB) {
                 val userIsInAlphaTeam2 = tester.jacksonBColumn.contains("\"Alpha\"", ".user.team")
                 val alphaTeamUsers = tester.select(tester.id).where { userIsInAlphaTeam2 }
@@ -295,7 +295,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
 
             val optional = if (testDB in TestDB.ALL_MYSQL_LIKE) "one" else null
 
-            // test data at path root '$' exists by providing no path arguments
+            // 경로 인자를 전달하지 않아 루트 경로 '$'의 데이터 존재 여부를 검증한다.
             // SELECT COUNT(*) FROM jackson_b_table WHERE JSONB_PATH_EXISTS(jackson_b_table.jackson_b_column, '$')
             val hasAnyData = tester.jacksonBColumn.exists(optional = optional)
             tester.selectAll().where { hasAnyData }.count() shouldBeEqualTo 2L
@@ -308,7 +308,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
             val hasLogins = tester.jacksonBColumn.exists(".logins", optional = optional)
             tester.selectAll().where { hasLogins }.count() shouldBeEqualTo 2L
 
-            // test data at path exists with filter condition & optional arguments
+            // 필터 조건과 선택 인자를 사용해 경로의 데이터 존재 여부를 검증한다.
             if (currentDialectTest is PostgreSQLDialect) {
                 // SELECT jackson_b_table.id FROM jackson_b_table
                 //  WHERE JSONB_PATH_EXISTS(jackson_b_table.jackson_b_column, '$.logins ? (@ == 1000)')
@@ -359,7 +359,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
             val firstIsOnTeamA = tester.groups.extract<String>(*path1) eq "Team A"
             tester.selectAll().where { firstIsOnTeamA }.single()[tester.id] shouldBeEqualTo singleId
 
-            // older MySQL and MariaDB versions require non-scalar extracted value from JSON Array
+            // 오래된 MySQL 및 MariaDB 버전은 JSON 배열에서 추출한 비스칼라 값 형식이 필요하다.
             val toScalar = testDB != TestDB.MYSQL_V5
             val path2 = when (currentDialectTest) {
                 is PostgreSQLDialect -> "0"
@@ -460,7 +460,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
                 SchemaUtils.create(defaultTester)
                 defaultTester.exists().shouldBeTrue()
 
-                // ensure defaults match returned metadata defaults
+                // 반환된 메타데이터의 기본값과 선언한 기본값이 일치하는지 검증한다.
                 // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
                 // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
                 val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
@@ -492,7 +492,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
         }
 
         withTables(testDB, iterables) {
-            // the logger is left in to test that it does not throw ClassCastException on insertion of iterables
+            // Iterable 값을 삽입할 때 ClassCastException이 발생하지 않는지 검증하려고 logger를 남겨 둔다.
             addLogger(StdOutSqlLogger)
 
             val user1 = User("A", "Team A")
@@ -594,7 +594,7 @@ class JacksonBColumnTest: AbstractExposedTest() {
             val value = jacksonb<User>("value").databaseGenerated()
         }
 
-        // MySQL versions prior to 8.0.13 do not accept default values on JSON columns
+        // MySQL 8.0.13 이전 버전은 JSON 컬럼 기본값을 허용하지 않는다.
         Assumptions.assumeTrue { testDB != TestDB.MYSQL_V5 }
         withTables(testDB, tester) {
             testerDatabaseGenerated.insert { }

--- a/06-advanced/11-exposed-jackson3/src/test/kotlin/exposed/examples/jackson3/JacksonColumnTest.kt
+++ b/06-advanced/11-exposed-jackson3/src/test/kotlin/exposed/examples/jackson3/JacksonColumnTest.kt
@@ -127,7 +127,7 @@ class JacksonColumnTest: AbstractExposedTest() {
         withJacksonTable(testDB) { tester, user1, data1 ->
             val pathPrefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
 
-            // SQLServer & Oracle return null if extracted JSON is not scalar
+            // SQLServer와 Oracle은 추출된 JSON 값이 스칼라가 아니면 null을 반환한다.
             val requiresScala = currentDialectTest is SQLServerDialect || currentDialectTest is OracleDialect
             val isActive = tester.jacksonColumn.extract<Boolean>("${pathPrefix}active", toScalar = requiresScala)
             val row = tester.select(isActive).singleOrNull()
@@ -170,7 +170,7 @@ class JacksonColumnTest: AbstractExposedTest() {
                 it[jacksonColumn] = data1.copy(logins = 1000)
             }
 
-            // Postgres requires type casting to compare json field as integer value in DB
+            // Postgres는 json 필드를 DB 내부에서 정수 값으로 비교하려면 타입 캐스팅이 필요하다.
             val logins = when (currentDialectTest) {
                 is PostgreSQLDialect -> tester.jacksonColumn.extract<Int>("logins").castTo(IntegerColumnType())
                 else -> tester.jacksonColumn.extract<Int>(".logins")
@@ -292,7 +292,7 @@ class JacksonColumnTest: AbstractExposedTest() {
             var userIsInAlphaTeam = tester.jacksonColumn.contains(stringLiteral(alphaTeamUserAsJson))
             tester.selectAll().where { userIsInAlphaTeam }.count() shouldBeEqualTo 1L
 
-            // test target contains candidate at specified path
+            // 지정한 경로의 대상 JSON이 후보 값을 포함하는지 검증한다.
             if (testDB in TestDB.ALL_MYSQL_LIKE) {
                 userIsInAlphaTeam = tester.jacksonColumn.contains("\"Alpha\"", ".user.team")
                 val alphaTeamUsers = tester.select(tester.id).where { userIsInAlphaTeam }
@@ -338,7 +338,7 @@ class JacksonColumnTest: AbstractExposedTest() {
 
             val optional = if (testDB in TestDB.ALL_MYSQL_LIKE) "one" else null
 
-            // test data at path root '$' exists by providing no path arguments
+            // 경로 인자를 전달하지 않아 루트 경로 '$'의 데이터 존재 여부를 검증한다.
             val hasAnyData = tester.jacksonColumn.exists(optional = optional)
             tester.selectAll().where { hasAnyData }.count() shouldBeEqualTo 2L
 
@@ -350,7 +350,7 @@ class JacksonColumnTest: AbstractExposedTest() {
             val hasLogins = tester.jacksonColumn.exists(".logins", optional = optional)
             tester.selectAll().where { hasLogins }.count() shouldBeEqualTo 2L
 
-            // test data at path exists with filter condition & optional arguments
+            // 필터 조건과 선택 인자를 사용해 경로의 데이터 존재 여부를 검증한다.
             val testDialect = currentDialectTest
             if (testDialect is OracleDialect || testDialect is SQLServerDialect) {
                 val filterPath = when (testDialect) {
@@ -404,7 +404,7 @@ class JacksonColumnTest: AbstractExposedTest() {
             val firstIsOnTeamA = tester.groups.extract<String>(*path1) eq "Team A"
             tester.selectAll().where { firstIsOnTeamA }.single()[tester.id] shouldBeEqualTo singleId
 
-            // older MySQL and MariaDB versions require non-scalar extracted value from JSON Array
+            // 오래된 MySQL 및 MariaDB 버전은 JSON 배열에서 추출한 비스칼라 값 형식이 필요하다.
             val toScalar = testDB != TestDB.MYSQL_V5
             val path2 = when (currentDialectTest) {
                 is PostgreSQLDialect -> "0"
@@ -581,7 +581,7 @@ class JacksonColumnTest: AbstractExposedTest() {
                 SchemaUtils.create(defaultTester)
                 defaultTester.exists().shouldBeTrue()
 
-                // ensure defaults match returned metadata defaults
+                // 반환된 메타데이터의 기본값과 선언한 기본값이 일치하는지 검증한다.
                 // [deprecated] SchemaUtils.statementsRequiredToActualizeScheme → MigrationUtils.statementsRequiredForDatabaseMigration 로 교체
                 // val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
                 val alters = MigrationUtils.statementsRequiredForDatabaseMigration(defaultTester)
@@ -613,7 +613,7 @@ class JacksonColumnTest: AbstractExposedTest() {
         }
 
         withTables(testDB, iterables) {
-            // the logger is left in to test that it does not throw ClassCastException on insertion of iterables
+            // Iterable 값을 삽입할 때 ClassCastException이 발생하지 않는지 검증하려고 logger를 남겨 둔다.
             addLogger(StdOutSqlLogger)
 
             val user1 = User("A", "Team A")
@@ -738,7 +738,7 @@ class JacksonColumnTest: AbstractExposedTest() {
             val value = jackson<User>("value").databaseGenerated()
         }
 
-        // MySQL versions prior to 8.0.13 do not accept default values on JSON columns
+        // MySQL 8.0.13 이전 버전은 JSON 컬럼 기본값을 허용하지 않는다.
         Assumptions.assumeTrue { testDB != TestDB.MYSQL_V5 }
         withTables(testDB, tester) {
             testerDatabaseGenerated.insert { }

--- a/06-advanced/12-exposed-tink/build.gradle.kts
+++ b/06-advanced/12-exposed-tink/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)


### PR DESCRIPTION
## Summary
- Rewrites advanced Exposed module dependency comments and explanatory KDoc/comment prose in Korean.
- Preserves SQL/JSON examples, identifiers, dialect names, build coordinates, and exact exception text.

Closes #185

## Validation
- `git diff --check`
- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-184-korean-dml-comments --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `USE_FAST_DB=true ./gradlew :01-exposed-crypt:test :02-exposed-javatime:test :03-exposed-kotlin-datetime:test :04-exposed-json:test :05-exposed-money:test :06-custom-columns:test :07-custom-entities:test :08-exposed-jackson:test :09-exposed-fastjson2:test :11-exposed-jackson3:test :12-exposed-tink:test --no-daemon`

## DoD Status
- [x] Korean comments/KDoc applied to the issue scope.
- [x] Bilingual README/manual and LLM-facing operating docs untouched.
- [x] Local scope, whitespace, and targeted test validation passed.