### PR TITLE
Localize multi-tenant comments

### DIFF
--- a/10-multi-tenant/01-multitenant-spring-web/build.gradle.kts
+++ b/10-multi-tenant/01-multitenant-spring-web/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 
     testImplementation(project(":exposed-shared-tests"))
 
-    // Exposed
+    // Exposed ORM 및 DSL 의존성
     implementation(libs.exposed.core)
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)
@@ -43,31 +43,31 @@ dependencies {
     implementation(libs.jetbrains.exposed.migration.jdbc)
     implementation(libs.jetbrains.exposed.spring.boot.starter)
 
-    // bluetape4k
+    // Bluetape4k 공통 테스트/유틸리티 의존성
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.jdbc)
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.spring.boot.core)
 
-    // Database Drivers
+    // 테스트 데이터베이스별 JDBC 드라이버 의존성
     implementation(libs.hikaricp)
 
     // H2
     runtimeOnly(libs.h2.v2)
 
-    // Docker
+    // Testcontainers 기반 Docker 실행 의존성
     implementation(libs.bluetape4k.testcontainers)
 
-    // MySQL
+    // MySQL 테스트 드라이버 의존성
     implementation(libs.testcontainers.mysql)
     runtimeOnly(libs.mysql.connector.j)
 
-    // PostgreSQL
+    // PostgreSQL 테스트 드라이버 의존성
     implementation(libs.testcontainers.postgresql)
     runtimeOnly(libs.postgresql.driver)
 
-    // Spring Boot
+    // Spring Boot 멀티테넌트 웹 예제 의존성
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
@@ -91,11 +91,11 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.reactor.kotlin.extensions)
 
-    // Monitoring
+    // 관찰성 및 모니터링 의존성
     implementation(libs.micrometer.core)
     implementation(libs.micrometer.registry.prometheus)
 
-    // SpringDoc - OpenAPI 3.0
+    // SpringDoc 기반 OpenAPI 3.0 문서화 의존성
     implementation(libs.springdoc.openapi.starter.webmvc.ui)
 
 }

--- a/10-multi-tenant/02-multitenant-spring-web-virtualthread/build.gradle.kts
+++ b/10-multi-tenant/02-multitenant-spring-web-virtualthread/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
 
     testImplementation(project(":exposed-shared-tests"))
 
-    // Exposed
+    // Exposed ORM 및 DSL 의존성
     implementation(libs.exposed.core)
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)
@@ -42,31 +42,31 @@ dependencies {
     implementation(libs.jetbrains.exposed.migration.jdbc)
     implementation(libs.jetbrains.exposed.spring.boot.starter)
 
-    // bluetape4k
+    // Bluetape4k 공통 테스트/유틸리티 의존성
     implementation(libs.bluetape4k.io)
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.jdbc)
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.spring.boot.core)
 
-    // Database Drivers
+    // 테스트 데이터베이스별 JDBC 드라이버 의존성
     implementation(libs.hikaricp)
 
     // H2
     runtimeOnly(libs.h2.v2)
 
-    // Docker
+    // Testcontainers 기반 Docker 실행 의존성
     implementation(libs.bluetape4k.testcontainers)
 
-    // MySQL
+    // MySQL 테스트 드라이버 의존성
     implementation(libs.testcontainers.mysql)
     runtimeOnly(libs.mysql.connector.j)
 
-    // PostgreSQL
+    // PostgreSQL 테스트 드라이버 의존성
     implementation(libs.testcontainers.postgresql)
     runtimeOnly(libs.postgresql.driver)
 
-    // Spring Boot
+    // Spring Boot 멀티테넌트 웹 예제 의존성
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
@@ -89,11 +89,11 @@ dependencies {
     implementation(libs.kotlinx.coroutines.reactive)
     testImplementation(libs.reactor.kotlin.extensions)
 
-    // Monitoring
+    // 관찰성 및 모니터링 의존성
     implementation(libs.micrometer.core)
     implementation(libs.micrometer.registry.prometheus)
 
-    // SpringDoc - OpenAPI 3.0
+    // SpringDoc 기반 OpenAPI 3.0 문서화 의존성
     implementation(libs.springdoc.openapi.starter.webmvc.ui)
 
 }

