### PR TITLE
Localize root Gradle comments

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,10 +8,10 @@ import org.gradle.api.plugins.ExtensionAware
 
 plugins {
     base
-    // jacoco
+    // JaCoCo 테스트 커버리지 리포트 플러그인
     alias(libs.plugins.kotlin.jvm)
 
-    // see: https://kotlinlang.org/docs/reference/compiler-plugins.html
+    // Kotlin compiler plugin 문서: https://kotlinlang.org/docs/reference/compiler-plugins.html
     alias(libs.plugins.kotlin.spring) apply false
     alias(libs.plugins.kotlin.allopen) apply false
     alias(libs.plugins.kotlin.noarg) apply false
@@ -129,7 +129,7 @@ subprojects {
             useJUnitPlatform()
 
             // 테스트 시 아래와 같은 예외 메시지를 제거하기 위해서
-            // OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
+            // OpenJDK 경고 원문: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
             jvmArgs(
                 "-Xshare:off",
                 "-Xms2G",
@@ -280,7 +280,7 @@ subprojects {
         implementation(rootLibs.jackson3.module.blackbird)
         implementation(rootLibs.logback)
 
-        // JUnit 5
+        // JUnit 5 테스트 엔진
         testImplementation(rootLibs.bluetape4k.junit5)
         testImplementation(rootLibs.junit.jupiter)
         testRuntimeOnly(rootLibs.junit.platform.engine)
@@ -290,7 +290,7 @@ subprojects {
         testImplementation(rootLibs.mockk)
         testImplementation(rootLibs.awaitility.kotlin)
 
-        // Property based test
+        // 속성 기반 테스트 라이브러리
         testImplementation(rootLibs.datafaker)
         testImplementation(rootLibs.random.beans)
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,7 +44,7 @@ fun includeModules(baseDir: String, withProjectName: Boolean = true, withBaseDir
                         withProjectName                 -> PROJECT_NAME + "-" + basePath + "-" + dir.name
                         else                            -> basePath + "-" + dir.name
                     }
-                    // println("include modules: $projectName")
+                    // 포함할 모듈 이름 확인용 로그: println("include modules: $projectName")
 
                     include(projectName)
                     project(":$projectName").projectDir = dir


### PR DESCRIPTION
## Summary
- Rewrites root Gradle Kotlin DSL comments in Korean.
- Preserves plugin ids, task names, coordinates, URLs, and exact warning text.

Closes #191

## Validation
- `git diff --check`
- `ruby scripts/localization/audit_scope.rb --strict-counts --base issue-190-korean-production-ecosystem-comments --check-diff`
- `ruby scripts/localization/localization_scope_audit_test.rb`
- `./gradlew projects --quiet --no-daemon`

## DoD Status
- [x] Korean comments applied to the issue scope.
- [x] Bilingual README/manual and LLM-facing operating docs untouched.
- [x] Local scope, whitespace, and Gradle configuration validation passed.