### PR TITLE
Localize JPA migration and coroutine comments

### DIFF
--- a/07-jpa/01-convert-jpa-basic/build.gradle.kts
+++ b/07-jpa/01-convert-jpa-basic/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation(libs.jetbrains.exposed.jdbc)
     implementation(libs.jetbrains.exposed.java.time)
 
-    // Validator
+    // 입력값 검증 예제를 위한 Validator 의존성
     implementation(libs.jakarta.validation.api)
     implementation(libs.hibernate.validator)
 
@@ -35,7 +35,7 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제를 위한 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex01_simple/Ex02_Simple_DAO.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex01_simple/Ex02_Simple_DAO.kt
@@ -63,7 +63,7 @@ class Ex02_Simple_DAO : AbstractExposedTest() {
     }
 
     /**
-     * Unique index violation
+     * 고유 인덱스 위반이 발생하는 경로를 검증한다.
      */
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex01_simple/SimpleSchema.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex01_simple/SimpleSchema.kt
@@ -19,7 +19,7 @@ import java.io.Serializable
 object SimpleSchema {
 
     /**
-     * Table
+     * Exposed Table 매핑 정의이다.
      *
      * ```sql
      * -- Postgres
@@ -39,7 +39,7 @@ object SimpleSchema {
     }
 
     /**
-     * Entity
+     * Exposed DAO Entity 매핑 정의이다.
      */
     class SimpleEntity(id: EntityID<Long>): LongEntity(id) {
         companion object: LongEntityClass<SimpleEntity>(SimpleTable) {
@@ -68,7 +68,7 @@ object SimpleSchema {
     }
 
     /**
-     * Record
+     * 조회 결과를 담는 레코드 DTO이다.
      */
     data class SimpleRecord(
         val id: Long,

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex02_entities/BlogSchema.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex02_entities/BlogSchema.kt
@@ -89,7 +89,7 @@ object BlogSchema {
     }
 
     /**
-     * Many-to-many relationship table
+     * 다대다 관계를 연결하는 조인 테이블이다.
      *
      * ```sql
      * CREATE TABLE IF NOT EXISTS post_tags (
@@ -160,7 +160,7 @@ object BlogSchema {
     class PostComment(id: EntityID<Long>): LongEntity(id) {
         companion object: LongEntityClass<PostComment>(PostCommentTable)
 
-        // one-to-many relationship
+        // 일대다 관계를 매핑한다.
         var post by Post referencedOn PostCommentTable.postId
         var review by PostCommentTable.review
 

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex02_entities/Ex02_Person.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex02_entities/Ex02_Person.kt
@@ -258,7 +258,7 @@ class Ex02_Person: AbstractExposedTest() {
     }
 
     /**
-     * PostgreSQL doesn't support LIMIT in DELETE clause
+     * PostgreSQL은 DELETE 절에서 LIMIT를 지원하지 않는다.
      *
      * ```sql
      * -- MySQL V8
@@ -268,7 +268,7 @@ class Ex02_Person: AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `delete by where with limit`(testDB: TestDB) {
-        // PostgreSQL doesn't support LIMIT in DELETE clause
+        // PostgreSQL은 DELETE 절에서 LIMIT를 지원하지 않는다.
         Assumptions.assumeTrue { testDB !in TestDB.ALL_POSTGRES_LIKE }
 
         withPersonAndAddress(testDB) { persons, _ ->

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex04_compositeId/BookSchema.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex04_compositeId/BookSchema.kt
@@ -21,9 +21,9 @@ object BookSchema {
     val allTables = arrayOf(Publishers, Authors, Books, Reviews, Offices)
 
     /**
-     * CompositeIdTable with 2 key columns - int & uuid (both db-generated)
+     * int와 uuid 두 키 컬럼을 사용하는 CompositeIdTable 예제이다. 두 값 모두 DB에서 생성된다.
      *
-     * Postgres:
+     * Postgres 예:
      * ```sql
      * CREATE TABLE IF NOT EXISTS publishers (
      *      pub_id SERIAL,
@@ -62,14 +62,14 @@ object BookSchema {
         val publisherIsbn = javaUUID("publisher_isbn")
         val penName = varchar("pen_name", 32)
 
-        // FK constraint with multiple columns is created as a table-level constraint
+        // 여러 컬럼으로 구성된 FK 제약은 테이블 수준 제약으로 생성된다.
         init {
             foreignKey(publisherId, publisherIsbn, target = Publishers.primaryKey)
         }
     }
 
     /**
-     * CompositeIdTable with 1 key column - int (db-generated)
+     * int 키 컬럼 하나를 사용하는 CompositeIdTable 예제이다. 값은 DB에서 생성된다.
      *
      * ```sql
      * CREATE TABLE IF NOT EXISTS books (
@@ -91,7 +91,7 @@ object BookSchema {
     }
 
     /**
-     * CompositeIdTable with 2 key columns - string & long (neither db-generated)
+     * string과 long 두 키 컬럼을 사용하는 CompositeIdTable 예제이다. 두 값 모두 애플리케이션에서 지정한다.
      *
      * ```sql
      * CREATE TABLE IF NOT EXISTS reviews (
@@ -119,7 +119,7 @@ object BookSchema {
     }
 
     /**
-     * CompositeIdTable with 3 key columns - string, string, & int (none db-generated)
+     * string, string, int 세 키 컬럼을 사용하는 CompositeIdTable 예제이다. 모든 값은 애플리케이션에서 지정한다.
      *
      * ```sql
      * CREATE TABLE IF NOT EXISTS offices (

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex04_compositeId/Ex01_CompositeId.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex04_compositeId/Ex01_CompositeId.kt
@@ -52,11 +52,11 @@ class Ex01_CompositeId: AbstractExposedTest() {
         }
 
         withDb(testDB) {
-            // Table can be created with no issue
+            // 테이블 생성 자체는 문제 없이 수행된다.
             SchemaUtils.create(missingIdsTable)
 
             expectException<IllegalStateException> {
-                // but trying to use id property requires idColumns not being empty
+                // 그러나 id 속성을 사용하려면 idColumns가 비어 있지 않아야 한다.
                 missingIdsTable.select(missingIdsTable.id).toList()
             }
 

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex04_compositeId/Ex02_IdClass.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex04_compositeId/Ex02_IdClass.kt
@@ -208,7 +208,7 @@ class Ex02_IdClass : AbstractExposedTest() {
             resultCarYear.value shouldBeEqualTo carYear
 
             /**
-             * Query by [CompositeID]
+             * [CompositeID] 값으로 엔티티를 조회한다.
              *
              * ```sql
              * -- Postgres

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex01_one_to_one/Ex02_OneToOne_Bidirectional.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex01_one_to_one/Ex02_OneToOne_Bidirectional.kt
@@ -64,7 +64,7 @@ class Ex02_OneToOne_Bidirectional: AbstractExposedTest() {
         var name: String by HusbandTable.name
 
         /**
-         * one-to-one bidirectional (husband -> wife)
+         * 양방향 일대일 관계를 husband에서 wife 방향으로 조회한다.
          */
         var wife: Wife? by Wife optionalReferencedOn HusbandTable.wifeId
 
@@ -82,7 +82,7 @@ class Ex02_OneToOne_Bidirectional: AbstractExposedTest() {
         var name by WifeTable.name
 
         /**
-         * one-to-one bidirectional (wife -> husband)
+         * 양방향 일대일 관계를 wife에서 husband 방향으로 조회한다.
          */
         val husband: Husband? by Husband optionalBackReferencedOn HusbandTable.wifeId
 

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex01_one_to_one/Ex04_OneToOne_Bidirectional_MapsId.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex01_one_to_one/Ex04_OneToOne_Bidirectional_MapsId.kt
@@ -215,7 +215,7 @@ class Ex04_OneToOne_Bidirectional_MapsId : AbstractExposedTest() {
 
             entityCache.clear()
 
-            // Load by join
+            // 조인으로 연관 데이터를 로드한다.
             val authors =
                 Authors
                     .innerJoin(Pictures)
@@ -233,7 +233,7 @@ class Ex04_OneToOne_Bidirectional_MapsId : AbstractExposedTest() {
             author4.picture shouldBeEqualTo picture
             author4.biography shouldBeEqualTo biography
 
-            // cascade delete (author -> biography, picture)
+            // author 삭제 시 biography와 picture까지 cascade delete 되는지 검증한다.
             author.delete()
             entityCache.clear()
 

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex01_OneToMany_Bidirectional_Batch.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex01_OneToMany_Bidirectional_Batch.kt
@@ -43,11 +43,11 @@ class Ex01_OneToMany_Bidirectional_Batch: AbstractExposedTest() {
                 .orderBy(BatchItemTable.id to SortOrder.ASC)
                 .toList() shouldBeEqualTo batchItems
 
-            // eager loading
+            // eager loading으로 연관 엔티티를 미리 로드한다.
             val loaded2 = Batch.all().with(Batch::items).single()
             loaded2.items.toList() shouldBeEqualTo batchItems
 
-            // eager loading
+            // eager loading으로 연관 엔티티를 미리 로드한다.
             val loaded3 = Batch.findById(batch1.id)?.load(Batch::items)
             loaded3?.items?.toList() shouldBeEqualTo batchItems
         }

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex02_OneToMany_Unidirectional_Family.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex02_OneToMany_Unidirectional_Family.kt
@@ -63,7 +63,7 @@ class Ex02_OneToMany_Unidirectional_Family: AbstractExposedTest() {
             loadedFather.children.count() shouldBeEqualTo 3
 
             /**
-             * one-to-many with ordering
+             * 정렬 조건이 있는 일대다 관계를 검증한다.
              *
              * ```sql
              * -- Postgres
@@ -78,7 +78,7 @@ class Ex02_OneToMany_Unidirectional_Family: AbstractExposedTest() {
             val expectedChildren = Child.all().orderBy(ChildTable.birthday to SortOrder.ASC).toList()
 
             /**
-             * Lazy loading
+             * lazy loading으로 연관 엔티티를 지연 로드한다.
              *
              * ```sql
              * -- Postgres

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex03_OneToMany_N_plus_1_Order.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex03_OneToMany_N_plus_1_Order.kt
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import kotlin.random.Random
 
 /**
- * bidirectional one-to-many relationship with eager loading and lazy loading
+ * 양방향 일대다 관계에서 eager loading과 lazy loading 동작을 비교한다.
  */
 class Ex03_OneToMany_N_plus_1_Order: AbstractExposedTest() {
 
@@ -41,7 +41,7 @@ class Ex03_OneToMany_N_plus_1_Order: AbstractExposedTest() {
             entityCache.clear()
 
             /**
-             * Fetch lazy loading `OrderItem` entity
+             * lazy loading으로 `OrderItem` 엔티티를 조회한다.
              * ```sql
              * -- Postgres
              * SELECT orders.id, orders."no"
@@ -56,7 +56,7 @@ class Ex03_OneToMany_N_plus_1_Order: AbstractExposedTest() {
             loaded.items.count() shouldBeEqualTo 3
 
             /**
-             * Fetch lazy loading `OrderItem` entity
+             * lazy loading으로 `OrderItem` 엔티티를 조회한다.
              *
              * ```sql
              * -- Postgres
@@ -70,7 +70,7 @@ class Ex03_OneToMany_N_plus_1_Order: AbstractExposedTest() {
             entityCache.clear()
 
             /**
-             * Eager loading `OrderItem` entity by `with(Order::items)`
+             * `with(Order::items)`로 `OrderItem` 엔티티를 eager loading한다.
              *
              * ```sql
              * -- Postgres
@@ -89,7 +89,7 @@ class Ex03_OneToMany_N_plus_1_Order: AbstractExposedTest() {
             entityCache.clear()
 
             /**
-             * join loading
+             * 조인으로 연관 엔티티를 로드한다.
              * ```sql
              * -- Postgres
              * SELECT orders.id, orders."no", order_items.id, order_items."name", order_items.price, order_items.order_id
@@ -120,14 +120,14 @@ class Ex03_OneToMany_N_plus_1_Order: AbstractExposedTest() {
             OrderItem.all().count() shouldBeEqualTo 2L
             order1.items.count() shouldBeEqualTo 2L
 
-            // cascade delete
+            // cascade delete 동작을 검증한다.
             order1.delete()
             OrderItem.all().count() shouldBeEqualTo 0L
         }
     }
 
     /**
-     * Eager loading with pagination
+     * 페이지네이션과 함께 eager loading을 검증한다.
      *
      * ```sql
      * -- Postgres
@@ -165,7 +165,7 @@ class Ex03_OneToMany_N_plus_1_Order: AbstractExposedTest() {
     }
 
     /**
-     * Lazy loading with pagination (N+1 문제)
+     * lazy loading으로 연관 엔티티를 지연 로드한다. with pagination (N+1 문제)
      *
      * ```sql
      * -- Postgres

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex04_OneToMany_N_plus_1_Restaurant.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex04_OneToMany_N_plus_1_Restaurant.kt
@@ -27,7 +27,7 @@ class Ex04_OneToMany_N_plus_1_Restaurant: AbstractExposedTest() {
     companion object: KLogging()
 
     /**
-     * Eager loading `Menu` entities (`with(Restaurant::menus)`)
+     * `with(Restaurant::menus)`로 `Menu` 엔티티를 eager loading한다.
      *
      * 참고: [Eager Loaing](https://jetbrains.github.io/Exposed/dao-relationships.html#eager-loading)
      */
@@ -41,7 +41,7 @@ class Ex04_OneToMany_N_plus_1_Restaurant: AbstractExposedTest() {
             entityCache.clear()
 
             /**
-             * Earger loading `Menu` entities (`with(Restaurant::menus)`)
+             * `with(Restaurant::menus)`로 `Menu` 엔티티를 eager loading한다.
              *
              * ```sql
              * SELECT restaurant.id, restaurant."name"

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex05_OneToMany_JoinTable.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex05_OneToMany_JoinTable.kt
@@ -44,7 +44,7 @@ class Ex05_OneToMany_JoinTable: AbstractExposedTest() {
             entityCache.clear()
 
             /**
-             * Eager loading with `load(User::addresses)`
+             * `load(User::addresses)`로 주소 관계를 eager loading한다.
              *
              * ```sql
              * -- Postgres

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex05_OneToMany_Via.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex05_OneToMany_Via.kt
@@ -133,7 +133,7 @@ class Ex05_OneToMany_Via: AbstractExposedTest() {
         var kind by CloudTable.kind
         var length by CloudTable.length
 
-        // one-to-many unidirectional association
+        // 단방향 일대다 연관을 매핑한다.
         var producedSnowflakes: SizedIterable<Snowflake> by Snowflake via CloudSnowflakeTable
 
         override fun equals(other: Any?): Boolean = idEquals(other)
@@ -181,7 +181,7 @@ class Ex05_OneToMany_Via: AbstractExposedTest() {
             cloud2.producedSnowflakes.count() shouldBeEqualTo 2L
             cloud2.producedSnowflakes.toSet() shouldContainSame setOf(snowflake1, snowflake2)
 
-            // Remove snowflake
+            // snowflake 엔티티를 제거한다.
             val snowflakes: List<Snowflake> = cloud2.producedSnowflakes.toList()
             cloud2.producedSnowflakes = SizedCollection(snowflakes.drop(1))
 
@@ -218,7 +218,7 @@ class Ex05_OneToMany_Via: AbstractExposedTest() {
             cloud2.producedSnowflakes.count() shouldBeEqualTo 2L
             cloud2.producedSnowflakes.toSet() shouldContainSame setOf(snowflake1, snowflake2)
 
-            // Remove first relation
+            // 첫 번째 관계 행을 제거한다.
             CloudSnowflakeTable
                 .deleteWhere {
                     (cloudId eq cloud.id) and (snowflakeId eq snowflake1.id)
@@ -296,7 +296,7 @@ class Ex05_OneToMany_Via: AbstractExposedTest() {
                 it[snowflakeId] = snowflake2.id
             }
 
-            // Duplicated entry
+            // 중복 엔트리 제약 위반을 검증한다.
             assertFailsWith<ExposedSQLException> {
                 CloudSnowflakeTable.insert {
                     it[cloudId] = cloud.id

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex06_OneToMany_Set.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex06_OneToMany_Set.kt
@@ -106,7 +106,7 @@ class Ex06_OneToMany_Set: AbstractExposedTest() {
 
         var amount: BigDecimal by BidTable.amount
 
-        // many-to-one relation
+        // 다대일 관계를 매핑한다.
         var item: BiddingItem by BiddingItem referencedOn BidTable.itemId
 
         override fun equals(other: Any?): Boolean = idEquals(other)

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex07_OneToMany_Map.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/Ex07_OneToMany_Map.kt
@@ -50,7 +50,7 @@ class Ex07_OneToMany_Map: AbstractExposedTest() {
 
             entityCache.clear()
 
-            // lazy loading
+            // lazy loading으로 연관 엔티티를 지연 로드한다.
             val loadedCar = Car.findById(car.id)!!
             loadedCar shouldBeEqualTo car
             loadedCar.options.values shouldContainSame car.options.values
@@ -67,7 +67,7 @@ class Ex07_OneToMany_Map: AbstractExposedTest() {
             // options 는 매번 읽어온다 
             car.options.values shouldContainSame listOf(option1, option3)
 
-            // Remove Car
+            // Car 엔티티를 제거한다.
             car.delete()
 
             CarTable.selectAll().count() shouldBeEqualTo 0L
@@ -206,8 +206,8 @@ class Ex07_OneToMany_Map: AbstractExposedTest() {
 
         var name by CarTable.name
 
-        // OneToMany Map with MapKeyColumn (optionKey: CarOption)  (CarOption is Component/Embeddable)
-        // JoinTable: CarOptionTable
+        // MapKeyColumn(optionKey: CarOption)을 사용하는 OneToMany Map 예제이다. CarOption은 Component/Embeddable이다.
+        // 조인 테이블은 CarOptionTable이다.
         val options: Map<String, CarOption>
             get() = CarOptionTable.selectAll()
                 .where { CarOptionTable.carId eq this@Car.id }
@@ -229,8 +229,8 @@ class Ex07_OneToMany_Map: AbstractExposedTest() {
             }
         }
 
-        // OneToMany Map with MapKeyColumn (partKey: CarPart) (CarPart is Entity)
-        // JoinTable: CarPartMapTable
+        // MapKeyColumn(partKey: CarPart)을 사용하는 OneToMany Map 예제이다. CarPart는 Entity이다.
+        // 조인 테이블은 CarPartMapTable이다.
         val parts: Map<String, CarPart>
             get() = CarPartMapTable.innerJoin(CarPartTable)
                 .select(listOf(CarPartMapTable.partKey) + CarPartTable.columns)

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/schema/BatchSchema.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/schema/BatchSchema.kt
@@ -12,7 +12,7 @@ import org.jetbrains.exposed.v1.dao.IntEntityClass
 import org.jetbrains.exposed.v1.jdbc.SizedIterable
 
 /**
- * One-To-Many bidirectional Relationship
+ * 양방향 일대다 관계 매핑이다.
  */
 object BatchSchema {
 
@@ -45,7 +45,7 @@ object BatchSchema {
     object BatchItemTable: IntIdTable("batch_item") {
         val name: Column<String> = varchar("name", 255)
 
-        // reference to Batch
+        // Batch 엔티티를 참조한다.
         val batchId: Column<EntityID<Int>> =
             reference("batch_id", BatchTable, onDelete = ReferenceOption.CASCADE).index()
     }
@@ -55,7 +55,7 @@ object BatchSchema {
 
         var name: String by BatchTable.name
 
-        // one-to-many relationship
+        // 일대다 관계를 매핑한다.
         val items: SizedIterable<BatchItem> by BatchItem referrersOn BatchItemTable.batchId
 
         override fun equals(other: Any?): Boolean = idEquals(other)
@@ -70,7 +70,7 @@ object BatchSchema {
 
         var name: String by BatchItemTable.name
 
-        // many-to-one relationship
+        // 다대일 관계를 매핑한다.ship
         var batch by Batch referencedOn BatchItemTable.batchId
 
         override fun equals(other: Any?): Boolean = idEquals(other)

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/schema/FamilySchema.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/schema/FamilySchema.kt
@@ -49,7 +49,7 @@ object FamilySchema {
         val name = varchar("name", 255)
         val birthday = date("birthday")
 
-        // reference to Father
+        // Father 엔티티를 참조한다.
         val father = reference("father_id", FatherTable, onDelete = ReferenceOption.CASCADE).index()
     }
 
@@ -58,8 +58,8 @@ object FamilySchema {
 
         var name by FatherTable.name
 
-        // Ordered by birthday
-        // one-to-many relationship
+        // 생일 컬럼 기준으로 정렬한다.
+        // 일대다 관계를 매핑한다.
         val children by Child.referrersOn(ChildTable.father)
             .orderBy(ChildTable.birthday to SortOrder.ASC)
 
@@ -76,7 +76,7 @@ object FamilySchema {
         var name by ChildTable.name
         var birthday by ChildTable.birthday
 
-        // many-to-one relationship (bidirectional)
+        // 다대일 관계를 매핑한다.ship (bidirectional)
         // var father by Father referencedOn ChildTable.father
 
         override fun equals(other: Any?): Boolean = idEquals(other)

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/schema/OrderSchema.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/schema/OrderSchema.kt
@@ -47,7 +47,7 @@ object OrderSchema {
         val name = varchar("name", 255)
         val price = decimal("price", 10, 2).nullable()
 
-        // reference to Order
+        // Order 엔티티를 참조한다.
         val orderId = reference(
             "order_id",
             OrderTable,
@@ -61,7 +61,7 @@ object OrderSchema {
 
         var no by OrderTable.no
 
-        // one-to-many relationship
+        // 일대다 관계를 매핑한다.
         val items: SizedIterable<OrderItem> by OrderItem
             .referrersOn(OrderItemTable.orderId)
             .orderBy(OrderItemTable.name)
@@ -79,7 +79,7 @@ object OrderSchema {
         var name by OrderItemTable.name
         var price by OrderItemTable.price
 
-        // many-to-one relationship
+        // 다대일 관계를 매핑한다.ship
         var order by Order referencedOn OrderItemTable.orderId
 
         override fun equals(other: Any?): Boolean = idEquals(other)

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/schema/RestaurantSchema.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex02_one_to_many/schema/RestaurantSchema.kt
@@ -49,7 +49,7 @@ object RestaurantSchema {
         // NOTE: RESTRICT 설정으로 Restaurant 삭제 시 Menu가 존재하면 FK constraint 위반 예외 발생.
         // JPA의 cascade = REMOVE와 달리 Exposed는 명시적으로 CASCADE를 설정해야 합니다.
         // CASCADE 삭제를 원하면: reference(..., onDelete = ReferenceOption.CASCADE)
-        // reference to Restaurant
+        // Restaurant 엔티티를 참조한다.
         val restaurantId = reference("restaurant_id", RestaurantTable).index()
     }
 
@@ -58,7 +58,7 @@ object RestaurantSchema {
 
         var name by RestaurantTable.name
 
-        // one-to-many relationship
+        // 일대다 관계를 매핑한다.
         val menus: SizedIterable<Menu> by Menu referrersOn MenuTable.restaurantId
 
         override fun equals(other: Any?): Boolean = idEquals(other)
@@ -74,7 +74,7 @@ object RestaurantSchema {
         var name by MenuTable.name
         var price by MenuTable.price
 
-        // many-to-one relationship
+        // 다대일 관계를 매핑한다.ship
         var restaurant: Restaurant by Restaurant referencedOn MenuTable.restaurantId
 
         override fun equals(other: Any?): Boolean = idEquals(other)

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex03_many_to_one/Ex01_ManyToOne.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex03_many_to_one/Ex01_ManyToOne.kt
@@ -38,7 +38,7 @@ class Ex01_ManyToOne: AbstractExposedTest() {
     companion object: KLogging()
 
     /**
-     * unidirectional many-to-one
+     * 단방향 다대일 관계를 검증한다.
      */
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
@@ -79,7 +79,7 @@ class Ex01_ManyToOne: AbstractExposedTest() {
         withBeerTables(testDB) { brewerys, beers ->
             val brewery1 = Brewery.findById(1)!!
 
-            // Fetch lazy loading
+            // lazy loading으로 연관 엔티티를 조회한다.
             val loaded = Brewery.all().first()
             loaded shouldBeEqualTo brewery1
             loaded.beers shouldHaveSize 3
@@ -87,7 +87,7 @@ class Ex01_ManyToOne: AbstractExposedTest() {
     }
 
     /**
-     * Eager loading with `with(Brewery::beers)`
+     * `with(Brewery::beers)`로 beer 컬렉션을 eager loading한다.
      *
      * ```sql
      * -- Postgres
@@ -101,7 +101,7 @@ class Ex01_ManyToOne: AbstractExposedTest() {
         withBeerTables(testDB) { brewerys, beers ->
             val berlin: Brewery = Brewery.findById(1)!!
 
-            // Eager loading
+            // eager loading으로 연관 엔티티를 미리 로드한다.
             val loadedBrewerys: SizedIterable<Brewery> = Brewery.all().with(Brewery::beers)
             val loaded: Brewery = loadedBrewerys.first()
             loaded shouldBeEqualTo berlin
@@ -115,7 +115,7 @@ class Ex01_ManyToOne: AbstractExposedTest() {
     }
 
     /**
-     * Lazy loading
+     * lazy loading으로 연관 엔티티를 지연 로드한다.
      * ```sql
      * -- Postgres
      * SELECT beer.id, beer."name", beer.brewery_id FROM beer WHERE beer.id = 1
@@ -124,7 +124,7 @@ class Ex01_ManyToOne: AbstractExposedTest() {
      * SELECT brewery.id, brewery."name" FROM brewery WHERE brewery.id = 1
      * ```
      *
-     * Eager loading
+     * eager loading으로 연관 엔티티를 미리 로드한다.
      * ```sql
      * -- Postgres
      * SELECT beer.id, beer."name", beer.brewery_id FROM beer WHERE beer.id = 1
@@ -145,7 +145,7 @@ class Ex01_ManyToOne: AbstractExposedTest() {
         }
         log.debug { "Eager loading brewery" }
         withBeerTables(testDB) { brewerys, beers ->
-            // Eager loading
+            // eager loading으로 연관 엔티티를 미리 로드한다.
             val beer1 = Beer.findById(1)!!.load(Beer::brewery)
             val beer2 = Beer.findById(2)!!
             log.debug { "Access to berr1.brewery" }
@@ -195,7 +195,7 @@ class Ex01_ManyToOne: AbstractExposedTest() {
             flushCache()
             entityCache.clear()
 
-            // eager loading
+            // eager loading으로 연관 엔티티를 미리 로드한다.
             val loaded = SalesForce.findById(salesForce.id)!!.load(SalesForce::salesGuys)
             log.debug { "loaded=$loaded" }
             loaded shouldBeEqualTo salesForce
@@ -207,7 +207,7 @@ class Ex01_ManyToOne: AbstractExposedTest() {
             flushCache()
             entityCache.clear()
 
-            // eager loading
+            // eager loading으로 연관 엔티티를 미리 로드한다.
             val loaded2 = SalesForce.findById(salesForce.id)!!.load(SalesForce::salesGuys)
             loaded2 shouldBeEqualTo salesForce
             loaded2.salesGuys.toList() shouldBeEqualTo listOf(salesGuy1, salesGuy2)

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex04_many_to_many/BankSchema.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex04_many_to_many/BankSchema.kt
@@ -96,7 +96,7 @@ object BankSchema {
 
         var number: String by BankAccountTable.number
 
-        // many to many with via
+        // via 조인 테이블을 사용하는 다대다 관계를 매핑한다.
         val owners: SizedIterable<AccountOwner> by AccountOwner via OwnerAccountMapTable
 
         override fun equals(other: Any?): Boolean = idEquals(other)
@@ -114,7 +114,7 @@ object BankSchema {
 
         var ssn: String by AccountOwnerTable.ssn
 
-        // many to many with via
+        // via 조인 테이블을 사용하는 다대다 관계를 매핑한다.
         val accounts: SizedIterable<BankAccount> by BankAccount via OwnerAccountMapTable
 
         override fun equals(other: Any?): Boolean = idEquals(other)

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex04_many_to_many/Ex01_ManyToMany_Bank.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex04_many_to_many/Ex01_ManyToMany_Bank.kt
@@ -45,7 +45,7 @@ class Ex01_ManyToMany_Bank: AbstractExposedTest() {
             entityCache.clear()
 
             /**
-             * Eager loading with `with(AccountOwner::accounts)`
+             * eager loading으로 연관 엔티티를 미리 로드한다. with `with(AccountOwner::accounts)`
              *
              * ```sql
              * -- Postgres
@@ -62,7 +62,7 @@ class Ex01_ManyToMany_Bank: AbstractExposedTest() {
             ownersWithAccounts shouldHaveSize 2
 
             /**
-             * Eager loading with `load(AccountOwner::accounts)`
+             * eager loading으로 연관 엔티티를 미리 로드한다. with `load(AccountOwner::accounts)`
              *
              * ```sql
              * -- Postgres
@@ -88,7 +88,7 @@ class Ex01_ManyToMany_Bank: AbstractExposedTest() {
             entityCache.clear()
 
             /**
-             * Eager loading with `load(BankAccount::owners)`
+             * eager loading으로 연관 엔티티를 미리 로드한다. with `load(BankAccount::owners)`
              * ```sql
              * -- Postgres
              * SELECT bank_account.id, bank_account."number"
@@ -107,7 +107,7 @@ class Ex01_ManyToMany_Bank: AbstractExposedTest() {
             loadedAccount1.owners shouldContainSame listOf(owner1, owner2)
 
             /**
-             * Delete mapping (ownerId = 2, accountId = 3)
+             * ownerId=2, accountId=3인 매핑 행을 삭제한다.
              *
              * ```sql
              * -- Postgres
@@ -145,7 +145,7 @@ class Ex01_ManyToMany_Bank: AbstractExposedTest() {
             entityCache.clear()
 
             /**
-             * Lazy loading
+             * lazy loading으로 연관 엔티티를 지연 로드한다.
              * ```sql
              * -- Postgres
              * SELECT bank_account.id, bank_account."number"
@@ -181,7 +181,7 @@ class Ex01_ManyToMany_Bank: AbstractExposedTest() {
             account4.assertAccountExists()
 
             /**
-             * Delete mapping (accountId = 3, ownerId = 2)
+             * accountId=3, ownerId=2인 매핑 행을 삭제한다.
              *
              * ```sql
              * -- Postgres
@@ -193,7 +193,7 @@ class Ex01_ManyToMany_Bank: AbstractExposedTest() {
             OwnerAccountMapTable.deleteWhere { (accountId eq account3.id) and (ownerId eq owner2.id) }
 
             /**
-             * Eager loading
+             * eager loading으로 연관 엔티티를 미리 로드한다.
              *
              * ```sql
              * -- Postgres
@@ -217,7 +217,7 @@ class Ex01_ManyToMany_Bank: AbstractExposedTest() {
     }
 
     /**
-     * Eager loading with `with(BankAccount::owners)`
+     * eager loading으로 연관 엔티티를 미리 로드한다. with `with(BankAccount::owners)`
      *
      * ```sql
      * -- Postgres

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex04_many_to_many/Ex02_ManyToMany_Member.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex04_many_to_many/Ex02_ManyToMany_Member.kt
@@ -39,7 +39,7 @@ class Ex02_ManyToMany_Member: AbstractExposedTest() {
 
     /**
      *
-     * Postgres:
+     * Postgres 예:
      * ```sql
      * SELECT "User".id,
      *        "User".first_name,

--- a/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex04_many_to_many/MemberSchema.kt
+++ b/07-jpa/01-convert-jpa-basic/src/test/kotlin/exposed/examples/jpa/ex05_relations/ex04_many_to_many/MemberSchema.kt
@@ -18,7 +18,7 @@ object MemberSchema {
     val memberTables = arrayOf(GroupTable, MemberTable, UserTable)
 
     /**
-     * Group Table
+     * Group 테이블 매핑 정의이다.
      *
      * ```sql
      * -- Postgres
@@ -84,7 +84,7 @@ object MemberSchema {
     }
 
     /**
-     * User Table
+     * User 테이블 매핑 정의이다.
      *
      * ```sql
      * -- Postgres

--- a/07-jpa/02-convert-jpa-advanced/build.gradle.kts
+++ b/07-jpa/02-convert-jpa-advanced/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제를 위한 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex01_joins/Ex01_Simple_Join.kt
+++ b/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex01_joins/Ex01_Simple_Join.kt
@@ -27,7 +27,7 @@ class Ex01_Simple_Join: AbstractExposedTest() {
     companion object: KLogging()
 
     /**
-     * Lazy loading by simple join
+     * lazy loading으로 연관 엔티티를 지연 로드한다. by simple join
      *
      * ```sql
      * -- Postgres
@@ -90,7 +90,7 @@ class Ex01_Simple_Join: AbstractExposedTest() {
     }
 
     /**
-     * Eager loading by simple join
+     * eager loading으로 연관 엔티티를 미리 로드한다. by simple join
      *
      * ```sql
      * -- Postgres:
@@ -117,14 +117,14 @@ class Ex01_Simple_Join: AbstractExposedTest() {
 
             orderEntities shouldHaveSize 2
             orderEntities.forEach { order ->
-                // eager loading 했으므로 fetching 하지 않는다.
+                // eager loading으로 연관 엔티티를 미리 로드한다. 했으므로 fetching 하지 않는다.
                 order.details.shouldNotBeEmpty()
             }
         }
     }
 
     /**
-     * Compound Join Conditions
+     * 복합 조인 조건을 검증한다.
      *
      * ```sql
      * -- Postgres:

--- a/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex01_joins/Ex03_Left_Join.kt
+++ b/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex01_joins/Ex03_Left_Join.kt
@@ -19,7 +19,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
 /**
- * Left Join
+ * Left Join 예제를 검증한다.
  */
 class Ex03_Left_Join: AbstractExposedTest() {
 
@@ -34,7 +34,7 @@ class Ex03_Left_Join: AbstractExposedTest() {
     )
 
     /**
-     * Join with aliases
+     * alias를 사용한 조인을 검증한다.
      *
      * ```sql
      * -- Postgres
@@ -102,7 +102,7 @@ class Ex03_Left_Join: AbstractExposedTest() {
     }
 
     /**
-     * Left Join with subqueries
+     * Left Join 예제를 검증한다. with subqueries
      *
      * ```sql
      * -- Postgres
@@ -180,7 +180,7 @@ class Ex03_Left_Join: AbstractExposedTest() {
     }
 
     /**
-     * Left Join
+     * Left Join 예제를 검증한다.
      *
      * ```sql
      * -- Postgres

--- a/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex01_joins/Ex04_Right_Join.kt
+++ b/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex01_joins/Ex04_Right_Join.kt
@@ -34,7 +34,7 @@ class Ex04_Right_Join: AbstractExposedTest() {
     )
 
     /**
-     * Right join with alias
+     * alias를 사용한 right join을 검증한다.
      *
      * ```sql
      * -- Postgres:
@@ -104,7 +104,7 @@ class Ex04_Right_Join: AbstractExposedTest() {
     }
 
     /**
-     * Right join with subqueries
+     * 서브쿼리를 포함한 right join을 검증한다.
      *
      * ```sql
      * -- Postgres
@@ -184,7 +184,7 @@ class Ex04_Right_Join: AbstractExposedTest() {
     }
 
     /**
-     * Right Join example
+     * Right Join 예제를 검증한다.
      *
      * ```sql
      * -- Postgres

--- a/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex01_joins/Ex05_Self_Join.kt
+++ b/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex01_joins/Ex05_Self_Join.kt
@@ -32,7 +32,7 @@ class Ex05_Self_Join: AbstractExposedTest() {
     }
 
     /**
-     * Inner join for self referenced table
+     * 자기 참조 테이블에 대한 inner join을 검증한다.
      * 자식 엔티티 (id=4)의 부모 엔티티를 조회한다.
      *
      * ```sql
@@ -85,7 +85,7 @@ class Ex05_Self_Join: AbstractExposedTest() {
     }
 
     /**
-     * Inner join for self referenced table with alias
+     * 자기 참조 테이블에 대한 inner join을 검증한다. with alias
      * 자식 엔티티 (id=4)의 부모 엔티티를 조회한다.
      *
      * ```sql

--- a/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex02_subquery/Ex01_SubQuery.kt
+++ b/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex02_subquery/Ex01_SubQuery.kt
@@ -215,7 +215,7 @@ class Ex01_SubQuery: AbstractExposedTest() {
      */
     @Test
     fun `update set to subquery in H2`() {
-        // implement a +/- operator using CustomOperator
+        // CustomOperator로 +/- 연산자를 구현한다.
         // NOTE: EntityID<ID> 는 CustomOperator를 사용할 수 없다
         withPersonsAndAddress(TestDB.H2) { persons, _ ->
             val affectedRows = persons.update({ persons.id eq 3L }) {
@@ -266,7 +266,7 @@ class Ex01_SubQuery: AbstractExposedTest() {
         }
     }
 
-    // implement a +/- operator using CustomOperator
+    // CustomOperator로 +/- 연산자를 구현한다.
     @JvmName("expressionPlusInt")
     infix operator fun Expression<*>.plus(operand: Int): CustomOperator<Int> =
         CustomOperator("+", IntegerColumnType(), this, intLiteral(operand))

--- a/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex03_inheritance/Ex02_Joined_Table_Inheritance.kt
+++ b/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex03_inheritance/Ex02_Joined_Table_Inheritance.kt
@@ -33,7 +33,7 @@ class Ex02_Joined_Table_Inheritance: AbstractExposedTest() {
     companion object: KLogging()
 
     /**
-     * Joined Person Table
+     * Joined 전략의 Person 테이블 매핑 정의이다.
      *
      * ```sql
      * -- Postgres
@@ -57,7 +57,7 @@ class Ex02_Joined_Table_Inheritance: AbstractExposedTest() {
     }
 
     /**
-     * Joined Employee Table
+     * Joined 전략의 Employee 테이블 매핑 정의이다.
      *
      * ```sql
      * -- Postgres
@@ -95,7 +95,7 @@ class Ex02_Joined_Table_Inheritance: AbstractExposedTest() {
     }
 
     /**
-     * Joined Customer Table
+     * Joined 전략의 Customer 테이블 매핑 정의이다.
      *
      * ```sql
      * -- Postgres
@@ -268,7 +268,7 @@ class Ex02_Joined_Table_Inheritance: AbstractExposedTest() {
             entityCache.clear()
 
             /**
-             * Eager loading with `with()`
+             * eager loading으로 연관 엔티티를 미리 로드한다. with `with()`
              *
              * ```sql
              * -- Postgres
@@ -282,7 +282,7 @@ class Ex02_Joined_Table_Inheritance: AbstractExposedTest() {
             }
 
             /**
-             * Lazy loading with `load()`
+             * lazy loading으로 연관 엔티티를 지연 로드한다. with `load()`
              *
              * ```sql
              * -- Postgres

--- a/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex03_inheritance/Ex03_TablePerClass_Inheritance.kt
+++ b/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex03_inheritance/Ex03_TablePerClass_Inheritance.kt
@@ -38,7 +38,7 @@ class Ex03_TablePerClass_Inheritance : AbstractExposedTest() {
     }
 
     /**
-     * CreditCard Table
+     * CreditCard 테이블 매핑 정의이다.
      *
      * ```sql
      * CREATE TABLE IF NOT EXISTS CREDIT_CARD (
@@ -70,7 +70,7 @@ class Ex03_TablePerClass_Inheritance : AbstractExposedTest() {
     }
 
     /**
-     * BankAccount Table
+     * BankAccount 테이블 매핑 정의이다.
      *
      * ```sql
      * CREATE TABLE IF NOT EXISTS BANK_ACCOUNT (
@@ -111,7 +111,7 @@ class Ex03_TablePerClass_Inheritance : AbstractExposedTest() {
     }
 
     /**
-     * CreditCard Entity
+     * CreditCard 엔티티 매핑 정의이다.
      */
     class CreditCard(
         id: EntityID<UUID>,
@@ -143,7 +143,7 @@ class Ex03_TablePerClass_Inheritance : AbstractExposedTest() {
     }
 
     /**
-     * BankAccount Entity
+     * BankAccount 엔티티 매핑 정의이다.
      */
     class BankAccount(
         id: EntityID<UUID>,

--- a/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex05_auditable/Ex01_AuditableEntity.kt
+++ b/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex05_auditable/Ex01_AuditableEntity.kt
@@ -60,7 +60,7 @@ class Ex01_AuditableEntity: AbstractExposedTest() {
                 val now = java.time.Instant.now()
                 Thread.sleep(100)
 
-                // Task Create
+                // Task 생성 시 감사 필드를 검증한다.
                 val task = TaskEntity.new {
                     title = "Test Task"
                     description = "This is a test task."
@@ -75,7 +75,7 @@ class Ex01_AuditableEntity: AbstractExposedTest() {
                 loaded.updatedAt.shouldBeNull()
                 loaded.updatedBy.shouldBeNull()
 
-                // Task Update
+                // Task 갱신 시 감사 필드를 검증한다.
                 loaded.title = "Test Task - Updated"
                 entityCache.clear()
 

--- a/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex07_version/Ex01_Version.kt
+++ b/07-jpa/02-convert-jpa-advanced/src/test/kotlin/exposed/examples/jpa/ex07_version/Ex01_Version.kt
@@ -35,7 +35,7 @@ import kotlin.test.assertFailsWith
  */
 class Ex01_Version: AbstractExposedTest() {
 
-    // these DB require key columns from ON clause to be included in the derived source table (USING clause)
+    // 이 데이터베이스들은 ON 절의 키 컬럼이 파생 소스 테이블(USING 절)에 포함되어야 한다.
     private val upsertViaMergeDB = TestDB.ALL_H2
 
     interface VersionedEntity {
@@ -100,7 +100,7 @@ class Ex01_Version: AbstractExposedTest() {
                 log.info { "Product: ${it[Products.name]}, Price: ${it[Products.price]}, Version: ${it[Products.version]}" }
             }
 
-            // Check the initial version
+            // 초기 version 값을 검증한다.
             val updatedRows = Products.update({ Products.id eq id and (Products.version eq 0) }) {
                 it[name] = "Updated Product A"
                 it[version] = Products.version + 1
@@ -126,7 +126,7 @@ class Ex01_Version: AbstractExposedTest() {
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `update versioned entity`(testDB: TestDB) {
         withTables(testDB, Products) {
-            // 1. Insert a product with version 0
+            // 1. version 0을 가진 product를 삽입한다.
             val p1 = Product.new {
                 name = "Product A"
                 price = 100.0.toBigDecimal()

--- a/08-coroutines/01-coroutines-basic/build.gradle.kts
+++ b/08-coroutines/01-coroutines-basic/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.postgresql)
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제를 위한 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/08-coroutines/02-virtualthreads-basic/build.gradle.kts
+++ b/08-coroutines/02-virtualthreads-basic/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 
     // TODO: Virtual Threads 모듈은 코루틴을 사용하지 않습니다.
     // "코루틴 없이 Virtual Threads만으로 비동기 처리"를 명확히 하려면 아래 의존성을 제거할 수 있습니다.
-    // Coroutines
+    // 코루틴 기반 트랜잭션 예제를 위한 의존성
     testImplementation(libs.bluetape4k.coroutines)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)


### PR DESCRIPTION
## Summary
- Rewrites JPA migration relationship/loading comments and coroutine module comments in Korean.
- Preserves SQL examples, identifiers, commented reference code, and exact error text.

Closes #186

## Validation
- `git diff --check`
- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-185-korean-advanced-comments --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `USE_FAST_DB=true ./gradlew :01-convert-jpa-basic:test :02-convert-jpa-advanced:test :01-coroutines-basic:test :02-virtualthreads-basic:test --no-daemon`

## DoD Status
- [x] Korean comments/KDoc applied to the issue scope.
- [x] Bilingual README/manual and LLM-facing operating docs untouched.
- [x] Local scope, whitespace, and targeted module tests passed.