### PR TITLE
Localize production and ecosystem comments

### DIFF
--- a/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/KtorArchitectureApplication.kt
+++ b/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/KtorArchitectureApplication.kt
@@ -19,13 +19,13 @@ import io.ktor.server.routing.routing
 private const val DEFAULT_PORT = 8080
 
 /**
- * Starts the Ktor architecture example with an in-memory H2 database.
+ * 인메모리 H2 데이터베이스로 Ktor 아키텍처 예제를 시작한다.
  *
- * ## Contract
- * - The route layer stays thin and delegates to a service.
- * - The repository owns every blocking Exposed JDBC transaction behind
- *   `Dispatchers.IO`.
- * - JSON errors are mapped to sanitized responses through `StatusPages`.
+ * ## 계약
+ * - 경로 계층은 얇게 유지하고 서비스에 처리를 위임한다.
+ * - 저장소는 모든 블로킹 Exposed JDBC 트랜잭션을
+ *   `Dispatchers.IO` 뒤에서 책임진다.
+ * - JSON 오류는 `StatusPages`를 통해 정제된 응답으로 매핑한다.
  */
 fun main() {
     embeddedServer(CIO, port = DEFAULT_PORT) {
@@ -34,10 +34,10 @@ fun main() {
 }
 
 /**
- * Configures the Ktor + Exposed architecture example.
+ * Ktor + Exposed 아키텍처 예제를 구성한다.
  *
- * The default persistence uses an in-memory H2 database for local execution.
- * Tests pass a dedicated persistence instance with a unique JDBC URL per test.
+ * 기본 영속성 구성은 로컬 실행을 위해 인메모리 H2 데이터베이스를 사용한다.
+ * 테스트는 테스트별 고유 JDBC URL을 가진 전용 영속성 인스턴스를 전달한다.
  */
 internal fun Application.ktorArchitectureModule(
     persistence: CustomerPersistence = CustomerPersistence.inMemory(),

--- a/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/persistence/CustomerPersistence.kt
+++ b/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/persistence/CustomerPersistence.kt
@@ -8,7 +8,7 @@ import org.jetbrains.exposed.v1.jdbc.Database
 private const val HIKARI_MAX_POOL_SIZE = 4
 
 /**
- * Holds the JDBC resources owned by a Ktor application instance.
+ * Ktor 애플리케이션 인스턴스가 소유하는 JDBC 자원을 보관한다.
  */
 internal class CustomerPersistence private constructor(
     private val dataSource: HikariDataSource,

--- a/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/repository/CustomerRepository.kt
+++ b/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/repository/CustomerRepository.kt
@@ -4,7 +4,7 @@ import exposed.examples.ktor.architecture.model.CreateCustomerCommand
 import exposed.examples.ktor.architecture.model.CustomerRecord
 
 /**
- * Customer persistence contract used by the service layer.
+ * 서비스 계층이 사용하는 고객 영속성 계약이다.
  */
 internal interface CustomerRepository {
     suspend fun create(command: CreateCustomerCommand): CustomerRecord

--- a/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/repository/ExposedCustomerRepository.kt
+++ b/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/repository/ExposedCustomerRepository.kt
@@ -17,7 +17,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Exposed JDBC implementation that isolates blocking work on `Dispatchers.IO`.
+ * 블로킹 작업을 `Dispatchers.IO`로 격리하는 Exposed JDBC 구현이다.
  */
 internal class ExposedCustomerRepository(
     private val database: Database,

--- a/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/routes/CustomerRoutes.kt
+++ b/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/routes/CustomerRoutes.kt
@@ -26,7 +26,7 @@ private const val MAX_REQUEST_BODY_BYTES = 64 * 1024L
 private const val REQUEST_BODY_BUFFER_BYTES = 8 * 1024
 
 /**
- * Registers customer routes for the architecture example.
+ * 아키텍처 예제의 고객 경로를 등록한다.
  */
 internal fun Route.customerRoutes(service: CustomerService) {
     route("/customers") {

--- a/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/service/CustomerService.kt
+++ b/12-production-integration/01-ktor-application-architecture/src/main/kotlin/exposed/examples/ktor/architecture/service/CustomerService.kt
@@ -9,7 +9,7 @@ import exposed.examples.ktor.architecture.model.toResponse
 import exposed.examples.ktor.architecture.repository.CustomerRepository
 
 /**
- * Customer use cases and caller input validation.
+ * 고객 유스케이스와 호출자 입력 검증을 담당한다.
  */
 internal class CustomerService(
     private val repository: CustomerRepository,

--- a/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/SpringArchitectureApplication.kt
+++ b/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/SpringArchitectureApplication.kt
@@ -14,12 +14,12 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * Spring Boot 4 application architecture example backed by Exposed JDBC.
+ * Exposed JDBC를 사용하는 Spring Boot 4 애플리케이션 아키텍처 예제이다.
  *
- * ## Contract
- * - Controllers remain thin and delegate to service use cases.
- * - Repositories own Exposed transactions and schema bootstrap.
- * - Error responses are sanitized by controller advice.
+ * ## 계약
+ * - 컨트롤러는 얇게 유지하고 서비스 유스케이스에 처리를 위임한다.
+ * - 저장소는 Exposed 트랜잭션과 스키마 부트스트랩을 책임진다.
+ * - 오류 응답은 controller advice에서 정제한다.
  */
 @SpringBootApplication
 internal class SpringArchitectureApplication

--- a/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/persistence/CustomerPersistence.kt
+++ b/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/persistence/CustomerPersistence.kt
@@ -6,7 +6,7 @@ import io.bluetape4k.codec.Base58
 import org.jetbrains.exposed.v1.jdbc.Database
 
 /**
- * Owns the Hikari data source and Exposed database handle for the Spring example.
+ * Spring 예제에서 사용하는 Hikari 데이터소스와 Exposed 데이터베이스 핸들을 소유한다.
  */
 internal class CustomerPersistence(
     private val dataSource: HikariDataSource,

--- a/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/repository/CustomerRepository.kt
+++ b/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/repository/CustomerRepository.kt
@@ -4,7 +4,7 @@ import exposed.examples.spring.architecture.model.CreateCustomerCommand
 import exposed.examples.spring.architecture.model.CustomerRecord
 
 /**
- * Customer persistence contract used by the Spring service layer.
+ * Spring 서비스 계층이 사용하는 고객 영속성 계약이다.
  */
 internal interface CustomerRepository {
     fun create(command: CreateCustomerCommand): CustomerRecord

--- a/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/repository/ExposedCustomerRepository.kt
+++ b/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/repository/ExposedCustomerRepository.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 /**
- * Exposed JDBC repository used by the Spring Boot 4 architecture example.
+ * Spring Boot 4 아키텍처 예제에서 사용하는 Exposed JDBC 저장소이다.
  */
 internal class ExposedCustomerRepository(
     private val database: Database,

--- a/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/service/CustomerService.kt
+++ b/12-production-integration/02-spring-application-architecture/src/main/kotlin/exposed/examples/spring/architecture/service/CustomerService.kt
@@ -9,7 +9,7 @@ import exposed.examples.spring.architecture.model.toResponse
 import exposed.examples.spring.architecture.repository.CustomerRepository
 
 /**
- * Customer use cases and caller input validation.
+ * 고객 유스케이스와 호출자 입력 검증을 담당한다.
  */
 internal class CustomerService(
     private val repository: CustomerRepository,

--- a/12-production-integration/05-spring-auth-session/src/main/kotlin/exposed/examples/spring/auth/SpringAuthSessionApplication.kt
+++ b/12-production-integration/05-spring-auth-session/src/main/kotlin/exposed/examples/spring/auth/SpringAuthSessionApplication.kt
@@ -4,12 +4,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 /**
- * Spring Boot 4 authentication and session metadata example backed by Exposed JDBC.
+ * Exposed JDBC를 사용하는 Spring Boot 4 인증 및 세션 메타데이터 예제이다.
  *
- * ## Contract
- * - Spring Security authenticates users loaded from the database.
- * - Authorization checks distinguish user and admin roles.
- * - Session/token metadata is persisted separately from the HTTP Basic credential.
+ * ## 계약
+ * - Spring Security는 데이터베이스에서 로드한 사용자를 인증한다.
+ * - 권한 검사는 user와 admin 역할을 구분한다.
+ * - 세션/토큰 메타데이터는 HTTP Basic 인증 정보와 분리해 저장한다.
  */
 @SpringBootApplication
 class SpringAuthSessionApplication

--- a/12-production-integration/09-spring-observability-readiness/src/main/kotlin/exposed/examples/spring/observability/SpringObservabilityReadinessApplication.kt
+++ b/12-production-integration/09-spring-observability-readiness/src/main/kotlin/exposed/examples/spring/observability/SpringObservabilityReadinessApplication.kt
@@ -4,12 +4,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 /**
- * Spring Boot 4 observability and readiness example backed by Exposed JDBC.
+ * Exposed JDBC를 사용하는 Spring Boot 4 관측성 및 readiness 예제이다.
  *
- * ## Contract
- * - Actuator readiness includes a database-backed custom health indicator.
- * - Every HTTP response receives a correlation id in `X-Request-ID`.
- * - Structured error responses never expose raw exception details.
+ * ## 계약
+ * - Actuator readiness는 데이터베이스 기반 custom health indicator를 포함한다.
+ * - 모든 HTTP 응답에는 `X-Request-ID` correlation id를 포함한다.
+ * - 구조화된 오류 응답은 원본 예외 세부 정보를 노출하지 않는다.
  */
 @SpringBootApplication
 class SpringObservabilityReadinessApplication

--- a/12-production-integration/10-ktor-observability-readiness/src/main/kotlin/exposed/examples/ktor/observability/KtorObservabilityReadinessApplication.kt
+++ b/12-production-integration/10-ktor-observability-readiness/src/main/kotlin/exposed/examples/ktor/observability/KtorObservabilityReadinessApplication.kt
@@ -20,12 +20,12 @@ import io.ktor.server.routing.routing
 private const val DEFAULT_PORT = 8081
 
 /**
- * Starts the Ktor observability and readiness example with in-memory H2.
+ * 인메모리 H2로 Ktor 관측성 및 readiness 예제를 시작한다.
  *
- * ## Contract
- * - `/readyz` performs a database-backed readiness check.
- * - Request correlation uses `X-Request-ID` and structured error responses.
- * - Slow operation diagnostics are persisted through Exposed JDBC.
+ * ## 계약
+ * - `/readyz`는 데이터베이스 기반 readiness 검사를 수행한다.
+ * - 요청 상관관계는 `X-Request-ID`와 구조화된 오류 응답을 사용한다.
+ * - 느린 작업 진단 정보는 Exposed JDBC로 저장한다.
  */
 fun main() {
     embeddedServer(CIO, port = DEFAULT_PORT) {

--- a/13-ecosystem-integrations/01-bigquery-dry-run/src/main/kotlin/exposed/examples/bigquery/dryrun/BigQueryDryRunWorkshop.kt
+++ b/13-ecosystem-integrations/01-bigquery-dry-run/src/main/kotlin/exposed/examples/bigquery/dryrun/BigQueryDryRunWorkshop.kt
@@ -12,10 +12,10 @@ import org.jetbrains.exposed.v1.jdbc.select
 import java.math.BigDecimal
 
 /**
- * Event table used by the BigQuery dry-run workshop.
+ * BigQuery 드라이런 워크숍에서 사용하는 이벤트 테이블이다.
  *
- * The table models a small analytical event stream. It is used only to let
- * Exposed generate SQL before the SQL is sent to BigQuery as a dry-run request.
+ * 이 테이블은 작은 분석 이벤트 스트림을 모델링한다. 용도는
+ * SQL을 BigQuery 드라이런 요청으로 보내기 전에 Exposed가 SQL을 생성하게 하는 데 한정된다.
  */
 object Events: Table("events") {
     val eventId = long("event_id")
@@ -26,10 +26,10 @@ object Events: Table("events") {
 }
 
 /**
- * Builds the regional revenue read-model query.
+ * 지역별 매출 조회 모델 쿼리를 구성한다.
  *
- * The query groups billable events by region and keeps the generated SQL stable
- * enough for workshop assertions without depending on a live warehouse.
+ * 이 쿼리는 과금 대상 이벤트를 지역별로 그룹화하고 생성 SQL을 안정적으로 유지한다.
+ * 그래서 실제 warehouse에 의존하지 않고도 워크숍 assertion을 수행할 수 있다.
  */
 fun buildRegionalRevenueQuery(
     minimumRevenue: BigDecimal = BigDecimal("10.00"),
@@ -41,11 +41,11 @@ fun buildRegionalRevenueQuery(
         .orderBy(Events.region)
 
 /**
- * Returns the default BigQuery dry-run options used by the workshop.
+ * 워크숍에서 사용하는 기본 BigQuery 드라이런 옵션을 반환한다.
  *
- * The options cap billed bytes, attach a workshop label, use batch priority,
- * and select the US location. `BigQueryContext.validateQuery` turns the request
- * into a dry run before it reaches the REST client.
+ * 이 옵션은 과금 바이트 상한을 설정하고, 워크숍 label을 붙이며, batch priority를 사용하고,
+ * US location을 선택한다. `BigQueryContext.validateQuery`는 요청을
+ * REST client에 도달하기 전에 드라이런으로 전환한다.
  */
 fun defaultDryRunOptions(): BigQueryQueryOptions =
     BigQueryQueryOptions(
@@ -57,11 +57,11 @@ fun defaultDryRunOptions(): BigQueryQueryOptions =
     )
 
 /**
- * Validates the regional revenue query with BigQuery dry-run semantics.
+ * BigQuery 드라이런 의미론으로 지역별 매출 쿼리를 검증한다.
  *
- * The supplied [context] owns the BigQuery REST client. Tests provide a mocked
- * client, so the default workshop command validates request construction
- * without credentials, network access, or billable query execution.
+ * 전달된 [context]가 BigQuery REST client를 소유한다. 테스트는 모의
+ * client를 제공하므로 기본 워크숍 명령은 요청 구성을 검증한다.
+ * 인증 정보, 네트워크 접근, 과금 쿼리 실행 없이 검증이 끝난다.
  */
 fun validateRegionalRevenueDryRun(
     context: BigQueryContext,

--- a/13-ecosystem-integrations/02-trino-session-options/src/main/kotlin/exposed/examples/trino/options/TrinoSessionOptionsWorkshop.kt
+++ b/13-ecosystem-integrations/02-trino-session-options/src/main/kotlin/exposed/examples/trino/options/TrinoSessionOptionsWorkshop.kt
@@ -13,11 +13,11 @@ import java.io.Serializable
 import java.math.BigDecimal
 
 /**
- * Validated application-facing Trino analytical connection profile.
+ * 애플리케이션에서 사용하는 검증된 Trino 분석 연결 프로필이다.
  *
- * The profile keeps catalog, schema, source, tags, and session properties typed
- * in application code before converting them to bluetape4k-exposed
- * [TrinoConnectionOptions].
+ * 이 프로필은 catalog, schema, source, tag, session property를 애플리케이션 코드에서 타입으로 보존하고,
+ * bluetape4k-exposed의
+ * [TrinoConnectionOptions]로 변환한다.
  */
 data class TrinoWorkshopConnectionProfile(
     val catalog: String = "hive",
@@ -48,7 +48,7 @@ data class TrinoWorkshopConnectionProfile(
     }
 
     /**
-     * Converts this workshop profile to the public bluetape4k Trino options API.
+     * 이 워크숍 프로필을 공개 bluetape4k Trino options API로 변환한다.
      */
     fun toConnectionOptions(): TrinoConnectionOptions =
         TrinoConnectionOptions(
@@ -61,11 +61,11 @@ data class TrinoWorkshopConnectionProfile(
         )
 
     /**
-     * Returns a stable, local-only preview of the JDBC property names.
+     * JDBC property 이름을 로컬에서만 확인하는 안정적인 preview를 반환한다.
      *
-     * `TrinoConnectionOptions` owns the actual driver property conversion inside
-     * the library. This preview is for workshop assertions and README examples,
-     * so users can see the property boundary without opening a JDBC connection.
+     * 실제 driver property 변환은 라이브러리 내부의 `TrinoConnectionOptions`가 책임진다.
+     * 이 preview는 워크숍 assertion과 README 예제를 위한 것이며,
+     * 사용자가 JDBC 연결을 열지 않고도 property 경계를 확인할 수 있게 한다.
      */
     fun jdbcPropertyPreview(user: String): Map<String, String> {
         user.requireNotBlank("user")
@@ -83,13 +83,13 @@ data class TrinoWorkshopConnectionProfile(
 }
 
 /**
- * Returns the default analytical profile used by the Trino workshop.
+ * Trino 워크숍에서 사용하는 기본 분석 프로필을 반환한다.
  */
 fun defaultTrinoAnalyticsProfile(): TrinoWorkshopConnectionProfile =
     TrinoWorkshopConnectionProfile()
 
 /**
- * Order table used to generate a pushdown-friendly analytical query.
+ * 푸시다운에 적합한 분석 쿼리를 생성하는 데 사용하는 주문 테이블이다.
  */
 object WarehouseOrders: Table("warehouse_orders") {
     val orderId = long("order_id")
@@ -99,7 +99,7 @@ object WarehouseOrders: Table("warehouse_orders") {
 }
 
 /**
- * Builds a top-N analytical query shape suitable for Trino EXPLAIN inspection.
+ * Trino EXPLAIN 검사에 적합한 top-N 분석 쿼리 형태를 구성한다.
  */
 fun buildRegionalTopOrdersQuery(
     minimumRevenue: BigDecimal = BigDecimal("25.00"),
@@ -111,10 +111,10 @@ fun buildRegionalTopOrdersQuery(
         .limit(10)
 
 /**
- * Generates SQL locally without contacting a Trino cluster.
+ * Trino cluster에 접속하지 않고 로컬에서 SQL을 생성한다.
  *
- * H2 is used only to give Exposed a JDBC transaction context for SQL
- * generation. The returned SQL is not executed.
+ * H2는 Exposed에 SQL 생성을 위한 JDBC 트랜잭션 컨텍스트를 제공하는 용도로만 사용된다.
+ * 반환된 SQL은 실행하지 않는다.
  */
 fun generateRegionalTopOrdersSql(
     minimumRevenue: BigDecimal = BigDecimal("25.00"),
@@ -130,11 +130,11 @@ fun generateRegionalTopOrdersSql(
 }
 
 /**
- * Wraps generated SQL in a Trino EXPLAIN request.
+ * 생성된 SQL을 Trino EXPLAIN 요청으로 감싼다.
  *
- * Real pushdown support is connector-specific. The workshop verifies that the
- * request keeps stable predicate, projection, ordering, and top-N signals that
- * a real Trino catalog can inspect with `EXPLAIN`.
+ * 실제 푸시다운 지원 여부는 커넥터별로 다르다. 워크숍은 요청이
+ * 안정적인 predicate, projection, ordering, top-N 신호를 유지하는지 검증한다.
+ * 실제 Trino catalog는 이 신호를 `EXPLAIN`으로 검사할 수 있다.
  */
 fun buildExplainRequest(sql: String): String {
     sql.requireNotBlank("sql")

--- a/13-ecosystem-integrations/03-cockroachdb-retry/src/main/kotlin/exposed/examples/cockroachdb/retry/CockroachRetryWorkshop.kt
+++ b/13-ecosystem-integrations/03-cockroachdb-retry/src/main/kotlin/exposed/examples/cockroachdb/retry/CockroachRetryWorkshop.kt
@@ -19,7 +19,7 @@ import java.sql.SQLException
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
- * Inventory row returned by the CockroachDB retry workshop.
+ * CockroachDB 재시도 워크숍이 반환하는 재고 행이다.
  */
 data class InventorySnapshot(
     val sku: String,
@@ -33,19 +33,19 @@ data class InventorySnapshot(
 }
 
 /**
- * Testable hook for showing how CockroachDB asks a client to retry a whole
- * serializable transaction.
+ * CockroachDB가 클라이언트에 전체 serializable 트랜잭션 재시도를 요청하는 방식을 보여 주기 위한
+ * 테스트 가능한 hook이다.
  */
 fun interface ReservationAttemptHook {
 
     /**
-     * Runs inside the retryable transaction before the inventory row is updated.
+     * 재고 행을 갱신하기 전에 재시도 가능한 트랜잭션 내부에서 실행된다.
      */
     fun beforeUpdate(attempt: Int)
 }
 
 /**
- * Inventory table used by the CockroachDB retry workshop.
+ * CockroachDB 재시도 워크숍에서 사용하는 재고 테이블이다.
  */
 object CockroachInventory: Table("bt4k_workshop_inventory") {
     val sku = varchar("sku", 64)
@@ -56,7 +56,7 @@ object CockroachInventory: Table("bt4k_workshop_inventory") {
 }
 
 /**
- * Ledger table used by the CockroachDB retry workshop.
+ * CockroachDB 재시도 워크숍에서 사용하는 ledger 테이블이다.
  */
 object CockroachLedger: Table("bt4k_workshop_ledger") {
     val id = long("id").autoIncrement()
@@ -68,11 +68,11 @@ object CockroachLedger: Table("bt4k_workshop_ledger") {
 }
 
 /**
- * Application-facing service that reserves stock inside a CockroachDB
- * serializable transaction.
+ * 애플리케이션에서 호출하는 서비스이며 CockroachDB
+ * serializable 트랜잭션 안에서 재고를 예약한다.
  *
- * The service deliberately delegates retry ownership to
- * [withCockroachTransaction] so non-retryable SQL errors are not replayed.
+ * 이 서비스는 재시도 책임을 의도적으로
+ * [withCockroachTransaction]에 위임해서 재시도 불가능한 SQL 오류를 반복 실행하지 않는다.
  */
 class CockroachInventoryService(
     private val db: Database,
@@ -80,7 +80,7 @@ class CockroachInventoryService(
 ) {
 
     /**
-     * Recreates the workshop tables and seeds a single inventory row.
+     * 워크숍 테이블을 다시 만들고 단일 재고 행을 시드한다.
      */
     fun bootstrapSchema(initialSku: String = "book-1", initialQuantity: Int = 10): InventorySnapshot {
         initialSku.requireNotBlank("initialSku")
@@ -102,8 +102,8 @@ class CockroachInventoryService(
     }
 
     /**
-     * Reserves inventory and writes a matching ledger row in one retryable
-     * CockroachDB transaction.
+     * 하나의 재시도 가능한
+     * CockroachDB 트랜잭션에서 재고를 예약하고 대응되는 ledger 행을 기록한다.
      */
     fun reserve(
         sku: String,
@@ -153,7 +153,7 @@ class CockroachInventoryService(
     }
 
     /**
-     * Reads the current inventory snapshot.
+     * 현재 재고 스냅숏을 읽는다.
      */
     fun inventory(sku: String): InventorySnapshot {
         sku.requireNotBlank("sku")
@@ -168,7 +168,7 @@ class CockroachInventoryService(
     }
 
     /**
-     * Counts ledger entries for the given SKU.
+     * 지정한 SKU의 ledger 항목 수를 계산한다.
      */
     fun ledgerCount(sku: String): Long {
         sku.requireNotBlank("sku")
@@ -183,7 +183,7 @@ class CockroachInventoryService(
 }
 
 /**
- * Returns the retry policy used by the workshop tests and README examples.
+ * 워크숍 테스트와 README 예제에서 사용하는 재시도 정책을 반환한다.
  */
 fun workshopRetryOptions(): CockroachTransactionRetryOptions =
     CockroachTransactionRetryOptions(
@@ -195,7 +195,7 @@ fun workshopRetryOptions(): CockroachTransactionRetryOptions =
     )
 
 /**
- * Creates a deterministic CockroachDB retryable transaction exception.
+ * 결정적인 CockroachDB 재시도 가능 트랜잭션 예외를 생성한다.
  */
 fun cockroachRetryableSerializationFailure(
     message: String = "restart transaction: simulated serializable conflict",

--- a/13-ecosystem-integrations/04-starrocks-olap-local/src/main/kotlin/exposed/examples/starrocks/olap/StarRocksOlapWorkshop.kt
+++ b/13-ecosystem-integrations/04-starrocks-olap-local/src/main/kotlin/exposed/examples/starrocks/olap/StarRocksOlapWorkshop.kt
@@ -19,10 +19,10 @@ import java.io.Serializable
 import java.math.BigDecimal
 
 /**
- * Typed application profile for the StarRocks OLAP workshop.
+ * StarRocks OLAP 워크숍에서 사용하는 타입화된 애플리케이션 프로필이다.
  *
- * The profile makes the JDBC boundary explicit without opening a StarRocks
- * connection during local structural tests.
+ * 이 프로필은 StarRocks 연결을 열지 않고도 JDBC 경계를 명시한다.
+ * 로컬 구조 테스트 중에는 실제 연결을 만들지 않는다.
  */
 data class StarRocksAnalyticsProfile(
     val host: String = "localhost",
@@ -49,19 +49,19 @@ data class StarRocksAnalyticsProfile(
     }
 
     /**
-     * Returns the StarRocks Connector/J URL that a real validation run uses.
+     * 실제 검증 실행에서 사용하는 StarRocks Connector/J URL을 반환한다.
      */
     fun jdbcUrl(): String =
         "jdbc:starrocks://$host:$port/$catalog.$database"
 
     /**
-     * Converts extra driver properties to the public bluetape4k StarRocks API.
+     * 추가 driver property를 공개 bluetape4k StarRocks API로 변환한다.
      */
     fun toConnectionOptions(): StarRocksConnectionOptions =
         StarRocksConnectionOptions(extraProperties = extraProperties)
 
     /**
-     * Exposes the driver property boundary for README and test assertions.
+     * README와 테스트 assertion을 위해 driver property 경계를 노출한다.
      */
     fun jdbcPropertyPreview(user: String): Map<String, String> {
         user.requireNotBlank("user")
@@ -74,13 +74,13 @@ data class StarRocksAnalyticsProfile(
 }
 
 /**
- * Returns the default local StarRocks analytics profile.
+ * 기본 로컬 StarRocks 분석 프로필을 반환한다.
  */
 fun defaultStarRocksAnalyticsProfile(): StarRocksAnalyticsProfile =
     StarRocksAnalyticsProfile()
 
 /**
- * Order event projected from OLTP storage into an OLAP rollup.
+ * OLTP 스토리지에서 OLAP rollup으로 투영되는 주문 이벤트이다.
  */
 data class OrderEvent(
     val orderId: Long,
@@ -100,7 +100,7 @@ data class OrderEvent(
 }
 
 /**
- * Daily regional revenue rollup ready for a StarRocks fact table.
+ * StarRocks fact table에 적재할 수 있는 일별 지역 매출 rollup이다.
  */
 data class RegionalRevenueRollup(
     val region: String,
@@ -115,7 +115,7 @@ data class RegionalRevenueRollup(
 }
 
 /**
- * Local OLTP-style fixture table used for deterministic projection tests.
+ * 결정적인 프로젝션 테스트에 사용하는 로컬 OLTP 스타일 픽스처 테이블이다.
  */
 object LocalOrderEvents: org.jetbrains.exposed.v1.core.Table("local_order_events") {
     val orderId = long("order_id")
@@ -127,7 +127,7 @@ object LocalOrderEvents: org.jetbrains.exposed.v1.core.Table("local_order_events
 }
 
 /**
- * StarRocks target table shape for the projected OLAP rollup.
+ * 프로젝션된 OLAP rollup을 위한 StarRocks 대상 테이블 형태이다.
  */
 object StarRocksRegionalSalesRollups: StarRocksTable("starrocks_regional_sales_rollups") {
     val region = varchar("region", 32)
@@ -137,7 +137,7 @@ object StarRocksRegionalSalesRollups: StarRocksTable("starrocks_regional_sales_r
 }
 
 /**
- * Creates a local H2 database for SQL rendering and aggregation tests.
+ * SQL 렌더링과 집계 테스트를 위한 로컬 H2 데이터베이스를 생성한다.
  */
 fun createLocalProjectionDatabase(name: String = "starrocks_projection"): Database {
     name.requireNotBlank("name")
@@ -149,7 +149,7 @@ fun createLocalProjectionDatabase(name: String = "starrocks_projection"): Databa
 }
 
 /**
- * Generates the StarRocks rollup DDL locally without executing it.
+ * StarRocks rollup DDL을 실행하지 않고 로컬에서 생성한다.
  */
 fun buildStarRocksRollupDdl(): String =
     transaction(createLocalProjectionDatabase("starrocks_rollup_ddl")) {
@@ -157,7 +157,7 @@ fun buildStarRocksRollupDdl(): String =
     }
 
 /**
- * Inserts deterministic local order events for projection tests.
+ * 프로젝션 테스트를 위한 결정적인 로컬 주문 이벤트를 삽입한다.
  */
 fun seedLocalOrderEvents(db: Database, events: List<OrderEvent>) {
     events.requireNotEmpty("events")
@@ -174,7 +174,7 @@ fun seedLocalOrderEvents(db: Database, events: List<OrderEvent>) {
 }
 
 /**
- * Builds the daily regional revenue query used before real StarRocks validation.
+ * 실제 StarRocks 검증 전에 사용하는 일별 지역 매출 쿼리를 구성한다.
  */
 fun buildDailyRegionalRevenueQuery(): Query {
     val orderCount = LocalOrderEvents.orderId.count()
@@ -195,7 +195,7 @@ fun buildDailyRegionalRevenueQuery(): Query {
 }
 
 /**
- * Generates the rollup SQL locally so readers can inspect projection shape.
+ * 독자가 프로젝션 형태를 확인할 수 있도록 rollup SQL을 로컬에서 생성한다.
  */
 fun generateDailyRegionalRevenueSql(): String =
     transaction(createLocalProjectionDatabase("starrocks_rollup_sql")) {
@@ -203,7 +203,7 @@ fun generateDailyRegionalRevenueSql(): String =
     }
 
 /**
- * Projects local order events into daily regional revenue rollups.
+ * 로컬 주문 이벤트를 일별 지역 매출 rollup으로 프로젝션한다.
  */
 fun projectDailyRegionalRevenue(db: Database): List<RegionalRevenueRollup> {
     val orderCount = LocalOrderEvents.orderId.count()

--- a/13-ecosystem-integrations/08-ddd-modulith-boundaries/src/main/kotlin/exposed/examples/spring/modulith/boundaries/BoundaryVerificationApplication.kt
+++ b/13-ecosystem-integrations/08-ddd-modulith-boundaries/src/main/kotlin/exposed/examples/spring/modulith/boundaries/BoundaryVerificationApplication.kt
@@ -4,7 +4,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 /**
- * Spring Boot entrypoint for the DDD and Spring Modulith boundary workshop.
+ * DDD 및 Spring Modulith 경계 워크숍의 Spring Boot 진입점이다.
  */
 @SpringBootApplication
 class BoundaryVerificationApplication

--- a/13-ecosystem-integrations/08-ddd-modulith-boundaries/src/main/kotlin/exposed/examples/spring/modulith/boundaries/orders/OrderApplicationService.kt
+++ b/13-ecosystem-integrations/08-ddd-modulith-boundaries/src/main/kotlin/exposed/examples/spring/modulith/boundaries/orders/OrderApplicationService.kt
@@ -9,7 +9,7 @@ import java.io.Serializable
 import java.time.Instant
 
 /**
- * Command used by the order bounded context to accept a new workshop order.
+ * order bounded context가 새 워크숍 주문을 접수할 때 사용하는 command이다.
  */
 data class AcceptOrderCommand(
     val orderKey: String,
@@ -21,7 +21,7 @@ data class AcceptOrderCommand(
 }
 
 /**
- * Read model returned after the order aggregate is persisted.
+ * order aggregate가 저장된 뒤 반환되는 조회 모델이다.
  */
 data class OrderSummary(
     val id: Long,
@@ -36,7 +36,7 @@ data class OrderSummary(
 }
 
 /**
- * Application service that owns the order transaction and publishes a domain event.
+ * order 트랜잭션을 책임지고 domain event를 발행하는 애플리케이션 서비스이다.
  */
 @Service
 class OrderApplicationService(

--- a/13-ecosystem-integrations/08-ddd-modulith-boundaries/src/main/kotlin/exposed/examples/spring/modulith/boundaries/orders/events/OrderAcceptedEvent.kt
+++ b/13-ecosystem-integrations/08-ddd-modulith-boundaries/src/main/kotlin/exposed/examples/spring/modulith/boundaries/orders/events/OrderAcceptedEvent.kt
@@ -4,7 +4,7 @@ import java.io.Serializable
 import java.time.Instant
 
 /**
- * Domain event exported as the only named interface of the order context.
+ * order context의 유일한 named interface로 공개되는 domain event이다.
  */
 data class OrderAcceptedEvent(
     val orderKey: String,

--- a/13-ecosystem-integrations/08-ddd-modulith-boundaries/src/main/kotlin/exposed/examples/spring/modulith/boundaries/shipping/ShippingReservationHandler.kt
+++ b/13-ecosystem-integrations/08-ddd-modulith-boundaries/src/main/kotlin/exposed/examples/spring/modulith/boundaries/shipping/ShippingReservationHandler.kt
@@ -9,7 +9,7 @@ import java.io.Serializable
 import java.time.Instant
 
 /**
- * Read model owned by the shipping bounded context.
+ * shipping bounded context가 소유하는 조회 모델이다.
  */
 data class ShippingReservation(
     val id: Long,
@@ -23,7 +23,7 @@ data class ShippingReservation(
 }
 
 /**
- * Consumes order events without depending on order repositories or tables.
+ * order 저장소나 테이블에 의존하지 않고 order event를 소비한다.
  */
 @Service
 class ShippingReservationHandler(

--- a/13-ecosystem-integrations/09-duckdb-embedded-analytics/build.gradle.kts
+++ b/13-ecosystem-integrations/09-duckdb-embedded-analytics/build.gradle.kts
@@ -3,7 +3,7 @@ configurations {
 }
 
 tasks.test {
-    // DuckDB JDBC loads a native library.
+    // DuckDB JDBC는 네이티브 라이브러리를 로드한다.
     jvmArgs("--enable-native-access=ALL-UNNAMED")
 }
 

--- a/13-ecosystem-integrations/09-duckdb-embedded-analytics/src/main/kotlin/exposed/examples/duckdb/analytics/DuckDbEmbeddedAnalyticsWorkshop.kt
+++ b/13-ecosystem-integrations/09-duckdb-embedded-analytics/src/main/kotlin/exposed/examples/duckdb/analytics/DuckDbEmbeddedAnalyticsWorkshop.kt
@@ -28,7 +28,7 @@ import java.sql.DriverManager
 import java.sql.PreparedStatement
 
 /**
- * Order event copied from an OLTP boundary into an embedded DuckDB analytics file.
+ * OLTP 경계에서 embedded DuckDB 분석 파일로 복사되는 주문 이벤트이다.
  */
 data class DuckDbOrderEvent(
     val orderId: Long,
@@ -50,7 +50,7 @@ data class DuckDbOrderEvent(
 }
 
 /**
- * Aggregated analytical row returned to the application after DuckDB execution.
+ * DuckDB 실행 후 애플리케이션에 반환되는 집계 분석 행이다.
  */
 data class DailyCategorySales(
     val region: String,
@@ -66,7 +66,7 @@ data class DailyCategorySales(
 }
 
 /**
- * File-backed DuckDB table used by this embedded analytics example.
+ * 이 embedded analytics 예제에서 사용하는 파일 기반 DuckDB 테이블이다.
  */
 object DuckDbOrderEvents: org.jetbrains.exposed.v1.core.Table("duckdb_order_events") {
     val orderId = long("order_id")
@@ -79,11 +79,11 @@ object DuckDbOrderEvents: org.jetbrains.exposed.v1.core.Table("duckdb_order_even
 }
 
 /**
- * Owns the root DuckDB connection used by the workshop database.
+ * 워크숍 데이터베이스에서 사용하는 root DuckDB 연결을 소유한다.
  *
- * DuckDB keeps one in-memory catalog per plain `jdbc:duckdb:` connection. This
- * file-backed workshop keeps a root connection open and gives Exposed duplicate
- * connections so separate transactions observe the same local database.
+ * DuckDB는 일반 `jdbc:duckdb:` 연결마다 하나의 인메모리 catalog를 유지한다. 이
+ * 파일 기반 워크숍은 root 연결을 열린 상태로 유지하고 Exposed에 중복
+ * 연결을 제공해서 별도 트랜잭션에서도 같은 로컬 데이터베이스를 보게 한다.
  */
 class DuckDbAnalyticsSession private constructor(
     val db: Database,
@@ -96,8 +96,8 @@ class DuckDbAnalyticsSession private constructor(
 
     companion object {
         /**
-         * Opens a file-backed DuckDB session and shares it through duplicated
-         * transaction connections.
+         * 파일 기반 DuckDB 세션을 열고 중복
+         * 트랜잭션 연결로 공유한다.
          */
         fun file(path: Path): DuckDbAnalyticsSession {
             val databasePath = path.toString().requireNotBlank("path")
@@ -116,13 +116,13 @@ class DuckDbAnalyticsSession private constructor(
 }
 
 /**
- * Opens a file-backed DuckDB analytics session.
+ * 파일 기반 DuckDB 분석 세션을 연다.
  */
 fun openDuckDbAnalyticsSession(path: Path): DuckDbAnalyticsSession =
     DuckDbAnalyticsSession.file(path)
 
 /**
- * Creates the workshop schema in the embedded DuckDB file.
+ * embedded DuckDB 파일에 워크숍 스키마를 생성한다.
  */
 suspend fun createDuckDbAnalyticsSchema(db: Database) {
     suspendTransaction(db) {
@@ -131,7 +131,7 @@ suspend fun createDuckDbAnalyticsSchema(db: Database) {
 }
 
 /**
- * Inserts deterministic fixture events into the embedded DuckDB file.
+ * embedded DuckDB 파일에 결정적인 픽스처 이벤트를 삽입한다.
  */
 suspend fun seedDuckDbOrderEvents(db: Database, events: List<DuckDbOrderEvent>) {
     events.requireNotEmpty("events")
@@ -149,7 +149,7 @@ suspend fun seedDuckDbOrderEvents(db: Database, events: List<DuckDbOrderEvent>) 
 }
 
 /**
- * Builds the daily category sales query that DuckDB executes locally.
+ * DuckDB가 로컬에서 실행할 일별 카테고리 매출 쿼리를 구성한다.
  */
 fun buildDailyCategorySalesQuery(): Query {
     val orderCount = DuckDbOrderEvents.orderId.count()
@@ -176,7 +176,7 @@ fun buildDailyCategorySalesQuery(): Query {
 }
 
 /**
- * Renders the analytical SQL so the README can show the exact query shape.
+ * README가 정확한 쿼리 형태를 보여 줄 수 있도록 분석 SQL을 렌더링한다.
  */
 fun generateDailyCategorySalesSql(db: Database): String =
     transaction(db) {
@@ -184,7 +184,7 @@ fun generateDailyCategorySalesSql(db: Database): String =
     }
 
 /**
- * Executes the aggregate query inside DuckDB and returns materialized rows.
+ * DuckDB 안에서 집계 쿼리를 실행하고 materialized row를 반환한다.
  */
 suspend fun projectDailyCategorySales(db: Database): List<DailyCategorySales> =
     suspendTransaction(db) {
@@ -192,11 +192,11 @@ suspend fun projectDailyCategorySales(db: Database): List<DailyCategorySales> =
     }
 
 /**
- * Exposes DuckDB aggregate results as a coroutine Flow.
+ * DuckDB 집계 결과를 코루틴 Flow로 노출한다.
  *
- * `queryFlow` materializes rows inside the Exposed transaction first. The Flow
- * boundary is useful for application pipelines, not a claim of JDBC row-by-row
- * streaming.
+ * `queryFlow`는 먼저 Exposed 트랜잭션 내부에서 row를 materialize한다. Flow
+ * 경계는 애플리케이션 파이프라인에 유용하지만 JDBC row-by-row
+ * 스트리밍을 보장한다는 뜻은 아니다.
  */
 fun streamDailyCategorySales(
     db: Database,
@@ -207,7 +207,7 @@ fun streamDailyCategorySales(
     }
 
 /**
- * Counts events in a separate Exposed transaction on the same file-backed DuckDB database.
+ * 같은 파일 기반 DuckDB 데이터베이스에서 별도 Exposed 트랜잭션으로 이벤트 수를 계산한다.
  */
 suspend fun countPersistedOrderEvents(db: Database): Long =
     suspendTransaction(db) {


### PR DESCRIPTION
## Summary
- Rewrites production and ecosystem integration KDoc/comments in Korean.
- Covers Ktor/Spring architecture, auth/session, observability, BigQuery, Trino, CockroachDB, StarRocks, Modulith, DDD, and DuckDB examples while preserving identifiers and exact technical boundaries.

Closes #190

## Validation
- `git diff --check`
- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-189-korean-high-performance-comments --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `USE_FAST_DB=true ./gradlew :01-ktor-application-architecture:test :02-spring-application-architecture:test :03-spring-http-outbox-idempotency:test :04-ktor-http-outbox-idempotency:test :05-spring-auth-session:test :06-ktor-auth-session:test :07-spring-outbox-realtime:test :08-ktor-outbox-realtime:test :09-spring-observability-readiness:test :10-ktor-observability-readiness:test :01-bigquery-dry-run:test :02-trino-session-options:test :03-cockroachdb-retry:test :04-starrocks-olap-local:test :05-ktor-exposed-integration:test :06-spring-modulith-publications:test :07-ddd-aggregate-repository:test :08-ddd-modulith-boundaries:test :09-duckdb-embedded-analytics:test --no-daemon`

## DoD Status
- [x] Korean comments/KDoc applied to the issue scope.
- [x] Bilingual README/manual and LLM-facing operating docs untouched.
- [x] Local scope, whitespace, and targeted production/ecosystem tests passed.