### PR TITLE
Localize high-performance comments

### DIFF
--- a/11-high-performance/01-cache-strategies/build.gradle.kts
+++ b/11-high-performance/01-cache-strategies/build.gradle.kts
@@ -35,14 +35,14 @@ configurations {
 dependencies {
     testImplementation(project(":exposed-shared-tests"))
 
-    // Exposed
+    // Exposed ORM 및 DSL 참조 라이브러리
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)
     implementation(libs.jetbrains.exposed.dao)
     implementation(libs.jetbrains.exposed.java.time)
     implementation(libs.jetbrains.exposed.spring.boot.starter)
 
-    // bluetape4k
+    // Bluetape4k 공통 테스트/유틸리티 참조 라이브러리
     implementation(libs.exposed.core)
     implementation(libs.exposed.jdbc.redisson)
     implementation(libs.bluetape4k.idgenerators)
@@ -51,33 +51,33 @@ dependencies {
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.spring.boot.core)
 
-    // Codecs
+    // 캐시 값 직렬화 코덱 참조 라이브러리
     runtimeOnly(libs.fory.kotlin)
     runtimeOnly(libs.kryo)
 
-    // Compressor
+    // 캐시 값 압축 처리 참조 라이브러리
     runtimeOnly(libs.lz4.java)
     runtimeOnly(libs.snappy.java)
     runtimeOnly(libs.zstd.jni)
 
-    // Near Cache
+    // Near Cache 전략 검증 참조 라이브러리
     implementation(libs.caffeine)
 
-    // Database Drivers
+    // 테스트 데이터베이스별 JDBC 드라이버 참조 라이브러리
     implementation(libs.hikaricp)
 
     // H2
     runtimeOnly(libs.h2.v2)
 
-    // MySQL
+    // MySQL 테스트 드라이버 참조 라이브러리
     implementation(libs.testcontainers.mysql)
     runtimeOnly(libs.mysql.connector.j)
 
-    // PostgreSQL
+    // PostgreSQL 테스트 드라이버 참조 라이브러리
     implementation(libs.testcontainers.postgresql)
     runtimeOnly(libs.postgresql.driver)
 
-    // Spring Boot
+    // Spring Boot 캐시/웹 예제 참조 라이브러리
     implementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation(libs.spring.boot.starter.webmvc.test)

--- a/11-high-performance/01-cache-strategies/src/main/kotlin/exposed/examples/cache/domain/repository/UserCredentialsCacheRepository.kt
+++ b/11-high-performance/01-cache-strategies/src/main/kotlin/exposed/examples/cache/domain/repository/UserCredentialsCacheRepository.kt
@@ -36,10 +36,10 @@ class UserCredentialsCacheRepository(
     // READ-ONLY 이므로,  updateEntity, insertEntity 에서 아무 작업도 하지 않습니다.
 
     override fun BatchInsertStatement.insertEntity(entity: UserCredentialsRecord) {
-        // No operation
+        // 이 저장소 구현에서는 별도 정리 작업이 필요하지 않다.
     }
 
     override fun UpdateStatement.updateEntity(entity: UserCredentialsRecord) {
-        // No operation
+        // 이 저장소 구현에서는 별도 정리 작업이 필요하지 않다.
     }
 }

--- a/11-high-performance/02-cache-strategies-coroutines/build.gradle.kts
+++ b/11-high-performance/02-cache-strategies-coroutines/build.gradle.kts
@@ -34,14 +34,14 @@ configurations {
 dependencies {
     testImplementation(project(":exposed-shared-tests"))
 
-    // Exposed
+    // Exposed ORM 및 DSL 참조 라이브러리
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)
     implementation(libs.jetbrains.exposed.dao)
     implementation(libs.jetbrains.exposed.java.time)
     implementation(libs.jetbrains.exposed.spring.boot.starter)
 
-    // bluetape4k
+    // Bluetape4k 공통 테스트/유틸리티 참조 라이브러리
     implementation(libs.exposed.core)
     implementation(libs.exposed.jdbc.redisson)
     implementation(libs.bluetape4k.idgenerators)
@@ -50,33 +50,33 @@ dependencies {
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.spring.boot.core)
 
-    // Codecs
+    // 캐시 값 직렬화 코덱 참조 라이브러리
     runtimeOnly(libs.fory.kotlin)
     runtimeOnly(libs.kryo)
 
-    // Compressor
+    // 캐시 값 압축 처리 참조 라이브러리
     runtimeOnly(libs.lz4.java)
     runtimeOnly(libs.snappy.java)
     runtimeOnly(libs.zstd.jni)
 
-    // Near Cache
+    // Near Cache 전략 검증 참조 라이브러리
     implementation(libs.caffeine)
 
-    // Database Drivers
+    // 테스트 데이터베이스별 JDBC 드라이버 참조 라이브러리
     implementation(libs.hikaricp)
 
     // H2
     runtimeOnly(libs.h2.v2)
 
-    // MySQL
+    // MySQL 테스트 드라이버 참조 라이브러리
     implementation(libs.testcontainers.mysql)
     runtimeOnly(libs.mysql.connector.j)
 
-    // PostgreSQL
+    // PostgreSQL 테스트 드라이버 참조 라이브러리
     implementation(libs.testcontainers.postgresql)
     runtimeOnly(libs.postgresql.driver)
 
-    // Spring Boot
+    // Spring Boot 캐시/웹 예제 참조 라이브러리
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "junit", module = "junit")
@@ -86,13 +86,13 @@ dependencies {
 
     implementation(libs.datafaker)
 
-    // Coroutines
+    // 코루틴 기반 캐시/트랜잭션 예제 참조 라이브러리
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.reactor)
     testImplementation(libs.kotlinx.coroutines.test)
 
-    // Reactor
+    // Reactor 어댑터 예제 참조 라이브러리
     implementation(libs.reactor.core)
     implementation(libs.reactor.kotlin.extensions)
     testImplementation(libs.reactor.test)

--- a/11-high-performance/04-benchmark/build.gradle.kts
+++ b/11-high-performance/04-benchmark/build.gradle.kts
@@ -24,22 +24,22 @@ dependencies {
     implementation(libs.kotlinx.benchmark.runtime.jvm)
     implementation(libs.jmh.core)
 
-    // Exposed
+    // Exposed ORM 및 DSL 참조 라이브러리
     implementation(libs.jetbrains.exposed.core)
     implementation(libs.jetbrains.exposed.jdbc)
     implementation(libs.jetbrains.exposed.dao)
     implementation(libs.jetbrains.exposed.java.time)
 
-    // JPA / Hibernate
+    // JPA/Hibernate 벤치마크 비교 참조 라이브러리
     implementation(libs.jakarta.persistence.api)
     implementation(libs.hibernate.core)
 
-    // Database
+    // 벤치마크 데이터베이스 실행 구성 요소
     implementation(libs.h2.v2)
     implementation(libs.hikaricp)
     implementation(libs.postgresql.driver)
 
-    // Testcontainers
+    // 벤치마크용 컨테이너 실행 구성 요소
     implementation(libs.bluetape4k.testcontainers)
     implementation(libs.testcontainers.postgresql)
 }

--- a/11-high-performance/04-benchmark/src/main/kotlin/exposed/examples/benchmark/crud/OneToManyCrudBenchmark.kt
+++ b/11-high-performance/04-benchmark/src/main/kotlin/exposed/examples/benchmark/crud/OneToManyCrudBenchmark.kt
@@ -113,7 +113,7 @@ open class OneToManyCrudBenchmark {
         }
     }
 