--- a/10-multi-tenant/03-multitenant-spring-webflux/build.gradle.kts
+++ b/10-multi-tenant/03-multitenant-spring-webflux/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
     testImplementation(project(":exposed-shared-tests"))
 
-    // Exposed
+    // Exposed ORM 및 DSL 의존성
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)
     implementation(libs.jetbrains.exposed.dao)
@@ -43,7 +43,7 @@ dependencies {
     implementation(libs.jetbrains.exposed.migration.jdbc)
     implementation(libs.jetbrains.exposed.spring.boot.starter)
 
-    // bluetape4k
+    // Bluetape4k 공통 테스트/유틸리티 의존성
     implementation(libs.exposed.core)
     implementation(libs.bluetape4k.jackson2)
     implementation(libs.bluetape4k.jdbc)
@@ -51,21 +51,21 @@ dependencies {
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.spring.boot.core)
 
-    // Database Drivers
+    // 테스트 데이터베이스별 JDBC 드라이버 의존성
     implementation(libs.hikaricp)
 
     // H2
     runtimeOnly(libs.h2.v2)
 
-    // MySQL
+    // MySQL 테스트 드라이버 의존성
     implementation(libs.testcontainers.mysql)
     runtimeOnly(libs.mysql.connector.j)
 
-    // PostgreSQL
+    // PostgreSQL 테스트 드라이버 의존성
     implementation(libs.testcontainers.postgresql)
     runtimeOnly(libs.postgresql.driver)
 
-    // Spring Boot
+    // Spring Boot 멀티테넌트 웹 예제 의존성
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
@@ -82,21 +82,21 @@ dependencies {
         exclude(module = "mockito-core")
     }
 
-    // Coroutines
+    // 코루틴 기반 트랜잭션 및 비동기 흐름 의존성
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.reactor)
     testImplementation(libs.kotlinx.coroutines.test)
 
-    // Reactor
+    // WebFlux/Reactor 어댑터 예제 의존성
     implementation(libs.reactor.netty)
     implementation(libs.reactor.kotlin.extensions)
     testImplementation(libs.reactor.test)
 
-    // Monitoring
+    // 관찰성 및 모니터링 의존성
     implementation(libs.micrometer.core)
     implementation(libs.micrometer.registry.prometheus)
 
-    // SpringDoc - OpenAPI 3.0
+    // SpringDoc 기반 OpenAPI 3.0 문서화 의존성
     implementation(libs.springdoc.openapi.starter.webflux.ui)
 }