-    // ── CREATE (Department + 20 Employees) ─────────────
+    // ── 생성: Department와 Employee 20개를 함께 저장한다 ─────────────
 
     @Benchmark
     fun create(): Long {
@@ -203,7 +203,7 @@ open class OneToManyCrudBenchmark {
         }
     }
 
-    // ── READ (Department + Employees eager) ─────────────
+    // ── 조회: Department와 Employee 컬렉션을 eager loading한다 ─────────────
 
     @Benchmark
     fun read(): Any? {
@@ -242,7 +242,7 @@ open class OneToManyCrudBenchmark {
         }
     }
 
-    // ── UPDATE ──────────────────────────────────────────
+    // ── 갱신 ──────────────────────────────────────────
 
     @Benchmark
     fun update(): Int {
@@ -306,7 +306,7 @@ open class OneToManyCrudBenchmark {
         }
     }
 
-    // ── DELETE (CASCADE) ────────────────────────────────
+    // ── 삭제: cascade delete 경로를 측정한다 ────────────────────────────────
 
     @Benchmark
     fun delete(): Int {
@@ -350,7 +350,7 @@ open class OneToManyCrudBenchmark {
         }
     }
 
-    // ── BATCH CREATE ───────────────────────────────────
+    // ── 배치 생성 ───────────────────────────────────
 
     @Benchmark
     fun batchCreate(): Int {
@@ -455,7 +455,7 @@ open class OneToManyCrudBenchmark {
         }
     }
 