--- a/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/AuthenticatedTenant.kt
+++ b/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/AuthenticatedTenant.kt
@@ -4,7 +4,7 @@ import exposed.multitenant.security.tenant.TenantId
 import java.io.Serializable
 
 /**
- * Tenant identity derived from an authenticated Spring Security principal.
+ * 인증된 Spring Security principal에서 추출한 테넌트 식별자이다.
  */
 internal data class AuthenticatedTenant(
     val tenantId: TenantId,

--- a/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/CredentialConflictFilter.kt
+++ b/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/CredentialConflictFilter.kt
@@ -9,7 +9,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.web.filter.OncePerRequestFilter
 
 /**
- * Rejects requests that mix multiple supported credential sources.
+ * 지원되는 여러 인증 정보 소스가 섞인 요청을 거부한다.
  */
 internal class CredentialConflictFilter : OncePerRequestFilter() {
 

--- a/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/DemoApiKeyAuthenticationFilter.kt
+++ b/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/DemoApiKeyAuthenticationFilter.kt
@@ -8,7 +8,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
 
 /**
- * Authenticates fixed API keys for the tenant authorization workshop.
+ * 테넌트 권한 부여 워크숍에서 사용하는 고정 API key를 인증한다.
  */
 internal class DemoApiKeyAuthenticationFilter : OncePerRequestFilter() {
 

--- a/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/DemoAuthenticationToken.kt
+++ b/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/DemoAuthenticationToken.kt
@@ -5,7 +5,7 @@ import org.springframework.security.authentication.AbstractAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 
 /**
- * Authentication token for fixed workshop API-key and demo-session credentials.
+ * 워크숍용 고정 API key와 demo-session 인증 정보를 담는 인증 토큰이다.
  */
 internal class DemoAuthenticationToken(
     val tenantId: TenantId,

--- a/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/DemoJwtDecoder.kt
+++ b/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/DemoJwtDecoder.kt
@@ -6,12 +6,12 @@ import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtException
 
 /**
- * Fixed-token JWT decoder for this workshop example.
+ * 이 워크숍 예제에서만 사용하는 고정 토큰 JWT decoder이다.
  *
- * This decoder intentionally emits unsigned `alg=none` tokens and performs no
- * production token validation. Do not copy it into production resource servers.
- * Real services must validate signatures, issuer, audience, expiry, and key
- * rotation through a real authorization server or trusted JWT infrastructure.
+ * 이 decoder는 의도적으로 서명 없는 `alg=none` 토큰을 발급하며,
+ * 운영 환경 수준의 토큰 검증을 수행하지 않는다. 운영 resource server에 복사해서 사용하면 안 된다.
+ * 실제 서비스는 서명, issuer, audience, expiry, key rotation을
+ * 신뢰할 수 있는 authorization server 또는 JWT 인프라를 통해 검증해야 한다.
  */
 internal class DemoJwtDecoder : JwtDecoder {
 

--- a/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/DemoSessionAuthenticationFilter.kt
+++ b/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/DemoSessionAuthenticationFilter.kt
@@ -8,7 +8,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
 
 /**
- * Authenticates fixed demo-session headers without creating server sessions.
+ * 서버 세션을 만들지 않고 고정 demo-session 헤더를 인증한다.
  */
 internal class DemoSessionAuthenticationFilter : OncePerRequestFilter() {
 

--- a/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/TenantAuthenticationResolver.kt
+++ b/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/TenantAuthenticationResolver.kt
@@ -6,7 +6,7 @@ import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 
 /**
- * Extracts tenant identity from authenticated Spring Security principals.
+ * 인증된 Spring Security principal에서 테넌트 식별자를 추출한다.
  */
 internal class TenantAuthenticationResolver {
 

--- a/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/TenantAuthorizationFilter.kt
+++ b/10-multi-tenant/06-spring-security-tenant-authorization-spring-web/src/main/kotlin/exposed/multitenant/security/security/TenantAuthorizationFilter.kt
@@ -10,7 +10,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
 
 /**
- * Authorizes requested tenant access and binds the tenant context downstream.
+ * 요청된 테넌트 접근 권한을 검증하고 downstream 처리에 테넌트 컨텍스트를 바인딩한다.
  */
 internal class TenantAuthorizationFilter(
     private val resolver: TenantAuthenticationResolver,


### PR DESCRIPTION
## Summary
- Rewrites multi-tenant build and security KDoc comments in Korean.
- Keeps SQL repository snippets, tenant identifiers, and API/security terms stable.

Closes #188

## Validation
- `git diff --check`
- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-187-korean-spring-integration-comments --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `USE_FAST_DB=true ./gradlew :01-multitenant-spring-web:test :02-multitenant-spring-web-virtualthread:test :03-multitenant-spring-webflux:test :04-schema-per-tenant-spring-web:test :05-database-per-tenant-spring-web:test :06-spring-security-tenant-authorization-spring-web:test :07-multitenant-ktor:test :08-tenant-onboarding-spring-web:test --no-daemon`

## DoD Status
- [x] Korean comments/KDoc applied to the issue scope.
- [x] Bilingual README/manual and LLM-facing operating docs untouched.
- [x] Local scope, whitespace, and targeted multi-tenant tests passed.