-    // ── READ ALL (DAO eager loading / JOIN FETCH) ──────
+    // ── 전체 조회: DAO eager loading과 JOIN FETCH를 비교한다 ──────
 
     @Benchmark
     fun readAll(): Int {

--- a/11-high-performance/04-benchmark/src/main/kotlin/exposed/examples/benchmark/crud/SingleEntityCrudBenchmark.kt
+++ b/11-high-performance/04-benchmark/src/main/kotlin/exposed/examples/benchmark/crud/SingleEntityCrudBenchmark.kt
@@ -95,7 +95,7 @@ open class SingleEntityCrudBenchmark {
         }
     }
 
-    // ── CREATE ──────────────────────────────────────────
+    // ── 생성 ──────────────────────────────────────────
 
     @Benchmark
     fun create(): Long {
@@ -152,7 +152,7 @@ open class SingleEntityCrudBenchmark {
         }
     }
 
-    // ── READ ────────────────────────────────────────────
+    // ── 조회 ────────────────────────────────────────────
 
     @Benchmark
     fun read(): Any? {
@@ -187,7 +187,7 @@ open class SingleEntityCrudBenchmark {
         }
     }
 
-    // ── UPDATE ──────────────────────────────────────────
+    // ── 갱신 ──────────────────────────────────────────
 
     @Benchmark
     fun update(): Int {
@@ -243,7 +243,7 @@ open class SingleEntityCrudBenchmark {
         }
     }
 
-    // ── DELETE ──────────────────────────────────────────
+    // ── 삭제 ──────────────────────────────────────────
 
     @Benchmark
     fun delete(): Int {
@@ -287,7 +287,7 @@ open class SingleEntityCrudBenchmark {
         }
     }
 
-    // ── BATCH CREATE ───────────────────────────────────
+    // ── 배치 생성 ───────────────────────────────────
 
     @Benchmark
     fun batchCreate(): Int {
@@ -357,7 +357,7 @@ open class SingleEntityCrudBenchmark {
         }
     }
 
-    // ── READ ALL (DAO / JPQL) ──────────────────────────
+    // ── 전체 조회: DAO와 JPQL 경로를 비교한다 ──────────────────────────
 
     @Benchmark
     fun readAll(): Int {

--- a/11-high-performance/04-benchmark/src/main/kotlin/exposed/examples/benchmark/crud/model/ExposedTables.kt
+++ b/11-high-performance/04-benchmark/src/main/kotlin/exposed/examples/benchmark/crud/model/ExposedTables.kt
@@ -8,7 +8,7 @@ import org.jetbrains.exposed.v1.dao.LongEntityClass
 import org.jetbrains.exposed.v1.javatime.CurrentTimestamp
 import org.jetbrains.exposed.v1.javatime.timestamp
 
-// ── DSL Tables ─────────────────────────────────────────
+// ── DSL 테이블 매핑 ─────────────────────────────────────────
 
 /**
  * Single Entity: Person (10 컬럼)
@@ -72,7 +72,7 @@ object EmployeeTable: LongIdTable("employees") {
     }
 }
 
-// ── DAO Entities ───────────────────────────────────────
+// ── DAO 엔티티 매핑 ───────────────────────────────────────
 
 class PersonEntity(id: EntityID<Long>): LongEntity(id) {
     companion object: LongEntityClass<PersonEntity>(PersonTable)


### PR DESCRIPTION
## Summary
- Rewrites high-performance cache, routing, and benchmark comments in Korean.
- Preserves benchmark method names, SQL/code identifiers, and performance terminology.

Closes #189

## Validation
- `git diff --check`
- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-188-korean-multitenant-comments --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `USE_FAST_DB=true ./gradlew :01-cache-strategies:test :02-cache-strategies-coroutines:test :03-routing-datasource:test :04-benchmark:test :05-cache-strategies-ktor:test :06-cache-strategies-coroutines-ktor:test :07-routing-datasource-ktor:test --no-daemon`

## DoD Status
- [x] Korean comments/KDoc applied to the issue scope.
- [x] Bilingual README/manual and LLM-facing operating docs untouched.
- [x] Local scope, whitespace, and targeted high-performance tests passed.